### PR TITLE
feat(index): add home sections 

### DIFF
--- a/components/HomeSection.vue
+++ b/components/HomeSection.vue
@@ -1,0 +1,96 @@
+<template>
+  <v-col v-show="items.length > 0">
+    <h1 class="text-h5">
+      <span>{{ section.name }}</span>
+    </h1>
+
+    <div class="d-flex flex-wrap">
+      <card
+        v-for="item in items"
+        :key="item.Id"
+        :to="`/item/${item.Id}`"
+        class="card mt-5"
+        :item="item"
+      />
+    </div>
+  </v-col>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import { BaseItemDto } from '../api';
+
+export default Vue.extend({
+  props: {
+    section: {
+      type: Object,
+      required: true
+    }
+  },
+  data() {
+    return {
+      items: [] as BaseItemDto[]
+    };
+  },
+  async created() {
+    switch (this.section.type) {
+      case 'resume': {
+        const resumeItems = await this.$itemsApi.getResumeItems({
+          userId: this.$auth.user.Id,
+          limit: 12,
+          fields: 'PrimaryImageAspectRatio',
+          imageTypeLimit: 1,
+          enableImageTypes: 'Primary,Backdrop,Thumb',
+          enableTotalRecordCount: false,
+          mediaTypes: 'Video'
+        });
+
+        this.items = resumeItems.data.Items as BaseItemDto[];
+        break;
+      }
+      case 'resumeaudio': {
+        const resumeItems = await this.$itemsApi.getResumeItems({
+          userId: this.$auth.user.Id,
+          limit: 12,
+          fields: 'PrimaryImageAspectRatio',
+          imageTypeLimit: 1,
+          enableImageTypes: 'Primary,Backdrop,Thumb',
+          enableTotalRecordCount: false,
+          mediaTypes: 'Audio'
+        });
+
+        this.items = resumeItems.data.Items as BaseItemDto[];
+        break;
+      }
+      case 'nextup': {
+        const latestItems = await this.$tvShowsApi.getNextUp({
+          userId: this.$auth.user.Id,
+          limit: 12,
+          fields: 'PrimaryImageAspectRatio',
+          imageTypeLimit: 1,
+          enableImageTypes: 'Primary,Backdrop,Thumb',
+          parentId: this.section.libraryId
+        });
+
+        this.items = latestItems.data.Items as BaseItemDto[];
+        break;
+      }
+      case 'latestmedia': {
+        const latestItems = await this.$userLibraryApi.getLatestMedia({
+          userId: this.$auth.user.Id,
+          limit: 12,
+          fields: 'PrimaryImageAspectRatio',
+          imageTypeLimit: 1,
+          enableImageTypes: 'Primary,Backdrop,Thumb',
+          parentId: this.section.libraryId
+        });
+
+        this.items = latestItems.data;
+        break;
+      }
+      default:
+        break;
+    }
+  }
+});
+</script>

--- a/components/HomeSection.vue
+++ b/components/HomeSection.vue
@@ -4,15 +4,11 @@
       <span>{{ section.name }}</span>
     </h1>
 
