### PR TITLE
Add playback profile detection

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -43,6 +43,7 @@ const config: NuxtConfig = {
     // Utility
     'plugins/browserDetection.ts',
     'plugins/deviceProfile.ts',
+    'plugins/playbackProfile.ts',
     'plugins/snackbar.ts',
     'plugins/user.ts',
     // API

--- a/plugins/browserDetection.ts
+++ b/plugins/browserDetection.ts
@@ -24,6 +24,16 @@ declare module 'vue/types/vue' {
  * @class BrowserDetector
  */
 class BrowserDetector {
+  supportsMediaSource() {
+    // Browsers that lack a media source implementation will have no reference
+    // to |window.MediaSource|.
+    if (!window.MediaSource) {
+      return false;
+    }
+
+    return true;
+  }
+
   /**
    * Check if the user agent of the navigator contains a key.
    *
@@ -221,6 +231,10 @@ class BrowserDetector {
 
   /* Platform Utilities */
 
+  isAndroid() {
+    return this.userAgentContains('Android');
+  }
+
   /**
    * Guesses if the platform is a mobile one (iOS or Android).
    *
@@ -256,7 +270,7 @@ class BrowserDetector {
    * @memberof BrowserDetector
    */
   isTv() {
-    return this.isTizen || this.isWebOS;
+    return this.isTizen() || this.isWebOS();
   }
 }
 

--- a/plugins/playbackProfile.ts
+++ b/plugins/playbackProfile.ts
@@ -28,7 +28,9 @@ const physicalAudioChannels = browserDetector.isTv() ? 6 : 2;
 const videoTestElement = document.createElement('video');
 
 /**
+ * Returns a valid DirectPlayProfile for the current platform.
  *
+ * @returns {Array<DirectPlayProfile>} An array of direct play profiles for the current platform.
  */
 function getDirectPlayProfiles(): Array<DirectPlayProfile> {
   const DirectPlayProfiles = [];
@@ -36,7 +38,7 @@ function getDirectPlayProfiles(): Array<DirectPlayProfile> {
   const mp4VideoCodecs = getSupportedMP4VideoCodecs(videoTestElement);
   const mp4AudioCodecs = getSupportedMP4AudioCodecs(videoTestElement);
   const vpxVideoCodecs = getSupportedVPXVideoCodecs(videoTestElement);
-  const webmAudioCodecs = getSupportedWebMAudioCodecs();
+  const webmAudioCodecs = getSupportedWebMAudioCodecs(videoTestElement);
 
   DirectPlayProfiles.push({
     Container: 'webm',
@@ -100,7 +102,9 @@ function getDirectPlayProfiles(): Array<DirectPlayProfile> {
 }
 
 /**
+ * Returns a valid TranscodingProfile for the current platform.
  *
+ * @returns {Array<TranscodingProfile>} An array of transcoding profiles for the current platform.
  */
 function getTranscodingProfiles(): Array<TranscodingProfile> {
   const TranscodingProfiles = [];
@@ -108,13 +112,16 @@ function getTranscodingProfiles(): Array<TranscodingProfile> {
   const hlsBreakOnNonKeyFrames = !!(
     browserDetector.isApple() ||
     browserDetector.isEdge() ||
-    !canPlayNativeHls()
+    !canPlayNativeHls(videoTestElement)
   );
 
-  if (canPlayNativeHls() || browserDetector.supportsMediaSource()) {
+  if (
+    canPlayNativeHls(videoTestElement) ||
+    browserDetector.supportsMediaSource()
+  ) {
     TranscodingProfiles.push({
       Container:
-        !canPlayNativeHls() ||
+        !canPlayNativeHls(videoTestElement) ||
         browserDetector.isEdge() ||
         browserDetector.isAndroid()
           ? 'ts'
@@ -160,7 +167,7 @@ function getTranscodingProfiles(): Array<TranscodingProfile> {
   const hlsVideoAudioCodecs = getHlsAudioCodecs(videoTestElement);
 
   if (
-    canPlayNativeHls() ||
+    canPlayNativeHls(videoTestElement) ||
     (browserDetector.supportsMediaSource() && hlsVideoAudioCodecs.length)
   ) {
     TranscodingProfiles.push({
@@ -194,7 +201,9 @@ function getTranscodingProfiles(): Array<TranscodingProfile> {
 }
 
 /**
+ * Returns a valid SubtitleProfile for the current platform.
  *
+ * @returns {Array<SubtitleProfile>} An array of subtitle profiles for the current platform.
  */
 function getSubtitleProfiles(): Array<SubtitleProfile> {
   const SubtitleProfiles = [];
@@ -208,7 +217,9 @@ function getSubtitleProfiles(): Array<SubtitleProfile> {
 }
 
 /**
+ * Returns a valid ResponseProfile for the current platform.
  *
+ * @returns {Array<ResponseProfile>} An array of subtitle profiles for the current platform.
  */
 function getResponseProfiles(): Array<ResponseProfile> {
   const ResponseProfiles = [];
@@ -225,7 +236,6 @@ function getResponseProfiles(): Array<ResponseProfile> {
 /**
  * Creates a device profile containing supported codecs for the active Cast device.
  *
- * @param {object} [options=Object]
  * @returns {object} Device profile.
  */
 function getDeviceProfile(): DeviceProfile {

--- a/plugins/playbackProfile.ts
+++ b/plugins/playbackProfile.ts
@@ -1,0 +1,264 @@
+import { Context } from '@nuxt/types/app';
+import { browserDetector } from './browserDetection';
+import {
+  getSupportedMP4VideoCodecs,
+  hasVp8Support
+} from '~/utils/mp4VideoFormats';
+import { getSupportedMP4AudioCodecs } from '~/utils/mp4AudioFormats';
+import { getSupportedVPXVideoCodecs } from '~/utils/vpxVideoFormats';
+import { getSupportedWebMAudioCodecs } from '~/utils/webmAudioFormats';
+import { getSupportedAudioCodecs } from '~/utils/audioFormats';
+import { canPlayNativeHls, hasMkvSupport } from '~/utils/transcodingFormats';
+import { getHlsVideoCodecs, getHlsAudioCodecs } from '~/utils/hlsFormats';
+import { getCodecProfiles } from '~/utils/codecProfiles';
+import {
+  DeviceProfile,
+  DirectPlayProfile,
+  DlnaProfileType,
+  TranscodingProfile,
+  EncodingContext,
+  SubtitleProfile,
+  SubtitleDeliveryMethod,
+  ResponseProfile
+} from '~/api';
+import { PluginInjection } from '~/types/utils';
+
+const physicalAudioChannels = browserDetector.isTv() ? 6 : 2;
+
+const videoTestElement = document.createElement('video');
+
+/**
+ *
+ */
+function getDirectPlayProfiles(): Array<DirectPlayProfile> {
+  const DirectPlayProfiles = [];
+
+  const mp4VideoCodecs = getSupportedMP4VideoCodecs(videoTestElement);
+  const mp4AudioCodecs = getSupportedMP4AudioCodecs(videoTestElement);
+  const vpxVideoCodecs = getSupportedVPXVideoCodecs(videoTestElement);
+  const webmAudioCodecs = getSupportedWebMAudioCodecs();
+
+  DirectPlayProfiles.push({
+    Container: 'webm',
+    Type: DlnaProfileType.Video,
+    AudioCodec: webmAudioCodecs.join(','),
+    VideoCodec: vpxVideoCodecs.join(',')
+  });
+
+  DirectPlayProfiles.push({
+    Container: 'mp4,m4v',
+    Type: DlnaProfileType.Video,
+    VideoCodec: mp4VideoCodecs.join(','),
+    AudioCodec: mp4AudioCodecs.join(',')
+  });
+
+  const supportedAudio = [
+    'opus',
+    'mp3',
+    'mp2',
+    'aac',
+    'flac',
+    'alac',
+    'webma',
+    'wma',
+    'wav',
+    'ogg',
+    'oga'
+  ];
+
+  for (const audioFormat of supportedAudio) {
+    if (audioFormat === 'mp2') {
+      DirectPlayProfiles.push({
+        Container: 'mp2,mp3',
+        Type: DlnaProfileType.Audio,
+        AudioCodec: audioFormat
+      });
+    } else if (audioFormat === 'mp3') {
+      DirectPlayProfiles.push({
+        Container: audioFormat,
+        Type: DlnaProfileType.Audio,
+        AudioCodec: audioFormat
+      });
+    } else {
+      DirectPlayProfiles.push({
+        Container: audioFormat === 'webma' ? 'webma,webm' : audioFormat,
+        Type: DlnaProfileType.Audio
+      });
+    }
+
+    // aac also appears in the m4a and m4b container
+    if (audioFormat === 'aac' || audioFormat === 'alac') {
+      DirectPlayProfiles.push({
+        Container: 'm4a,m4b',
+        AudioCodec: audioFormat,
+        Type: DlnaProfileType.Audio
+      });
+    }
+  }
+
+  return DirectPlayProfiles;
+}
+
+/**
+ *
+ */
+function getTranscodingProfiles(): Array<TranscodingProfile> {
+  const TranscodingProfiles = [];
+
+  const hlsBreakOnNonKeyFrames = !!(
+    browserDetector.isApple() ||
+    browserDetector.isEdge() ||
+    !canPlayNativeHls()
+  );
+
+  if (canPlayNativeHls() || browserDetector.supportsMediaSource()) {
+    TranscodingProfiles.push({
+      Container:
+        !canPlayNativeHls() ||
+        browserDetector.isEdge() ||
+        browserDetector.isAndroid()
+          ? 'ts'
+          : 'aac',
+      Type: DlnaProfileType.Audio,
+      AudioCodec: 'aac',
+      Context: EncodingContext.Streaming,
+      Protocol: 'hls',
+      MaxAudioChannels: physicalAudioChannels.toString(),
+      MinSegments: browserDetector.isApple() ? 2 : 1,
+      BreakOnNonKeyFrames: hlsBreakOnNonKeyFrames
+    });
+  }
+
+  ['aac', 'mp3', 'opus', 'wav']
+    .filter(getSupportedAudioCodecs)
+    .forEach(function (audioFormat) {
+      TranscodingProfiles.push({
+        Container: audioFormat,
+        Type: DlnaProfileType.Audio,
+        AudioCodec: audioFormat,
+        Context: EncodingContext.Streaming,
+        Protocol: 'http',
+        MaxAudioChannels: physicalAudioChannels.toString()
+      });
+    });
+
+  const mp4VideoCodecs = getSupportedMP4VideoCodecs(videoTestElement);
+  const mp4AudioCodecs = getSupportedMP4AudioCodecs(videoTestElement);
+
+  if (hasMkvSupport(videoTestElement) && !browserDetector.isTizen()) {
+    TranscodingProfiles.push({
+      Container: 'mkv',
+      Type: DlnaProfileType.Video,
+      AudioCodec: mp4AudioCodecs.join(','),
+      VideoCodec: mp4VideoCodecs.join(','),
+      Context: EncodingContext.Streaming,
+      MaxAudioChannels: physicalAudioChannels.toString(),
+      CopyTimestamps: true
+    });
+  }
+
+  const hlsVideoAudioCodecs = getHlsAudioCodecs(videoTestElement);
+
+  if (
+    canPlayNativeHls() ||
+    (browserDetector.supportsMediaSource() && hlsVideoAudioCodecs.length)
+  ) {
+    TranscodingProfiles.push({
+      Container: 'ts',
+      Type: DlnaProfileType.Video,
+      AudioCodec: hlsVideoAudioCodecs.join(','),
+      VideoCodec: getHlsVideoCodecs(videoTestElement).join(','),
+      Context: EncodingContext.Streaming,
+      Protocol: 'hls',
+      MaxAudioChannels: physicalAudioChannels.toString(),
+      MinSegments: browserDetector.isApple() ? 2 : 1,
+      BreakOnNonKeyFrames: hlsBreakOnNonKeyFrames
+    });
+  }
+
+  if (hasVp8Support(videoTestElement)) {
+    TranscodingProfiles.push({
+      Container: 'webm',
+      Type: DlnaProfileType.Video,
+      AudioCodec: 'vorbis',
+      VideoCodec: 'vpx',
+      Context: EncodingContext.Streaming,
+      Protocol: 'http',
+      // If audio transcoding is needed, limit channels to number of physical audio channels
+      // Trying to transcode to 5 channels when there are only 2 speakers generally does not sound good
+      MaxAudioChannels: physicalAudioChannels.toString()
+    });
+  }
+
+  return TranscodingProfiles;
+}
+
+/**
+ *
+ */
+function getSubtitleProfiles(): Array<SubtitleProfile> {
+  const SubtitleProfiles = [];
+
+  SubtitleProfiles.push({
+    Format: 'vtt',
+    Method: SubtitleDeliveryMethod.External
+  });
+
+  return SubtitleProfiles;
+}
+
+/**
+ *
+ */
+function getResponseProfiles(): Array<ResponseProfile> {
+  const ResponseProfiles = [];
+
+  ResponseProfiles.push({
+    Type: DlnaProfileType.Video,
+    Container: 'm4v',
+    MimeType: 'video/mp4'
+  });
+
+  return ResponseProfiles;
+}
+
+/**
+ * Creates a device profile containing supported codecs for the active Cast device.
+ *
+ * @param {object} [options=Object]
+ * @returns {object} Device profile.
+ */
+function getDeviceProfile(): DeviceProfile {
+  // MaxStaticBitrate seems to be for offline sync only
+  return {
+    MaxStreamingBitrate: 120000000,
+    MaxStaticBitrate: 0,
+    MusicStreamingTranscodingBitrate: Math.min(120000000, 192000),
+    DirectPlayProfiles: getDirectPlayProfiles(),
+    TranscodingProfiles: getTranscodingProfiles(),
+    ContainerProfiles: [],
+    CodecProfiles: getCodecProfiles(videoTestElement),
+    SubtitleProfiles: getSubtitleProfiles(),
+    ResponseProfiles: getResponseProfiles()
+  };
+}
+
+declare module '@nuxt/types' {
+  interface Context {
+    $playbackProfile: DeviceProfile;
+  }
+
+  interface NuxtAppOptions {
+    $playbackProfile: DeviceProfile;
+  }
+}
+
+declare module 'vue/types/vue' {
+  interface Vue {
+    $playbackProfile: DeviceProfile;
+  }
+}
+
+export default (_context: Context, inject: PluginInjection): void => {
+  inject('playbackProfile', getDeviceProfile());
+};

--- a/utils/audioFormats.ts
+++ b/utils/audioFormats.ts
@@ -1,0 +1,52 @@
+import { browserDetector } from '~/plugins/browserDetection';
+
+/**
+ * @param format
+ */
+export function getSupportedAudioCodecs(format: string) {
+  let typeString;
+
+  if (format === 'flac') {
+    if (browserDetector.isTv()) {
+      return true;
+    }
+  } else if (format === 'wma') {
+    if (browserDetector.isTizen()) {
+      return true;
+    }
+  } else if (format === 'asf') {
+    if (browserDetector.isTv()) {
+      return true;
+    }
+  } else if (format === 'opus') {
+    if (!browserDetector.isWebOS()) {
+      typeString = 'audio/ogg; codecs="opus"';
+      return !!document
+        .createElement('audio')
+        .canPlayType(typeString)
+        .replace(/no/, '');
+    }
+
+    return false;
+  } else if (format === 'alac') {
+    if (browserDetector.isApple()) {
+      return true;
+    }
+  } else if (format === 'mp2') {
+    // TODO: Remnant from jf-web. Investigate where it is supported
+    return false;
+  }
+
+  if (format === 'webma') {
+    typeString = 'audio/webm';
+  } else if (format === 'mp2') {
+    typeString = 'audio/mpeg';
+  } else {
+    typeString = 'audio/' + format;
+  }
+
+  return !!document
+    .createElement('audio')
+    .canPlayType(typeString)
+    .replace(/no/, '');
+}

--- a/utils/audioFormats.ts
+++ b/utils/audioFormats.ts
@@ -1,9 +1,13 @@
 import { browserDetector } from '~/plugins/browserDetection';
 
 /**
- * @param format
+ *
+ *
+ *
+ * @param {string} format
+ * @returns
  */
-export function getSupportedAudioCodecs(format: string) {
+export function getSupportedAudioCodecs(format: string): boolean {
   let typeString;
 
   if (format === 'flac') {

--- a/utils/codecProfiles.ts
+++ b/utils/codecProfiles.ts
@@ -31,7 +31,10 @@ function createProfileCondition(
 }
 
 /**
- * @param videoTestElement
+ *
+ *
+ * @param {HTMLVideoElement} videoTestElement
+ * @returns {Array<CodecProfile>}
  */
 export function getCodecProfiles(
   videoTestElement: HTMLVideoElement

--- a/utils/codecProfiles.ts
+++ b/utils/codecProfiles.ts
@@ -1,0 +1,184 @@
+import { browserDetector } from '~/plugins/browserDetection';
+import {
+  CodecProfile,
+  CodecType,
+  ProfileConditionType,
+  ProfileCondition,
+  ProfileConditionValue
+} from '~/api';
+
+/**
+ * Creates a profile condition object for use in device playback profiles.
+ *
+ * @param Property
+ * @param Condition
+ * @param Value
+ * @param IsRequired
+ * @returns {ProfileCondition}
+ */
+function createProfileCondition(
+  Property: ProfileConditionValue,
+  Condition: ProfileConditionType,
+  Value: string,
+  IsRequired = false
+): ProfileCondition {
+  return {
+    Condition,
+    Property,
+    Value,
+    IsRequired
+  };
+}
+
+/**
+ * @param videoTestElement
+ */
+export function getCodecProfiles(
+  videoTestElement: HTMLVideoElement
+): Array<CodecProfile> {
+  const CodecProfiles = [];
+
+  const supportsSecondaryAudio = browserDetector.isTizen();
+
+  const aacProfileConditions = [] as ProfileCondition[];
+
+  if (
+    !videoTestElement
+      .canPlayType('video/mp4; codecs="avc1.640029, mp4a.40.5"')
+      .replace(/no/, '')
+  ) {
+    aacProfileConditions.push(
+      createProfileCondition(
+        ProfileConditionValue.AudioProfile,
+        ProfileConditionType.NotEquals,
+        'HE-AAC'
+      )
+    );
+  }
+
+  if (!supportsSecondaryAudio) {
+    aacProfileConditions.push(
+      createProfileCondition(
+        ProfileConditionValue.IsSecondaryAudio,
+        ProfileConditionType.Equals,
+        'false'
+      )
+    );
+  }
+
+  if (aacProfileConditions.length) {
+    CodecProfiles.push({
+      Type: CodecType.VideoAudio,
+      Codec: 'aac',
+      Conditions: aacProfileConditions
+    });
+  }
+
+  if (!supportsSecondaryAudio) {
+    CodecProfiles.push({
+      Type: CodecType.VideoAudio,
+      Conditions: [
+        createProfileCondition(
+          ProfileConditionValue.IsSecondaryAudio,
+          ProfileConditionType.Equals,
+          'false'
+        )
+      ]
+    });
+  }
+
+  let maxH264Level = 42;
+  let h264Profiles = 'high|main|baseline|constrained baseline';
+
+  if (
+    browserDetector.isTv() ||
+    videoTestElement
+      .canPlayType('video/mp4; codecs="avc1.640833"')
+      .replace(/no/, '')
+  ) {
+    maxH264Level = 51;
+  }
+
+  // Support H264 Level 52 (Tizen 5.0) - app only
+  if (browserDetector.isTizen5()) {
+    maxH264Level = 52;
+  }
+
+  if (
+    browserDetector.isTizen() ||
+    videoTestElement
+      .canPlayType('video/mp4; codecs="avc1.6e0033"')
+      .replace(/no/, '')
+  ) {
+    // These tests are passing in safari, but playback is failing
+    if (
+      !browserDetector.isApple() ||
+      !browserDetector.isWebOS() ||
+      !browserDetector.isEdge()
+    ) {
+      h264Profiles += '|high 10';
+    }
+  }
+
+  const h264CodecProfileConditions = [
+    createProfileCondition(
+      ProfileConditionValue.IsAnamorphic,
+      ProfileConditionType.NotEquals,
+      'true'
+    ),
+    createProfileCondition(
+      ProfileConditionValue.VideoProfile,
+      ProfileConditionType.EqualsAny,
+      h264Profiles
+    ),
+    createProfileCondition(
+      ProfileConditionValue.VideoLevel,
+      ProfileConditionType.LessThanEqual,
+      maxH264Level.toString()
+    )
+  ];
+
+  if (!browserDetector.isTv()) {
+    h264CodecProfileConditions.push(
+      createProfileCondition(
+        ProfileConditionValue.IsInterlaced,
+        ProfileConditionType.NotEquals,
+        'true'
+      )
+    );
+  }
+
+  // On iOS 12.x, for TS container max h264 level is 4.2
+  if (
+    browserDetector.isApple() &&
+    browserDetector.isMobile() &&
+    (browserDetector.safariVersion() as number) < 13
+  ) {
+    const codecProfile = {
+      Type: CodecType.Video,
+      Codec: 'h264',
+      Container: 'ts',
+      Conditions: h264CodecProfileConditions.filter((condition) => {
+        return condition.Property !== 'VideoLevel';
+      })
+    };
+
+    codecProfile.Conditions.push(
+      createProfileCondition(
+        ProfileConditionValue.VideoLevel,
+        ProfileConditionType.LessThanEqual,
+        '42'
+      )
+    );
+
+    CodecProfiles.push(codecProfile);
+  }
+
+  CodecProfiles.push({
+    Type: CodecType.Video,
+    Codec: 'h264',
+    Conditions: h264CodecProfileConditions
+  });
+
+  return CodecProfiles;
+}

--- a/utils/hlsFormats.ts
+++ b/utils/hlsFormats.ts
@@ -8,7 +8,10 @@ import { getSupportedAudioCodecs } from './audioFormats';
 import { browserDetector } from '~/plugins/browserDetection';
 
 /**
- * @param videoTestElement
+ *
+ *
+ * @param {HTMLVideoElement} videoTestElement
+ * @returns
  */
 function supportsAc3InHls(videoTestElement: HTMLVideoElement) {
   if (browserDetector.isTv()) {
@@ -32,7 +35,11 @@ function supportsAc3InHls(videoTestElement: HTMLVideoElement) {
 }
 
 /**
- * @param videoTestElement
+ *
+ *
+ * @export
+ * @param {HTMLVideoElement} videoTestElement
+ * @returns {string[]}
  */
 export function getHlsVideoCodecs(
   videoTestElement: HTMLVideoElement
@@ -52,7 +59,11 @@ export function getHlsVideoCodecs(
 }
 
 /**
- * @param videoTestElement
+ *
+ *
+ * @export
+ * @param {HTMLVideoElement} videoTestElement
+ * @returns {string[]}
  */
 export function getHlsAudioCodecs(
   videoTestElement: HTMLVideoElement

--- a/utils/hlsFormats.ts
+++ b/utils/hlsFormats.ts
@@ -1,0 +1,83 @@
+import { hasH264Support, hasH265Support } from './mp4VideoFormats';
+import {
+  hasEac3Support,
+  hasMp3Support,
+  hasAacSupport
+} from './mp4AudioFormats';
+import { getSupportedAudioCodecs } from './audioFormats';
+import { browserDetector } from '~/plugins/browserDetection';
+
+/**
+ * @param videoTestElement
+ */
+function supportsAc3InHls(videoTestElement: HTMLVideoElement) {
+  if (browserDetector.isTv()) {
+    return true;
+  }
+
+  if (videoTestElement.canPlayType) {
+    return (
+      videoTestElement
+        .canPlayType('application/x-mpegurl; codecs="avc1.42E01E, ac-3"')
+        .replace(/no/, '') ||
+      videoTestElement
+        .canPlayType(
+          'application/vnd.apple.mpegURL; codecs="avc1.42E01E, ac-3"'
+        )
+        .replace(/no/, '')
+    );
+  }
+
+  return false;
+}
+
+/**
+ * @param videoTestElement
+ */
+export function getHlsVideoCodecs(
+  videoTestElement: HTMLVideoElement
+): string[] {
+  const hlsVideoCodecs = [];
+
+  if (hasH264Support(videoTestElement)) {
+    hlsVideoCodecs.push('h264');
+  }
+
+  if (hasH265Support(videoTestElement) || browserDetector.isTv()) {
+    hlsVideoCodecs.push('h265');
+    hlsVideoCodecs.push('hevc');
+  }
+
+  return hlsVideoCodecs;
+}
+
+/**
+ * @param videoTestElement
+ */
+export function getHlsAudioCodecs(
+  videoTestElement: HTMLVideoElement
+): string[] {
+  const hlsVideoAudioCodecs = [];
+
+  if (supportsAc3InHls(videoTestElement)) {
+    hlsVideoAudioCodecs.push('ac3');
+
+    if (hasEac3Support(videoTestElement)) {
+      hlsVideoAudioCodecs.push('eac3');
+    }
+  }
+
+  if (hasMp3Support(videoTestElement)) {
+    hlsVideoAudioCodecs.push('mp3');
+  }
+
+  if (hasAacSupport(videoTestElement)) {
+    hlsVideoAudioCodecs.push('aac');
+  }
+
+  if (getSupportedAudioCodecs('opus')) {
+    hlsVideoAudioCodecs.push('opus');
+  }
+
+  return hlsVideoAudioCodecs;
+}

--- a/utils/mp4AudioFormats.ts
+++ b/utils/mp4AudioFormats.ts
@@ -1,0 +1,139 @@
+import { hasVp8Support } from './mp4VideoFormats';
+import { getSupportedAudioCodecs } from './audioFormats';
+import { browserDetector } from '~/plugins/browserDetection';
+
+/**
+ * @param videoTestElement
+ */
+function hasAc3Support(videoTestElement: HTMLVideoElement) {
+  if (browserDetector.isTv()) {
+    return true;
+  }
+
+  return videoTestElement
+    .canPlayType('audio/mp4; codecs="ac-3"')
+    .replace(/no/, '');
+}
+
+/**
+ * @param videoTestElement
+ */
+export function hasEac3Support(videoTestElement: HTMLVideoElement) {
+  if (browserDetector.isTv()) {
+    return true;
+  }
+
+  return videoTestElement
+    .canPlayType('audio/mp4; codecs="ec-3"')
+    .replace(/no/, '');
+}
+
+/**
+ * @param videoTestElement
+ */
+export function hasMp3Support(videoTestElement: HTMLVideoElement) {
+  return (
+    videoTestElement
+      .canPlayType('video/mp4; codecs="avc1.640029, mp4a.69"')
+      .replace(/no/, '') ||
+    videoTestElement
+      .canPlayType('video/mp4; codecs="avc1.640029, mp4a.6B"')
+      .replace(/no/, '') ||
+    videoTestElement
+      .canPlayType('video/mp4; codecs="avc1.640029, mp3"')
+      .replace(/no/, '')
+  );
+}
+
+/**
+ * @param videoTestElement
+ */
+export function hasAacSupport(videoTestElement: HTMLVideoElement) {
+  return videoTestElement
+    .canPlayType('video/mp4; codecs="avc1.640029, mp4a.40.2"')
+    .replace(/no/, '');
+}
+
+/**
+ * @param videoTestElement
+ */
+function hasMp2AudioSupport() {
+  return browserDetector.isTv();
+}
+
+/**
+ * @param videoTestElement
+ */
+function hasDtsSupport(videoTestElement: HTMLVideoElement) {
+  // DTS audio not supported in 2018 models (Tizen 4.0)
+  if (
+    browserDetector.isTizen4() ||
+    browserDetector.isTizen5() ||
+    browserDetector.isTizen55()
+  ) {
+    return false;
+  }
+
+  return (
+    browserDetector.isTv() ||
+    videoTestElement
+      .canPlayType('video/mp4; codecs="dts-"')
+      .replace(/no/, '') ||
+    videoTestElement.canPlayType('video/mp4; codecs="dts+"').replace(/no/, '')
+  );
+}
+
+/**
+ * @param videoTestElement
+ */
+export function getSupportedMP4AudioCodecs(videoTestElement: HTMLVideoElement) {
+  const codecs = [];
+
+  if (hasAc3Support(videoTestElement)) {
+    codecs.push('ac3');
+  }
+
+  if (hasEac3Support(videoTestElement)) {
+    codecs.push('eac3');
+  }
+
+  if (hasMp3Support(videoTestElement)) {
+    codecs.push('mp3');
+  }
+
+  if (hasAacSupport(videoTestElement)) {
+    codecs.push('aac');
+  }
+
+  if (hasMp2AudioSupport()) {
+    codecs.push('mp2');
+  }
+
+  if (hasDtsSupport(videoTestElement)) {
+    codecs.push('dca');
+    codecs.push('dts');
+  }
+
+  if (browserDetector.isTv()) {
+    codecs.push('pcm_s16le');
+    codecs.push('pcm_s24le');
+  }
+
+  if (browserDetector.isTizen()) {
+    codecs.push('aac_latm');
+  }
+
+  if (getSupportedAudioCodecs('opus')) {
+    codecs.push('opus');
+  }
+
+  if (getSupportedAudioCodecs('flac')) {
+    codecs.push('flac');
+  }
+
+  if (hasVp8Support(videoTestElement)) {
+    codecs.push('vorbis');
+  }
+
+  return codecs;
+}

--- a/utils/mp4AudioFormats.ts
+++ b/utils/mp4AudioFormats.ts
@@ -3,36 +3,45 @@ import { getSupportedAudioCodecs } from './audioFormats';
 import { browserDetector } from '~/plugins/browserDetection';
 
 /**
- * @param videoTestElement
+ *
+ *
+ * @param {HTMLVideoElement} videoTestElement
+ * @returns
  */
-function hasAc3Support(videoTestElement: HTMLVideoElement) {
+function hasAc3Support(videoTestElement: HTMLVideoElement): boolean {
   if (browserDetector.isTv()) {
     return true;
   }
 
-  return videoTestElement
+  return !!videoTestElement
     .canPlayType('audio/mp4; codecs="ac-3"')
     .replace(/no/, '');
 }
 
 /**
- * @param videoTestElement
+ *
+ *
+ * @param {HTMLVideoElement} videoTestElement
+ * @returns
  */
-export function hasEac3Support(videoTestElement: HTMLVideoElement) {
+export function hasEac3Support(videoTestElement: HTMLVideoElement): boolean {
   if (browserDetector.isTv()) {
     return true;
   }
 
-  return videoTestElement
+  return !!videoTestElement
     .canPlayType('audio/mp4; codecs="ec-3"')
     .replace(/no/, '');
 }
 
 /**
- * @param videoTestElement
+ *
+ *
+ * @param {HTMLVideoElement} videoTestElement
+ * @returns
  */
-export function hasMp3Support(videoTestElement: HTMLVideoElement) {
-  return (
+export function hasMp3Support(videoTestElement: HTMLVideoElement): boolean {
+  return !!(
     videoTestElement
       .canPlayType('video/mp4; codecs="avc1.640029, mp4a.69"')
       .replace(/no/, '') ||
@@ -46,23 +55,31 @@ export function hasMp3Support(videoTestElement: HTMLVideoElement) {
 }
 
 /**
- * @param videoTestElement
+ *
+ *
+ * @param {HTMLVideoElement} videoTestElement
+ * @returns
  */
-export function hasAacSupport(videoTestElement: HTMLVideoElement) {
-  return videoTestElement
+export function hasAacSupport(videoTestElement: HTMLVideoElement): boolean {
+  return !!videoTestElement
     .canPlayType('video/mp4; codecs="avc1.640029, mp4a.40.2"')
     .replace(/no/, '');
 }
 
 /**
- * @param videoTestElement
+ *
+ *
+ * @returns
  */
 function hasMp2AudioSupport() {
   return browserDetector.isTv();
 }
 
 /**
- * @param videoTestElement
+ *
+ *
+ * @param {HTMLVideoElement} videoTestElement
+ * @returns
  */
 function hasDtsSupport(videoTestElement: HTMLVideoElement) {
   // DTS audio not supported in 2018 models (Tizen 4.0)
@@ -84,9 +101,14 @@ function hasDtsSupport(videoTestElement: HTMLVideoElement) {
 }
 
 /**
- * @param videoTestElement
+ *
+ *
+ * @param {HTMLVideoElement} videoTestElement
+ * @returns
  */
-export function getSupportedMP4AudioCodecs(videoTestElement: HTMLVideoElement) {
+export function getSupportedMP4AudioCodecs(
+  videoTestElement: HTMLVideoElement
+): string[] {
   const codecs = [];
 
   if (hasAc3Support(videoTestElement)) {

--- a/utils/mp4VideoFormats.ts
+++ b/utils/mp4VideoFormats.ts
@@ -1,10 +1,13 @@
 import { browserDetector } from '~/plugins/browserDetection';
 
 /**
- * @param videoTestElement
+ *
+ *
+ * @param {HTMLVideoElement} videoTestElement
+ * @returns
  */
-export function hasH264Support(videoTestElement: HTMLVideoElement) {
-  return (
+export function hasH264Support(videoTestElement: HTMLVideoElement): boolean {
+  return !!(
     videoTestElement.canPlayType &&
     videoTestElement
       .canPlayType('video/mp4; codecs="avc1.42E01E, mp4a.40.2"')
@@ -13,14 +16,17 @@ export function hasH264Support(videoTestElement: HTMLVideoElement) {
 }
 
 /**
- * @param videoTestElement
+ *
+ *
+ * @param {HTMLVideoElement} videoTestElement
+ * @returns
  */
-export function hasH265Support(videoTestElement: HTMLVideoElement) {
+export function hasH265Support(videoTestElement: HTMLVideoElement): boolean {
   if (browserDetector.isTv()) {
     return true;
   }
 
-  return (
+  return !!(
     videoTestElement.canPlayType &&
     (videoTestElement
       .canPlayType('video/mp4; codecs="hvc1.1.L120"')
@@ -38,16 +44,19 @@ export function hasH265Support(videoTestElement: HTMLVideoElement) {
 }
 
 /**
- * @param videoTestElement
+ *
+ *
+ * @param {HTMLVideoElement} videoTestElement
+ * @returns
  */
-export function hasAv1Support(videoTestElement: HTMLVideoElement) {
+export function hasAv1Support(videoTestElement: HTMLVideoElement): boolean {
   if (browserDetector.isTizen && browserDetector.isTizen55()) {
     return true;
   } else if (browserDetector.isWebOS5() && window.outerHeight >= 2160) {
     return true;
   }
 
-  return (
+  return !!(
     videoTestElement.canPlayType &&
     videoTestElement
       .canPlayType('video/webm; codecs="av01.0.15M.10"')
@@ -56,30 +65,39 @@ export function hasAv1Support(videoTestElement: HTMLVideoElement) {
 }
 
 /**
- * @param videoTestElement
+ *
+ *
+ * @param {HTMLVideoElement} videoTestElement
+ * @returns
  */
-function hasVc1Support(videoTestElement: HTMLVideoElement) {
-  return (
+function hasVc1Support(videoTestElement: HTMLVideoElement): boolean {
+  return !!(
     browserDetector.isTv() ||
     videoTestElement.canPlayType('video/mp4; codecs="vc-1"').replace(/no/, '')
   );
 }
 
 /**
- * @param videoTestElement
+ *
+ *
+ * @param {HTMLVideoElement} videoTestElement
+ * @returns
  */
-export function hasVp8Support(videoTestElement: HTMLVideoElement) {
-  return (
+export function hasVp8Support(videoTestElement: HTMLVideoElement): boolean {
+  return !!(
     videoTestElement.canPlayType &&
     videoTestElement.canPlayType('video/webm; codecs="vp8"').replace(/no/, '')
   );
 }
 
 /**
- * @param videoTestElement
+ *
+ *
+ * @param {HTMLVideoElement} videoTestElement
+ * @returns
  */
-export function hasVp9Support(videoTestElement: HTMLVideoElement) {
-  return (
+export function hasVp9Support(videoTestElement: HTMLVideoElement): boolean {
+  return !!(
     videoTestElement.canPlayType &&
     videoTestElement.canPlayType('video/webm; codecs="vp9"').replace(/no/, '')
   );

--- a/utils/mp4VideoFormats.ts
+++ b/utils/mp4VideoFormats.ts
@@ -1,0 +1,129 @@
+import { browserDetector } from '~/plugins/browserDetection';
+
+/**
+ * @param videoTestElement
+ */
+export function hasH264Support(videoTestElement: HTMLVideoElement) {
+  return (
+    videoTestElement.canPlayType &&
+    videoTestElement
+      .canPlayType('video/mp4; codecs="avc1.42E01E, mp4a.40.2"')
+      .replace(/no/, '')
+  );
+}
+
+/**
+ * @param videoTestElement
+ */
+export function hasH265Support(videoTestElement: HTMLVideoElement) {
+  if (browserDetector.isTv()) {
+    return true;
+  }
+
+  return (
+    videoTestElement.canPlayType &&
+    (videoTestElement
+      .canPlayType('video/mp4; codecs="hvc1.1.L120"')
+      .replace(/no/, '') ||
+      videoTestElement
+        .canPlayType('video/mp4; codecs="hev1.1.L120"')
+        .replace(/no/, '') ||
+      videoTestElement
+        .canPlayType('video/mp4; codecs="hvc1.1.0.L120"')
+        .replace(/no/, '') ||
+      videoTestElement
+        .canPlayType('video/mp4; codecs="hev1.1.0.L120"')
+        .replace(/no/, ''))
+  );
+}
+
+/**
+ * @param videoTestElement
+ */
+export function hasAv1Support(videoTestElement: HTMLVideoElement) {
+  if (browserDetector.isTizen && browserDetector.isTizen55()) {
+    return true;
+  } else if (browserDetector.isWebOS5() && window.outerHeight >= 2160) {
+    return true;
+  }
+
+  return (
+    videoTestElement.canPlayType &&
+    videoTestElement
+      .canPlayType('video/webm; codecs="av01.0.15M.10"')
+      .replace(/no/, '')
+  );
+}
+
+/**
+ * @param videoTestElement
+ */
+function hasVc1Support(videoTestElement: HTMLVideoElement) {
+  return (
+    browserDetector.isTv() ||
+    videoTestElement.canPlayType('video/mp4; codecs="vc-1"').replace(/no/, '')
+  );
+}
+
+/**
+ * @param videoTestElement
+ */
+export function hasVp8Support(videoTestElement: HTMLVideoElement) {
+  return (
+    videoTestElement.canPlayType &&
+    videoTestElement.canPlayType('video/webm; codecs="vp8"').replace(/no/, '')
+  );
+}
+
+/**
+ * @param videoTestElement
+ */
+export function hasVp9Support(videoTestElement: HTMLVideoElement) {
+  return (
+    videoTestElement.canPlayType &&
+    videoTestElement.canPlayType('video/webm; codecs="vp9"').replace(/no/, '')
+  );
+}
+
+/**
+ * Queries the platform for the codecs suppers in an MP4 container.
+ *
+ * @param videoTestElement
+ * @returns {string[]} Array of codec identifiers.
+ */
+export function getSupportedMP4VideoCodecs(
+  videoTestElement: HTMLVideoElement
+): string[] {
+  const codecs = [];
+
+  if (hasH264Support(videoTestElement)) {
+    codecs.push('h264');
+  }
+
+  if (hasH265Support(videoTestElement)) {
+    codecs.push('h265');
+    codecs.push('hevc');
+  }
+
+  if (browserDetector.isTv()) {
+    codecs.push('mpeg2video');
+  }
+
+  if (hasVc1Support(videoTestElement)) {
+    codecs.push('vc1');
+  }
+
+  if (hasAv1Support(videoTestElement)) {
+    codecs.push('av1');
+  }
+
+  if (hasVp8Support(videoTestElement)) {
+    codecs.push('vp8');
+  }
+
+  if (hasVp9Support(videoTestElement)) {
+    codecs.push('vp9');
+  }
+
+  return codecs;
+}

--- a/utils/transcodingFormats.ts
+++ b/utils/transcodingFormats.ts
@@ -1,0 +1,42 @@
+import { browserDetector } from '~/plugins/browserDetection';
+
+/**
+ *
+ */
+export function canPlayNativeHls(): boolean {
+  if (browserDetector.isTizen()) {
+    return true;
+  }
+
+  const media = document.createElement('video');
+  if (
+    media.canPlayType('application/x-mpegURL').replace(/no/, '') ||
+    media.canPlayType('application/vnd.apple.mpegURL').replace(/no/, '')
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * @param videoTestElement
+ */
+export function hasMkvSupport(videoTestElement: HTMLVideoElement) {
+  if (browserDetector.isTv()) {
+    return true;
+  }
+
+  if (
+    videoTestElement.canPlayType('video/x-matroska').replace(/no/, '') ||
+    videoTestElement.canPlayType('video/mkv').replace(/no/, '')
+  ) {
+    return true;
+  }
+
+  if (browserDetector.isEdge()) {
+    return true;
+  }
+
+  return false;
+}

--- a/utils/transcodingFormats.ts
+++ b/utils/transcodingFormats.ts
@@ -2,16 +2,20 @@ import { browserDetector } from '~/plugins/browserDetection';
 
 /**
  *
+ *
+ * @param {HTMLVideoElement} videoTestElement
+ * @returns {boolean}
  */
-export function canPlayNativeHls(): boolean {
+export function canPlayNativeHls(videoTestElement: HTMLVideoElement): boolean {
   if (browserDetector.isTizen()) {
     return true;
   }
 
-  const media = document.createElement('video');
   if (
-    media.canPlayType('application/x-mpegURL').replace(/no/, '') ||
-    media.canPlayType('application/vnd.apple.mpegURL').replace(/no/, '')
+    videoTestElement.canPlayType('application/x-mpegURL').replace(/no/, '') ||
+    videoTestElement
+      .canPlayType('application/vnd.apple.mpegURL')
+      .replace(/no/, '')
   ) {
     return true;
   }
@@ -20,9 +24,12 @@ export function canPlayNativeHls(): boolean {
 }
 
 /**
- * @param videoTestElement
+ *
+ *
+ * @param {HTMLVideoElement} videoTestElement
+ * @returns
  */
-export function hasMkvSupport(videoTestElement: HTMLVideoElement) {
+export function hasMkvSupport(videoTestElement: HTMLVideoElement): boolean {
   if (browserDetector.isTv()) {
     return true;
   }

--- a/utils/vpxVideoFormats.ts
+++ b/utils/vpxVideoFormats.ts
@@ -1,7 +1,10 @@
 import { hasVp8Support, hasVp9Support, hasAv1Support } from './mp4VideoFormats';
 
 /**
- * @param videoTestElement
+ *
+ *
+ * @param {HTMLVideoElement} videoTestElement
+ * @returns {string[]}
  */
 export function getSupportedVPXVideoCodecs(
   videoTestElement: HTMLVideoElement

--- a/utils/vpxVideoFormats.ts
+++ b/utils/vpxVideoFormats.ts
@@ -1,0 +1,23 @@
+import { hasVp8Support, hasVp9Support, hasAv1Support } from './mp4VideoFormats';
+
+/**
+ * @param videoTestElement
+ */
+export function getSupportedVPXVideoCodecs(
+  videoTestElement: HTMLVideoElement
+): string[] {
+  const codecs = [];
+  if (hasVp8Support(videoTestElement)) {
+    codecs.push('vp8');
+  }
+
+  if (hasVp9Support(videoTestElement)) {
+    codecs.push('vp9');
+  }
+
+  if (hasAv1Support(videoTestElement)) {
+    codecs.push('av1');
+  }
+
+  return codecs;
+}

--- a/utils/webmAudioFormats.ts
+++ b/utils/webmAudioFormats.ts
@@ -1,0 +1,22 @@
+import { browserDetector } from '~/plugins/browserDetection';
+
+/**
+ * @param videoTestElement
+ */
+export function getSupportedWebMAudioCodecs() {
+  const codecs = [];
+
+  codecs.push('vorbis');
+
+  if (
+    !browserDetector.isWebOS() &&
+    document
+      .createElement('audio')
+      .canPlayType('audio/ogg; codecs="opus"')
+      .replace(/no/, '')
+  ) {
+    codecs.push('opus');
+  }
+
+  return codecs;
+}

--- a/utils/webmAudioFormats.ts
+++ b/utils/webmAudioFormats.ts
@@ -1,19 +1,21 @@
 import { browserDetector } from '~/plugins/browserDetection';
 
 /**
- * @param videoTestElement
+ *
+ *
+ * @param {HTMLVideoElement} videoTestElement
+ * @returns
  */
-export function getSupportedWebMAudioCodecs() {
+export function getSupportedWebMAudioCodecs(
+  videoTestElement: HTMLVideoElement
+): string[] {
   const codecs = [];
 
   codecs.push('vorbis');
 
   if (
     !browserDetector.isWebOS() &&
-    document
-      .createElement('audio')
-      .canPlayType('audio/ogg; codecs="opus"')
-      .replace(/no/, '')
+    videoTestElement.canPlayType('audio/ogg; codecs="opus"').replace(/no/, '')
   ) {
     codecs.push('opus');
   }


### PR DESCRIPTION
Adds full playback profile generation. Should be identical to jf-web in the result, with some exceptions for dropped platforms.

Part of #60 