### PR TITLE
Design improvements

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -23,7 +23,7 @@
           </v-list-item-content>
         </v-list-item>
       </v-list>
-      <v-divider></v-divider>
+      <v-divider v-if="libraries.length > 0"></v-divider>
       <v-list>
         <v-list-item
           v-for="(library, i) in libraries"

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,12 +1,6 @@
 <template>
   <v-app dark>
-    <v-navigation-drawer
-      v-model="drawer"
-      :mini-variant="miniVariant"
-      :clipped="clipped"
-      fixed
-      app
-    >
+    <v-navigation-drawer v-model="drawer" :clipped="clipped" fixed app>
       <v-list>
         <v-list-item
           v-for="(item, i) in items"
@@ -60,9 +54,6 @@
     </v-navigation-drawer>
     <v-app-bar :clipped-left="clipped" fixed app>
       <v-app-bar-nav-icon @click.stop="drawer = !drawer" />
-      <v-btn icon @click.stop="miniVariant = !miniVariant">
-        <v-icon>mdi-{{ `chevron-${miniVariant ? 'right' : 'left'}` }}</v-icon>
-      </v-btn>
       <v-toolbar-title v-text="title" />
       <v-spacer />
       <locale-switcher />
@@ -108,7 +99,6 @@ export default Vue.extend({
       clipped: true,
       drawer: true,
       libraries: {},
-      miniVariant: false,
       title: 'Jellyfin'
     };
   },

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -97,7 +97,7 @@ export default Vue.extend({
         }
       ],
       clipped: true,
-      drawer: true,
+      drawer: !this.$vuetify.breakpoint.mobile,
       libraries: {},
       title: 'Jellyfin'
     };


### PR DESCRIPTION
* Removing one of the dividers in the nav drawer when no library is in the list, to avoid having two dividers displayed
* Hidden the button which enabled / disabled the mini variant of navigation drawer. All the code is still there, only the button is commented in HTML
* Hiding the drawer by default, better for mobile usage in order to avoid having to close it almost every time
* Removed the flex usage in the _viewId page. We should use rows and cols to make a responsive grid.
* Removed the .card and .cardImage classes. First one statically applied a size to the cards, which at least shouldn't be set to the component. Second one didn't have a definition anywhere else.

Feel free to comment on anything. :)