### PR TITLE
fix(item details): fix Incorrect font color when in light mode

### DIFF
--- a/pages/item/_itemId/index.vue
+++ b/pages/item/_itemId/index.vue
@@ -8,7 +8,7 @@
     >
       <div class="d-flex align-end gradient-container">
         <div class="d-flex flex-wrap item-details-container">
-          <div class="itemDetailsLeft">
+          <div class="white--text">
             <v-img
               v-if="
                 item.ImageTags && item.ImageTags.Logo && getAspectRatio() > 1


### PR DESCRIPTION
Makes all content on the item backdrop have a white font color to improve contrast when using light
mode