### PR TITLE
Removed and replaced unexisting props from LoginForm.vue

### DIFF
--- a/pages/login.vue
+++ b/pages/login.vue
@@ -1,7 +1,7 @@
 <template>
   <v-container fill-height>
     <v-row align="center" justify="center">
-      <v-col align="center" justify="center" md="4" no-gutters>
+      <v-col align="center" justify="center" md="4">
         <h1 class="text-h4 mb-6">Login</h1>
         <login-form />
       </v-col>

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -1,8 +1,8 @@
 <template>
   <v-container fill-height>
     <v-row align="center" justify="center">
-      <v-col align="center" justify="center" md="4">
-        <h1 class="text-h4 mb-6">Login</h1>
+      <v-col md="4">
+        <h1 class="text-h4 mb-6 text-center">Login</h1>
         <login-form />
       </v-col>
     </v-row>


### PR DESCRIPTION
Those props aren't described in the Vuetify API.

* `no-gutters`: doesn't exist on `v-col` and didn't change the styling. Removed.
* `justify`, `align`: also don't exist, even though at least one of them worked. Replaced by a class `text-center` on the title to get the same styling.