### PR TITLE
fix(card.vue): fixed type error of 'shape' prop

### DIFF
--- a/components/Card.vue
+++ b/components/Card.vue
@@ -46,7 +46,7 @@ export default Vue.extend({
       }
     },
     shape: {
-      type: String,
+      type: [String, Boolean],
       required: false,
       default: () => {
         return false;


### PR DESCRIPTION
Prop 'shape' is specified to be a string, but default value is false. Seeing how the check for existence is an `if(shape)`, putting the default to an empty string doesn't change the result but stops the error in the JS console.
