### PR TITLE
fix(auth): fix user data disappearing on refresh

### DIFF
--- a/components/LoginForm.vue
+++ b/components/LoginForm.vue
@@ -62,11 +62,14 @@ export default Vue.extend({
           data: this.login
         });
 
+        const accessToken = `MediaBrowser Client="Jellyfin Web", Device="Firefox", DeviceId="TW96aWxsYS81LjAgKFgxMTsgTGludXggeDg2XzY0OyBydjo3Ny4wKSBHZWNrby8yMDEwMDEwMSBGaXJlZm94Lzc3LjB8MTU5NTQ1MTYzMzE4OQ11", Version="10.7.0", Token="${response.data.AccessToken}"`;
+
         this.$auth.setUserToken(
           // TODO: Generate the token properly
-          `MediaBrowser Client="Jellyfin Web", Device="Firefox", DeviceId="TW96aWxsYS81LjAgKFgxMTsgTGludXggeDg2XzY0OyBydjo3Ny4wKSBHZWNrby8yMDEwMDEwMSBGaXJlZm94Lzc3LjB8MTU5NTQ1MTYzMzE4OQ11", Version="10.7.0", Token="${response.data.AccessToken}"`
+          accessToken
         );
         this.$auth.setUser(response.data.User);
+        this.$user.set(response.data.User.Id, this.serverUrl, accessToken);
       } catch (error) {
         let errorMessage = 'Unexpected Error';
 

--- a/components/UserButton.vue
+++ b/components/UserButton.vue
@@ -29,6 +29,7 @@ export default Vue.extend({
           title: 'Logout',
           action: () => {
             this.$auth.logout();
+            this.$user.clear();
           }
         }
       ]

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -41,7 +41,9 @@ const config: NuxtConfig = {
     'plugins/userViewsApi.ts',
     'plugins/itemsApi.ts',
     'plugins/imageApi.ts',
-    'plugins/snackbar.ts'
+    'plugins/userApi.ts',
+    'plugins/snackbar.ts',
+    'plugins/user.ts'
   ],
   /*
    ** Auto import components
@@ -62,6 +64,12 @@ const config: NuxtConfig = {
    */
   modules: [
     // Doc: https://axios.nuxtjs.org/usage
+    [
+      'nuxt-vuex-localstorage',
+      {
+        localStorage: ['user']
+      }
+    ],
     '@nuxtjs/axios',
     '@nuxtjs/auth-next',
     '@nuxtjs/pwa'
@@ -129,7 +137,8 @@ const config: NuxtConfig = {
           type: false
         }
       }
-    }
+    },
+    plugins: ['plugins/userInit.ts']
   },
   /*
    ** vuetify module configuration

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "@nuxtjs/auth-next": "^5.0.0-1595976864.509d9d6",
     "@nuxtjs/axios": "^5.12.0",
     "@nuxtjs/pwa": "^3.0.0-beta.20",
-    "nuxt": "^2.14.0"
+    "nuxt": "^2.14.0",
+    "nuxt-vuex-localstorage": "^1.2.7"
   },
   "devDependencies": {
     "@commitlint/cli": "^9.1.2",

--- a/plugins/user.ts
+++ b/plugins/user.ts
@@ -1,0 +1,42 @@
+import { Context } from '@nuxt/types';
+import { PluginInjection } from '~/types/utils';
+
+interface UserStore {
+  set: (id: string, serverUrl: string, accessToken: string) => void;
+  clear: () => void;
+}
+
+declare module '@nuxt/types' {
+  interface Context {
+    $user: UserStore;
+  }
+
+  interface NuxtAppOptions {
+    $user: UserStore;
+  }
+}
+
+declare module 'vue/types/vue' {
+  interface Vue {
+    $user: UserStore;
+  }
+}
+
+declare module 'vuex/types/index' {
+  interface Store<S> {
+    $user: UserStore;
+  }
+}
+
+export default (context: Context, inject: PluginInjection): void => {
+  const user = {
+    set: (id: string, serverUrl: string, accessToken: string) => {
+      context.store.commit('user/set', { id, serverUrl, accessToken });
+    },
+    clear: () => {
+      context.store.commit('user/clear');
+    }
+  };
+
+  inject('user', user);
+};

--- a/plugins/userApi.ts
+++ b/plugins/userApi.ts
@@ -1,0 +1,27 @@
+import { Context } from '@nuxt/types';
+import { UserApi } from '~/api/api';
+import { Configuration } from '~/api/configuration';
+import { PluginInjection } from '~/types/utils';
+
+declare module '@nuxt/types' {
+  interface Context {
+    $userApi: UserApi;
+  }
+
+  interface NuxtAppOptions {
+    $userApi: UserApi;
+  }
+}
+
+declare module 'vue/types/vue' {
+  interface Vue {
+    $userApi: UserApi;
+  }
+}
+
+export default (context: Context, inject: PluginInjection): void => {
+  const config = new Configuration();
+
+  const userApi = new UserApi(config, '', context.$axios);
+  inject('userApi', userApi);
+};

--- a/plugins/userInit.ts
+++ b/plugins/userInit.ts
@@ -1,0 +1,19 @@
+import { Context } from '@nuxt/types';
+
+export default async (context: Context): Promise<void> => {
+  if (
+    context.store.state.user.id &&
+    context.store.state.user.serverUrl &&
+    context.store.state.user.accessToken
+  ) {
+    context.$axios.setBaseURL(context.store.state.user.serverUrl);
+
+    context.$auth.setUserToken(context.store.state.user.accessToken);
+
+    const response = await context.$userApi.getUserById({
+      userId: context.store.state.user.id
+    });
+
+    context.$auth.setUser(response.data);
+  }
+};

--- a/store/user.ts
+++ b/store/user.ts
@@ -1,0 +1,32 @@
+import { MutationTree } from 'vuex';
+
+export interface UserState {
+  id: string;
+  serverUrl: string;
+  accessToken: string;
+}
+
+export const state = (): UserState => ({
+  id: '',
+  serverUrl: '',
+  accessToken: ''
+});
+
+interface MutationPayload {
+  id: string;
+  serverUrl: string;
+  accessToken: string;
+}
+
+export const mutations: MutationTree<UserState> = {
+  set(state: UserState, payload: MutationPayload) {
+    state.id = payload.id;
+    state.serverUrl = payload.serverUrl;
+    state.accessToken = payload.accessToken;
+  },
+  clear(state: UserState) {
+    state.serverUrl = '';
+    state.serverUrl = '';
+    state.accessToken = '';
+  }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2854,6 +2854,13 @@ axios-retry@^3.1.8:
   dependencies:
     is-retry-allowed "^1.1.0"
 
+axios@^0.19.2:
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
+  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
+  dependencies:
+    follow-redirects "1.5.10"
+
 axios@^0.20.0:
   version "0.20.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.20.0.tgz#057ba30f04884694993a8cd07fa394cff11c50bd"
@@ -4494,6 +4501,13 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
+debug@=3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
+  dependencies:
+    ms "2.0.0"
+
 debug@^3.1.0:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
@@ -5753,6 +5767,13 @@ flush-write-stream@^1.0.0:
   dependencies:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
+
+follow-redirects@1.5.10:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
+  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
+  dependencies:
+    debug "=3.1.0"
 
 follow-redirects@^1.0.0, follow-redirects@^1.10.0:
   version "1.13.0"
@@ -8662,6 +8683,13 @@ num2fraction@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/num2fraction/-/num2fraction-1.2.2.tgz#6f682b6a027a4e9ddfa4564cd2589d1d4e669ede"
   integrity sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=
+
+nuxt-vuex-localstorage@^1.2.7:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/nuxt-vuex-localstorage/-/nuxt-vuex-localstorage-1.2.7.tgz#6d609407d9e7b449907e85aeecbbc249fda8c97e"
+  integrity sha512-3L31Kibd83Dm/swEQzFHCwSHhEB2pQkBaE3sYw1NhivX+P7LHGGw+MC3y/89ef4RxblPWZKCm+jnNmPhTW8Bzg==
+  dependencies:
+    axios "^0.19.2"
 
 nuxt@^2.14.0:
   version "2.14.4"


### PR DESCRIPTION
Nuxt Auth expects a normal API to poll the user data on refresh, like `/user/me`.

Due to Jellyfin needing the user's ID to fetch their information, this commit registers a new Auth plugin and a persistent Vuex store, saved to localStorage, to perform the request manually when Nuxt starts up.

It then sets all the required information before the client properly starts, meaning the information
is always fresh when the user refreshes the page.