### PR TITLE
fix(library view cards): Fix going from library to item details

### DIFF
--- a/components/Card.vue
+++ b/components/Card.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card>
+  <v-card :to="`../item/${item.Id}`">
     <v-img class="cardImage" :src="imageLink(item.Id)" />
     <v-card-title>
       <span>{{ item.Name }}</span>

--- a/pages/library/_viewId.vue
+++ b/pages/library/_viewId.vue
@@ -7,7 +7,6 @@
       <card
         v-for="item in items"
         :key="item.Id"
-        :to="`../item/${item.Id}`"
         class="card mt-5"
         :item="item"
       />


### PR DESCRIPTION
Moves `:to` from `card` to `v-card` in `components/card` since only `v-card` supports `:to`