### PR TITLE
refactor: removed component imports

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -79,8 +79,6 @@
 <script lang="ts">
 import Vue from 'vue';
 import { BaseItemDto } from '~/api/api';
-import UserButton from '~/components/UserButton.vue';
-import Snackbar from '~/components/Snackbar.vue';
 import { getLibraryIcon } from '~/utils/items';
 
 interface NavigationDrawerItem {
@@ -90,10 +88,6 @@ interface NavigationDrawerItem {
 }
 
 export default Vue.extend({
-  components: {
-    UserButton,
-    Snackbar
-  },
   data() {
     return {
       items: [

--- a/layouts/fullpage.vue
+++ b/layouts/fullpage.vue
@@ -6,11 +6,3 @@
     <snackbar />
   </v-app>
 </template>
-
-<script lang="ts">
-import Snackbar from '~/components/Snackbar.vue';
-
-export default {
-  components: { Snackbar }
-};
-</script>

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -11,12 +11,8 @@
 
 <script lang="ts">
 import Vue from 'vue';
-import LoginForm from '~/components/LoginForm.vue';
 
 export default Vue.extend({
-  layout: 'fullpage',
-  components: {
-    LoginForm
-  }
+  layout: 'fullpage'
 });
 </script>


### PR DESCRIPTION
In nuxt.config.ts, the option 'components' is set to true. Nuxt auto imports used components in templates from the components/ directory.