### PR TITLE
Localizations fix on nav drawer

### DIFF
--- a/components/LocaleSwitcher.vue
+++ b/components/LocaleSwitcher.vue
@@ -7,7 +7,7 @@
     </template>
     <v-list>
       <v-list-item
-        v-for="(item, index) in menuItems"
+        v-for="(item, index) in $i18n.locales"
         :key="index"
         :input-value="item.code === $i18n.locale"
         @click="$i18n.setLocale(item.code)"
@@ -17,17 +17,3 @@
     </v-list>
   </v-menu>
 </template>
-
-<script lang="ts">
-import Vue from 'vue';
-
-export default Vue.extend({
-  computed: {
-    menuItems: {
-      get() {
-        return this.$i18n.locales;
-      }
-    }
-  }
-});
-</script>

--- a/components/LocaleSwitcher.vue
+++ b/components/LocaleSwitcher.vue
@@ -9,6 +9,7 @@
       <v-list-item
         v-for="(item, index) in menuItems"
         :key="index"
+        :input-value="item.code === $i18n.locale"
         @click="$i18n.setLocale(item.code)"
       >
         <v-list-item-title>{{ item.name }}</v-list-item-title>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -82,25 +82,32 @@ interface NavigationDrawerItem {
 export default Vue.extend({
   data() {
     return {
-      items: [
+      clipped: true,
+      drawer: true,
+      libraries: {},
+      miniVariant: false,
+      title: 'Jellyfin'
+    };
+  },
+  computed: {
+    items() {
+      return [
         {
           icon: 'mdi-home',
           title: this.$t('home'),
           to: '/'
         }
-      ],
-      configItems: [
+      ];
+    },
+    configItems() {
+      return [
         {
           icon: 'mdi-cog',
           title: this.$t('settings'),
           to: '/settings'
         }
-      ],
-      clipped: true,
-      drawer: !this.$vuetify.breakpoint.mobile,
-      libraries: {},
-      title: 'Jellyfin'
-    };
+      ];
+    }
   },
   async beforeMount() {
     const userViewsRequest = await this.$userViewsApi.getUserViews({


### PR DESCRIPTION
…locale

When switching locale, a reload of the page is triggered. Also, the current active locale is
higlighted in the switcher.

Edit: I see that for instance if I put the locale switcher on the login form, it works without reloading. I don't know why on the home page it doesn't work, I'll look into it.

Edit 2: it now works with computed values for the drawer. This PR is now:

* Computed localizations for the nav drawer
* Removed a getter in locale-switcher