### PR TITLE
feat(userbutton): add profile picture support

### DIFF
--- a/components/LoginForm.vue
+++ b/components/LoginForm.vue
@@ -64,14 +64,11 @@ export default {
           data: this.login
         });
 
-        this.$auth.setUser(response.data.User);
         this.$auth.setUserToken(
           // TODO: Generate the token properly
           `MediaBrowser Client="Jellyfin Web", Device="Firefox", DeviceId="TW96aWxsYS81LjAgKFgxMTsgTGludXggeDg2XzY0OyBydjo3Ny4wKSBHZWNrby8yMDEwMDEwMSBGaXJlZm94Lzc3LjB8MTU5NTQ1MTYzMzE4OQ11", Version="10.7.0", Token="${response.data.AccessToken}"`
         );
-
         this.$auth.setUser(response.data.User);
-        this.$router.push('/');
       } catch (error) {
         console.error('Failed to login:', error);
 

--- a/components/UserButton.vue
+++ b/components/UserButton.vue
@@ -2,7 +2,8 @@
   <v-menu offset-y>
     <template v-slot:activator="{ on, attrs }">
       <v-avatar color="grey darken-2" size="36" v-bind="attrs" v-on="on">
-        <v-icon dark>mdi-account</v-icon>
+        <v-img v-if="userImage" :src="userImage" :alt="$auth.user.name"></v-img>
+        <v-icon v-else dark>mdi-account</v-icon>
       </v-avatar>
     </template>
     <v-list>
@@ -21,7 +22,6 @@
 export default {
   data() {
     return {
-      userAvatar: false,
       menuItems: [
         {
           title: 'Logout',
@@ -31,6 +31,17 @@ export default {
         }
       ]
     };
+  },
+  computed: {
+    userImage: {
+      get() {
+        if (this.$auth.user?.PrimaryImageTag) {
+          return `${this.$axios.defaults.baseURL}/Users/${this.$auth.user.Id}/Images/Primary/?tag=${this.$auth.user.PrimaryImageTag}&maxWidth=36`;
+        } else {
+          return '';
+        }
+      }
+    }
   }
 };
 </script>


### PR DESCRIPTION
While waiting for the API to be in a working state, this adds support for showing the user's picture if they have one.

![image](https://user-images.githubusercontent.com/19396809/92172752-1b330b80-ee3c-11ea-8a35-7c8876a9296b.png)

Otherwise it will show the fallback icon, like before

![image](https://user-images.githubusercontent.com/19396809/92173096-3736ad00-ee3c-11ea-8946-3cadbc3dbedc.png)