-    <div class="d-flex flex-wrap">
-      <card
-        v-for="item in items"
-        :key="item.Id"
-        :to="`/item/${item.Id}`"
-        class="card mt-5"
-        :item="item"
-      />
-    </div>
+    <v-slide-group>
+      <v-slide-item v-for="item in items" :key="item.Id">
+        <card :to="`/item/${item.Id}`" class="card mt-5" :item="item" />
+      </v-slide-item>
+    </v-slide-group>
   </v-col>
 </template>
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -38,13 +38,15 @@ const config: NuxtConfig = {
    ** https://nuxtjs.org/guide/plugins
    */
   plugins: [
-    'plugins/userViewsApi.ts',
-    'plugins/itemsApi.ts',
+    'plugins/displayPreferenceApi.ts',
     'plugins/imageApi.ts',
-    'plugins/tvShowsApi.ts',
-    'plugins/userApi.ts',
+    'plugins/itemsApi.ts',
     'plugins/snackbar.ts',
-    'plugins/user.ts'
+    'plugins/tvShowsApi.ts',
+    'plugins/user.ts',
+    'plugins/userApi.ts',
+    'plugins/userApi.ts',
+    'plugins/userViewsApi.ts'
   ],
   /*
    ** Auto import components

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -45,7 +45,7 @@ const config: NuxtConfig = {
     'plugins/tvShowsApi.ts',
     'plugins/user.ts',
     'plugins/userApi.ts',
-    'plugins/userApi.ts',
+    'plugins/userLibraryApi.ts',
     'plugins/userViewsApi.ts'
   ],
   /*

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "@nuxtjs/auth-next": "^5.0.0-1595976864.509d9d6",
     "@nuxtjs/axios": "^5.12.0",
     "@nuxtjs/pwa": "^3.0.0-beta.20",
+    "@types/lodash": "^4.14.161",
+    "lodash": "^4.17.20",
     "nuxt": "^2.14.0",
     "nuxt-vuex-localstorage": "^1.2.7"
   },

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,7 +1,12 @@
 <template>
-  <v-layout column justify-center align-center>
-    {{ homeSections }}
-  </v-layout>
+  <v-container fluid>
+    <v-row
+      v-for="(homeSection, homeSectionIndex) in homeSections"
+      :key="homeSectionIndex"
+    >
+      <home-section :section="homeSection" />
+    </v-row>
+  </v-container>
 </template>
 
 <script lang="ts">
@@ -9,20 +14,110 @@ import Vue from 'vue';
 import { pickBy } from 'lodash';
 
 export default Vue.extend({
-  computed: {
-    homeSections: {
-      get() {
-        const homeSections = pickBy(
-          this.$store.state.user.displayPreferences,
-          (value: string, key: string) => {
-            return value && key.startsWith('homesection');
-          }
+  data() {
+    return {
+      homeSections: [
+        {
+          name: 'Continue Watching',
+          libraryId: '',
+          type: 'resume'
+        },
+        {
+          name: 'Continue Listening',
+          libraryId: '',
+          type: 'resumeaudio'
+        },
+        {
+          name: 'Next Up',
+          libraryId: '',
+          type: 'nextup'
+        }
+      ]
+    };
+  },
+  async created() {
+    const validSections = ['resume', 'resumeaudio', 'nextup', 'latestmedia'];
+
+    // Filter for valid sections in Jellyfin Vue
+    let homeSectionsArray = pickBy(
+      this.$store.state.user.displayPreferences,
+      (value: string, key: string) => {
+        return (
+          value &&
+          validSections.includes(value) &&
+          key.startsWith('homesection')
         );
-
-        console.dir(this.$store.state.user.displayPreferences);
-
-        return homeSections;
       }
+    );
+
+    if (homeSectionsArray) {
+      // Convert to an array
+      homeSectionsArray = Object.values(homeSectionsArray);
+
+      const homeSections = [];
+
+      for (const homeSection of homeSectionsArray as Array<string>) {
+        switch (homeSection) {
+          case 'latestmedia': {
+            const latestMediaSections = [];
+
+            const userViewsRequest = await this.$userViewsApi.getUserViews({
+              userId: this.$auth.user.Id
+            });
+
+            if (userViewsRequest.data.Items) {
+              const excludeViewTypes = [
+                'playlists',
+                'livetv',
+                'boxsets',
+                'channels'
+              ];
+
+              for (const userView of userViewsRequest.data.Items) {
+                if (
+                  excludeViewTypes.includes(userView.CollectionType as string)
+                ) {
+                  continue;
+                }
+
+                latestMediaSections.push({
+                  name: `Latest ${userView.Name}`,
+                  libraryId: userView.Id || '',
+                  type: 'latestmedia'
+                });
+              }
+
+              homeSections.push(...latestMediaSections);
+            }
+            break;
+          }
+          case 'resume':
+            homeSections.push({
+              name: 'Continue Watching',
+              libraryId: '',
+              type: 'resume'
+            });
+            break;
+          case 'resumeaudio':
+            homeSections.push({
+              name: 'Continue Listening',
+              libraryId: '',
+              type: 'resumeaudio'
+            });
+            break;
+          case 'nextup':
+            homeSections.push({
+              name: 'Next Up',
+              libraryId: '',
+              type: 'nextup'
+            });
+            break;
+          default:
+            break;
+        }
+      }
+
+      this.homeSections = homeSections;
     }
   }
 });

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,3 +1,29 @@
 <template>
-  <v-layout column justify-center align-center></v-layout>
+  <v-layout column justify-center align-center>
+    {{ homeSections }}
+  </v-layout>
 </template>
+
+<script lang="ts">
+import Vue from 'vue';
+import { pickBy } from 'lodash';
+
+export default Vue.extend({
+  computed: {
+    homeSections: {
+      get() {
+        const homeSections = pickBy(
+          this.$store.state.user.displayPreferences,
+          (value: string, key: string) => {
+            return value && key.startsWith('homesection');
+          }
+        );
+
+        console.dir(this.$store.state.user.displayPreferences);
+
+        return homeSections;
+      }
+    }
+  }
+});
+</script>

--- a/pages/library/_viewId.vue
+++ b/pages/library/_viewId.vue
@@ -16,12 +16,13 @@
 
 <script lang="ts">
 import Vue from 'vue';
+import { BaseItemDto } from '../../api';
 
 export default Vue.extend({
   data() {
     return {
       name: '',
-      items: {}
+      items: [] as BaseItemDto[]
     };
   },
   async beforeMount() {

--- a/plugins/displayPreferenceApi.ts
+++ b/plugins/displayPreferenceApi.ts
@@ -1,4 +1,5 @@
 import { Context } from '@nuxt/types';
+import { AxiosInstance } from 'axios';
 import { DisplayPreferencesApi } from '~/api/api';
 import { Configuration } from '~/api/configuration';
 import { PluginInjection } from '~/types/utils';
@@ -25,7 +26,7 @@ export default (context: Context, inject: PluginInjection): void => {
   const displayPreferencesApi = new DisplayPreferencesApi(
     config,
     '',
-    context.$axios
+    context.$axios as AxiosInstance
   );
   inject('displayPreferencesApi', displayPreferencesApi);
 };

--- a/plugins/displayPreferenceApi.ts
+++ b/plugins/displayPreferenceApi.ts
@@ -1,0 +1,31 @@
+import { Context } from '@nuxt/types';
+import { DisplayPreferencesApi } from '~/api/api';
+import { Configuration } from '~/api/configuration';
+import { PluginInjection } from '~/types/utils';
+
+declare module '@nuxt/types' {
+  interface Context {
+    $displayPreferencesApi: DisplayPreferencesApi;
+  }
+
+  interface NuxtAppOptions {
+    $displayPreferencesApi: DisplayPreferencesApi;
+  }
+}
+
+declare module 'vue/types/vue' {
+  interface Vue {
+    $displayPreferencesApi: DisplayPreferencesApi;
+  }
+}
+
+export default (context: Context, inject: PluginInjection): void => {
+  const config = new Configuration();
+
+  const displayPreferencesApi = new DisplayPreferencesApi(
+    config,
+    '',
+    context.$axios
+  );
+  inject('displayPreferencesApi', displayPreferencesApi);
+};

--- a/plugins/imageApi.ts
+++ b/plugins/imageApi.ts
@@ -1,4 +1,5 @@
 import { Context } from '@nuxt/types';
+import { AxiosInstance } from 'axios';
 import { ImageApi } from '~/api/api';
 import { Configuration } from '~/api/configuration';
 import { PluginInjection } from '~/types/utils';
@@ -22,6 +23,6 @@ declare module 'vue/types/vue' {
 export default (context: Context, inject: PluginInjection): void => {
   const config = new Configuration();
 
-  const imageApi = new ImageApi(config, '', context.$axios);
+  const imageApi = new ImageApi(config, '', context.$axios as AxiosInstance);
   inject('imageApi', imageApi);
 };

--- a/plugins/itemsApi.ts
+++ b/plugins/itemsApi.ts
@@ -1,4 +1,5 @@
 import { Context } from '@nuxt/types';
+import { AxiosInstance } from 'axios';
 import { ItemsApi } from '~/api/api';
 import { Configuration } from '~/api/configuration';
 import { PluginInjection } from '~/types/utils';
@@ -22,6 +23,6 @@ declare module 'vue/types/vue' {
 export default (context: Context, inject: PluginInjection): void => {
   const config = new Configuration();
 
-  const itemsApi = new ItemsApi(config, '', context.$axios);
+  const itemsApi = new ItemsApi(config, '', context.$axios as AxiosInstance);
   inject('itemsApi', itemsApi);
 };

--- a/plugins/tvShowsApi.ts
+++ b/plugins/tvShowsApi.ts
@@ -1,4 +1,5 @@
 import { Context } from '@nuxt/types';
+import { AxiosInstance } from 'axios';
 import { TvShowsApi } from '~/api/api';
 import { Configuration } from '~/api/configuration';
 import { PluginInjection } from '~/types/utils';
@@ -22,6 +23,10 @@ declare module 'vue/types/vue' {
 export default (context: Context, inject: PluginInjection): void => {
   const config = new Configuration();
 
-  const tvShowsApi = new TvShowsApi(config, '', context.$axios);
+  const tvShowsApi = new TvShowsApi(
+    config,
+    '',
+    context.$axios as AxiosInstance
+  );
   inject('tvShowsApi', tvShowsApi);
 };

--- a/plugins/user.ts
+++ b/plugins/user.ts
@@ -30,8 +30,17 @@ declare module 'vuex/types/index' {
 
 export default (context: Context, inject: PluginInjection): void => {
   const user = {
-    set: (id: string, serverUrl: string, accessToken: string) => {
-      context.store.commit('user/set', { id, serverUrl, accessToken });
+    set: async (id: string, serverUrl: string, accessToken: string) => {
+      const response = await context.$displayPreferencesApi.getDisplayPreferences(
+        { displayPreferencesId: 'usersettings', userId: id, client: 'emby' }
+      );
+
+      context.store.commit('user/set', {
+        id,
+        serverUrl,
+        accessToken,
+        displayPreferences: response.data.CustomPrefs
+      });
     },
     clear: () => {
       context.store.commit('user/clear');

--- a/plugins/userApi.ts
+++ b/plugins/userApi.ts
@@ -1,4 +1,5 @@
 import { Context } from '@nuxt/types';
+import { AxiosInstance } from 'axios';
 import { UserApi } from '~/api/api';
 import { Configuration } from '~/api/configuration';
 import { PluginInjection } from '~/types/utils';
@@ -22,6 +23,6 @@ declare module 'vue/types/vue' {
 export default (context: Context, inject: PluginInjection): void => {
   const config = new Configuration();
 
-  const userApi = new UserApi(config, '', context.$axios);
+  const userApi = new UserApi(config, '', context.$axios as AxiosInstance);
   inject('userApi', userApi);
 };

--- a/plugins/userLibraryApi.ts
+++ b/plugins/userLibraryApi.ts
@@ -1,0 +1,32 @@
+import { Context } from '@nuxt/types';
+import { AxiosInstance } from 'axios';
+import { UserLibraryApi } from '~/api/api';
+import { Configuration } from '~/api/configuration';
+import { PluginInjection } from '~/types/utils';
+
+declare module '@nuxt/types' {
+  interface Context {
+    $userLibraryApi: UserLibraryApi;
+  }
+
+  interface NuxtAppOptions {
+    $userLibraryApi: UserLibraryApi;
+  }
+}
+
+declare module 'vue/types/vue' {
+  interface Vue {
+    $userLibraryApi: UserLibraryApi;
+  }
+}
+
+export default (context: Context, inject: PluginInjection): void => {
+  const config = new Configuration();
+
+  const userLibraryApi = new UserLibraryApi(
+    config,
+    '',
+    context.$axios as AxiosInstance
+  );
+  inject('userLibraryApi', userLibraryApi);
+};

--- a/plugins/userViewsApi.ts
+++ b/plugins/userViewsApi.ts
@@ -1,4 +1,5 @@
 import { Context } from '@nuxt/types';
+import { AxiosInstance } from 'axios';
 import { UserViewsApi } from '~/api/api';
 import { Configuration } from '~/api/configuration';
 import { PluginInjection } from '~/types/utils';
@@ -22,6 +23,10 @@ declare module 'vue/types/vue' {
 export default (context: Context, inject: PluginInjection): void => {
   const config = new Configuration();
 
-  const userViewsApi = new UserViewsApi(config, '', context.$axios);
+  const userViewsApi = new UserViewsApi(
+    config,
+    '',
+    context.$axios as AxiosInstance
+  );
   inject('userViewsApi', userViewsApi);
 };

--- a/store/user.ts
+++ b/store/user.ts
@@ -4,18 +4,21 @@ export interface UserState {
   id: string;
   serverUrl: string;
   accessToken: string;
+  displayPreferences: { [key: string]: string };
 }
 
 export const state = (): UserState => ({
   id: '',
   serverUrl: '',
-  accessToken: ''
+  accessToken: '',
+  displayPreferences: {}
 });
 
 interface MutationPayload {
   id: string;
   serverUrl: string;
   accessToken: string;
+  displayPreferences: { [key: string]: string };
 }
 
 export const mutations: MutationTree<UserState> = {
@@ -23,10 +26,12 @@ export const mutations: MutationTree<UserState> = {
     state.id = payload.id;
     state.serverUrl = payload.serverUrl;
     state.accessToken = payload.accessToken;
+    state.displayPreferences = payload.displayPreferences;
   },
   clear(state: UserState) {
     state.serverUrl = '';
     state.serverUrl = '';
     state.accessToken = '';
+    state.displayPreferences = {};
   }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1957,6 +1957,11 @@
   resolved "https://registry.yarnpkg.com/@types/less/-/less-3.0.1.tgz#625694093c72f8356c4042754e222407e50d6b08"
   integrity sha512-dBp05MtWN/w1fGVjj5LVrDw6VrdYllpWczbUkCsrzBj08IHsSyRLOFvUrCFqZFVR+nsqkrRLNg6oOlvqMLPaSA==
 
+"@types/lodash@^4.14.161":
+  version "4.14.161"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.161.tgz#a21ca0777dabc6e4f44f3d07f37b765f54188b18"
+  integrity sha512-EP6O3Jkr7bXvZZSZYlsgt5DIjiGr0dXP1/jVEwVLTFgg0d+3lWVQkRavYVQszV7dYUwvg0B8R0MBDpcmXg7XIA==
+
 "@types/memory-fs@*":
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/@types/memory-fs/-/memory-fs-0.3.2.tgz#5d4753f9b390cb077c8c8af97bc96463399ceccd"


### PR DESCRIPTION
Adds support for the following home sections:

* resume
* resumeaudio
* nextup
* latest

Some current sections have been omitted voluntarily for now:

* librarytiles
  Makes sense later on, but not a priority
* librarybuttons
  Would be implemented with librarytiles and rely on the same component
* activerecordings
  Not a priority, annoying to test
* onnow/livetv
  Needs a visual redesign, since we don't want the buttons there, only programs

![image](https://user-images.githubusercontent.com/19396809/92311138-bf3fc280-efb4-11ea-8c85-ce1f95f0f79e.png)
