### PR TITLE
Global snackbar

### DIFF
--- a/components/LoginForm.vue
+++ b/components/LoginForm.vue
@@ -28,9 +28,6 @@
         >submit</v-btn
       >
     </v-form>
-    <v-snackbar color="red" bottom left v-model="errorMessageSnackbar">
-      {{ errorMessage }}
-    </v-snackbar>
   </div>
 </template>
 
@@ -44,8 +41,6 @@ export default {
         pw: ''
       },
       showPassword: false,
-      errorMessageSnackbar: false,
-      errorMessage: '',
       validInputs: false,
       rules: {
         serverUrlTest: [
@@ -72,16 +67,15 @@ export default {
         this.$auth.setUser(response.data.User);
       } catch (error) {
         console.error('Failed to login:', error);
+        let errorMessage = 'Unexpected Error';
         if (!error.response) {
-          this.errorMessage = 'Server Not Found';
+          errorMessage = 'Server Not Found';
         } else if (error.response.status === 500) {
-          this.errorMessage = 'Incorrect Password';
+          errorMessage = 'Incorrect Password';
         } else if (error.response.status === 400) {
-          this.errorMessage = 'Bad Request. Try Again';
-        } else {
-          this.errorMessage = 'Unexpected Error';
+          errorMessage = 'Bad Request. Try Again';
         }
-        this.errorMessageSnackbar = true;
+        this.$snackbar(errorMessage, 'red');
       }
     }
   }

--- a/components/LoginForm.vue
+++ b/components/LoginForm.vue
@@ -75,7 +75,7 @@ export default {
         } else if (error.response.status === 400) {
           errorMessage = 'Bad Request. Try Again';
         }
-        this.$snackbar(errorMessage, 'red');
+        this.$snackbar(errorMessage, 'error');
       }
     }
   }

--- a/components/Snackbar.vue
+++ b/components/Snackbar.vue
@@ -1,0 +1,32 @@
+<template>
+  <v-snackbar v-model="model" :color="color" bottom left>
+    {{ message }}
+  </v-snackbar>
+</template>
+
+<script lang="ts">
+export default {
+  data() {
+    return {
+      model: false,
+      color: '',
+      message: ''
+    };
+  },
+  created() {
+    this.$store.subscribe((mutation, state) => {
+      if (mutation.type === 'snackbar/display') {
+        this.message = state.snackbar.message;
+        this.color = state.snackbar.color;
+        this.model = true;
+      }
+    });
+  }
+};
+</script>
+
+<style scoped>
+div.v-snack:not(.v-snack--absolute) {
+  height: 100%;
+}
+</style>

--- a/components/Snackbar.vue
+++ b/components/Snackbar.vue
@@ -1,11 +1,12 @@
 <template>
-  <v-snackbar v-model="model" :color="color" bottom left>
+  <v-snackbar app v-model="model" :color="color" bottom left>
     {{ message }}
   </v-snackbar>
 </template>
 
 <script lang="ts">
 import Vue from 'vue';
+
 export default Vue.extend({
   data() {
     return {

--- a/components/Snackbar.vue
+++ b/components/Snackbar.vue
@@ -5,7 +5,8 @@
 </template>
 
 <script lang="ts">
-export default {
+import Vue from 'vue';
+export default Vue.extend({
   data() {
     return {
       model: false,
@@ -22,7 +23,7 @@ export default {
       }
     });
   }
-};
+});
 </script>
 
 <style scoped>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -72,7 +72,7 @@
         <nuxt />
       </v-container>
     </v-main>
-    <Snackbar></Snackbar>
+    <snackbar />
   </v-app>
 </template>
 

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -72,12 +72,14 @@
         <nuxt />
       </v-container>
     </v-main>
+    <Snackbar></Snackbar>
   </v-app>
 </template>
 
 <script lang="ts">
 import { BaseItemDto } from '../api/api';
 import UserButton from '../components/UserButton.vue';
+import Snackbar from '../components/Snackbar.vue';
 import { getLibraryIcon } from '../utils/items';
 
 interface NavigationDrawerItem {
@@ -88,7 +90,8 @@ interface NavigationDrawerItem {
 
 export default {
   components: {
-    UserButton
+    UserButton,
+    Snackbar
   },
   data() {
     return {

--- a/layouts/fullpage.vue
+++ b/layouts/fullpage.vue
@@ -3,5 +3,13 @@
     <v-main>
       <nuxt />
     </v-main>
+    <Snackbar></Snackbar>
   </v-app>
 </template>
+
+<script lang="ts">
+import Snackbar from '../components/Snackbar.vue';
+export default {
+  components: { Snackbar }
+};
+</script>

--- a/layouts/fullpage.vue
+++ b/layouts/fullpage.vue
@@ -3,12 +3,13 @@
     <v-main>
       <nuxt />
     </v-main>
-    <Snackbar></Snackbar>
+    <snackbar />
   </v-app>
 </template>
 
 <script lang="ts">
 import Snackbar from '../components/Snackbar.vue';
+
 export default {
   components: { Snackbar }
 };

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -40,7 +40,8 @@ const config: NuxtConfig = {
   plugins: [
     'plugins/userViewsApi.ts',
     'plugins/itemsApi.ts',
-    'plugins/imageApi.ts'
+    'plugins/imageApi.ts',
+    'plugins/snackbar.ts'
   ],
   /*
    ** Auto import components

--- a/plugins/snackbar.ts
+++ b/plugins/snackbar.ts
@@ -1,0 +1,29 @@
+import { Context } from '@nuxt/types';
+
+declare module '@nuxt/types' {
+  interface Context {
+    $snackbar(message: string, color: string): void;
+  }
+
+  interface NuxtAppOptions {
+    $snackbar(message: string, color: string): void;
+  }
+}
+
+declare module 'vue/types/vue' {
+  interface Vue {
+    $snackbar(message: string, color: string): void;
+  }
+}
+
+declare module 'vuex/types/index' {
+  interface Store<S> {
+    $snackbar(message: string, color: string): void;
+  }
+}
+
+export default (context: Context, inject: Function) => {
+  inject('snackbar', (message: string, color: string | undefined | null) => {
+    context.store.commit('snackbar/display', { message, color });
+  });
+};

--- a/store/snackbar.ts
+++ b/store/snackbar.ts
@@ -1,0 +1,20 @@
+import { MutationTree } from 'vuex';
+
+export const state = () => ({
+  message: '',
+  color: ''
+});
+
+export type SnackbarState = ReturnType<typeof state>;
+
+interface MutationPayload {
+  message: string;
+  color: string | undefined | null;
+}
+
+export const mutations: MutationTree<SnackbarState> = {
+  display(state: SnackbarState, payload: MutationPayload) {
+    state.message = payload.message;
+    state.color = !!payload.color ? <string>payload.color : '';
+  }
+};


### PR DESCRIPTION
This global snackbar can be called in Vue instances, stores and Nuxt contexts.

The method signature is $snackbar(message: string, color: string|undefined|null) and it will appear. If no color is specified, an empty string is given to the Vuetify component and it applies the default of the theme (black for our dark theme).

Closes #18 