### PR TITLE
build(package.json): set host for yarn dev cmd

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -149,7 +149,14 @@ const config: NuxtConfig = {
    ** Build configuration
    ** See https://nuxtjs.org/api/configuration-build/
    */
-  build: {}
+  build: {},
+
+  /**
+   * Host set to 0.0.0.0 in order to access the dev server on the LAN
+   */
+  server: {
+    host: '0.0.0.0'
+  }
 };
 
 export default config;


### PR DESCRIPTION
setting host to 0.0.0.0 when launching yarn dev allows devices on LAN to access the dev server
(easier to quickly test something on a phone for instance)