### PR TITLE
Fix a bunch of things

### DIFF
--- a/components/Card.vue
+++ b/components/Card.vue
@@ -4,7 +4,11 @@
       <div :class="cardType">
         <button
           class="card-content card-content-button d-flex justify-center align-center"
-          :style="{ backgroundImage: `url('${imageLink(item.Id)}')` }"
+          :style="[
+            item.ImageTags.Primary
+              ? { backgroundImage: `url('${imageLink(item.Id)}')` }
+              : {}
+          ]"
         >
           <v-icon
             v-if="!item.ImageTags.Primary"

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -12,6 +12,11 @@ const config: NuxtConfig = {
    */
   target: 'server',
   /*
+   ** Module loading mode
+   ** See https://nuxtjs.org/api/configuration-modern
+   */
+  modern: 'client',
+  /*
    ** Headers of the page
    ** See https://nuxtjs.org/api/configuration-head
    */

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -197,7 +197,21 @@ const config: NuxtConfig = {
    ** Build configuration
    ** See https://nuxtjs.org/api/configuration-build/
    */
-  build: {},
+  build: {
+    babel: {
+      // envName: server, client, modern
+      presets() {
+        return [
+          [
+            '@nuxt/babel-preset-app',
+            {
+              corejs: { version: 3 }
+            }
+          ]
+        ];
+      }
+    }
+  },
 
   /**
    * Host set to 0.0.0.0 in order to access the dev server on the LAN

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "^10.1.0",
     "babel-jest": "^26.1.0",
+    "core-js": "^3.6.5",
     "cz-conventional-changelog": "3.3.0",
     "eslint": "^7.9.0",
     "eslint-config-prettier": "^6.11.0",

--- a/plugins/browserDetection.ts
+++ b/plugins/browserDetection.ts
@@ -1,5 +1,4 @@
-import { Context } from '@nuxt/types';
-import { PluginInjection } from '~/types/utils';
+import { Plugin } from '@nuxt/types';
 
 declare module '@nuxt/types' {
   interface Context {
@@ -276,6 +275,8 @@ class BrowserDetector {
 
 export const browserDetector = new BrowserDetector();
 
-export default (_context: Context, inject: PluginInjection): void => {
+const browserDetectorPlugin: Plugin = (_context, inject) => {
   inject('browser', browserDetector);
 };
+
+export default browserDetectorPlugin;

--- a/plugins/deviceProfile.ts
+++ b/plugins/deviceProfile.ts
@@ -1,6 +1,5 @@
-import { Context } from '@nuxt/types';
+import { Plugin } from '@nuxt/types';
 import { v4 as uuidv4 } from 'uuid';
-import { PluginInjection } from '~/types/utils';
 
 interface DeviceProfile {
   set: () => void;
@@ -86,7 +85,7 @@ function getClientName(): string {
   return 'Jellyfin Web (Vue)';
 }
 
-export default (context: Context, inject: PluginInjection): void => {
+const deviceProfilePlugin: Plugin = (context, inject) => {
   const deviceProfile = {
     set: () => {
       context.store.commit('deviceProfile/set', {
@@ -103,3 +102,5 @@ export default (context: Context, inject: PluginInjection): void => {
 
   inject('deviceProfile', deviceProfile);
 };
+
+export default deviceProfilePlugin;

--- a/plugins/displayPreferenceApi.ts
+++ b/plugins/displayPreferenceApi.ts
@@ -1,8 +1,7 @@
-import { Context } from '@nuxt/types';
+import { Plugin } from '@nuxt/types';
 import { AxiosInstance } from 'axios';
 import { DisplayPreferencesApi } from '~/api/api';
 import { Configuration } from '~/api/configuration';
-import { PluginInjection } from '~/types/utils';
 
 declare module '@nuxt/types' {
   interface Context {
@@ -20,7 +19,7 @@ declare module 'vue/types/vue' {
   }
 }
 
-export default (context: Context, inject: PluginInjection): void => {
+const displayPreferencesApiPlugin: Plugin = (context, inject) => {
   const config = new Configuration();
 
   const displayPreferencesApi = new DisplayPreferencesApi(
@@ -30,3 +29,5 @@ export default (context: Context, inject: PluginInjection): void => {
   );
   inject('displayPreferencesApi', displayPreferencesApi);
 };
+
+export default displayPreferencesApiPlugin;

--- a/plugins/imageApi.ts
+++ b/plugins/imageApi.ts
@@ -1,8 +1,7 @@
-import { Context } from '@nuxt/types';
+import { Plugin } from '@nuxt/types';
 import { AxiosInstance } from 'axios';
 import { ImageApi } from '~/api/api';
 import { Configuration } from '~/api/configuration';
-import { PluginInjection } from '~/types/utils';
 
 declare module '@nuxt/types' {
   interface Context {
@@ -20,9 +19,11 @@ declare module 'vue/types/vue' {
   }
 }
 
-export default (context: Context, inject: PluginInjection): void => {
+const imageApiPlugin: Plugin = (context, inject) => {
   const config = new Configuration();
 
   const imageApi = new ImageApi(config, '', context.$axios as AxiosInstance);
   inject('imageApi', imageApi);
 };
+
+export default imageApiPlugin;

--- a/plugins/itemsApi.ts
+++ b/plugins/itemsApi.ts
@@ -1,8 +1,7 @@
-import { Context } from '@nuxt/types';
+import { Plugin } from '@nuxt/types';
 import { AxiosInstance } from 'axios';
 import { ItemsApi } from '~/api/api';
 import { Configuration } from '~/api/configuration';
-import { PluginInjection } from '~/types/utils';
 
 declare module '@nuxt/types' {
   interface Context {
@@ -20,9 +19,11 @@ declare module 'vue/types/vue' {
   }
 }
 
-export default (context: Context, inject: PluginInjection): void => {
+const itemsApiPlugin: Plugin = (context, inject) => {
   const config = new Configuration();
 
   const itemsApi = new ItemsApi(config, '', context.$axios as AxiosInstance);
   inject('itemsApi', itemsApi);
 };
+
+export default itemsApiPlugin;

--- a/plugins/playbackProfile.ts
+++ b/plugins/playbackProfile.ts
@@ -1,4 +1,4 @@
-import { Context } from '@nuxt/types/app';
+import { Plugin } from '@nuxt/types/app';
 import { browserDetector } from './browserDetection';
 import {
   getSupportedMP4VideoCodecs,
@@ -21,7 +21,6 @@ import {
   SubtitleDeliveryMethod,
   ResponseProfile
 } from '~/api';
-import { PluginInjection } from '~/types/utils';
 
 const physicalAudioChannels = browserDetector.isTv() ? 6 : 2;
 
@@ -269,6 +268,8 @@ declare module 'vue/types/vue' {
   }
 }
 
-export default (_context: Context, inject: PluginInjection): void => {
+const playbackProfilePlugin: Plugin = (_context, inject) => {
   inject('playbackProfile', getDeviceProfile());
 };
+
+export default playbackProfilePlugin;

--- a/plugins/snackbar.ts
+++ b/plugins/snackbar.ts
@@ -1,5 +1,4 @@
-import { Context } from '@nuxt/types';
-import { PluginInjection } from '~/types/utils';
+import { Plugin } from '@nuxt/types';
 
 declare module '@nuxt/types' {
   interface Context {
@@ -23,8 +22,10 @@ declare module 'vuex/types/index' {
   }
 }
 
-export default (context: Context, inject: PluginInjection): void => {
+const snackbarPlugin: Plugin = (context, inject) => {
   inject('snackbar', (message: string, color: string | undefined | null) => {
     context.store.commit('snackbar/display', { message, color });
   });
 };
+
+export default snackbarPlugin;

--- a/plugins/tvShowsApi.ts
+++ b/plugins/tvShowsApi.ts
@@ -1,8 +1,7 @@
-import { Context } from '@nuxt/types';
+import { Plugin } from '@nuxt/types';
 import { AxiosInstance } from 'axios';
 import { TvShowsApi } from '~/api/api';
 import { Configuration } from '~/api/configuration';
-import { PluginInjection } from '~/types/utils';
 
 declare module '@nuxt/types' {
   interface Context {
@@ -20,7 +19,7 @@ declare module 'vue/types/vue' {
   }
 }
 
-export default (context: Context, inject: PluginInjection): void => {
+const tvShowsApiPlugin: Plugin = (context, inject) => {
   const config = new Configuration();
 
   const tvShowsApi = new TvShowsApi(
@@ -30,3 +29,5 @@ export default (context: Context, inject: PluginInjection): void => {
   );
   inject('tvShowsApi', tvShowsApi);
 };
+
+export default tvShowsApiPlugin;

--- a/plugins/user.ts
+++ b/plugins/user.ts
@@ -1,5 +1,4 @@
-import { Context } from '@nuxt/types';
-import { PluginInjection } from '~/types/utils';
+import { Plugin } from '@nuxt/types';
 
 interface UserStore {
   set: (id: string, serverUrl: string, accessToken: string) => void;
@@ -28,7 +27,7 @@ declare module 'vuex/types/index' {
   }
 }
 
-export default (context: Context, inject: PluginInjection): void => {
+const userPlugin: Plugin = (context, inject) => {
   const user = {
     set: async (id: string, serverUrl: string, accessToken: string) => {
       const response = await context.$displayPreferencesApi.getDisplayPreferences(
@@ -49,3 +48,5 @@ export default (context: Context, inject: PluginInjection): void => {
 
   inject('user', user);
 };
+
+export default userPlugin;

--- a/plugins/userApi.ts
+++ b/plugins/userApi.ts
@@ -1,8 +1,7 @@
-import { Context } from '@nuxt/types';
+import { Plugin } from '@nuxt/types';
 import { AxiosInstance } from 'axios';
 import { UserApi } from '~/api/api';
 import { Configuration } from '~/api/configuration';
-import { PluginInjection } from '~/types/utils';
 
 declare module '@nuxt/types' {
   interface Context {
@@ -20,9 +19,11 @@ declare module 'vue/types/vue' {
   }
 }
 
-export default (context: Context, inject: PluginInjection): void => {
+const userApiPlugin: Plugin = (context, inject) => {
   const config = new Configuration();
 
   const userApi = new UserApi(config, '', context.$axios as AxiosInstance);
   inject('userApi', userApi);
 };
+
+export default userApiPlugin;

--- a/plugins/userInit.ts
+++ b/plugins/userInit.ts
@@ -1,6 +1,6 @@
-import { Context } from '@nuxt/types';
+import { Plugin } from '@nuxt/types';
 
-export default async (context: Context): Promise<void> => {
+const userInitPlugin: Plugin = async (context) => {
   if (
     context.store.state.user.id &&
     context.store.state.user.serverUrl &&
@@ -17,3 +17,5 @@ export default async (context: Context): Promise<void> => {
     context.$auth.setUser(response.data);
   }
 };
+
+export default userInitPlugin;

--- a/plugins/userLibraryApi.ts
+++ b/plugins/userLibraryApi.ts
@@ -1,8 +1,7 @@
-import { Context } from '@nuxt/types';
+import { Plugin } from '@nuxt/types';
 import { AxiosInstance } from 'axios';
 import { UserLibraryApi } from '~/api/api';
 import { Configuration } from '~/api/configuration';
-import { PluginInjection } from '~/types/utils';
 
 declare module '@nuxt/types' {
   interface Context {
@@ -20,7 +19,7 @@ declare module 'vue/types/vue' {
   }
 }
 
-export default (context: Context, inject: PluginInjection): void => {
+const userLibraryApiPlugin: Plugin = (context, inject) => {
   const config = new Configuration();
 
   const userLibraryApi = new UserLibraryApi(
@@ -30,3 +29,5 @@ export default (context: Context, inject: PluginInjection): void => {
   );
   inject('userLibraryApi', userLibraryApi);
 };
+
+export default userLibraryApiPlugin;

--- a/plugins/userViewsApi.ts
+++ b/plugins/userViewsApi.ts
@@ -1,8 +1,7 @@
-import { Context } from '@nuxt/types';
+import { Plugin } from '@nuxt/types';
 import { AxiosInstance } from 'axios';
 import { UserViewsApi } from '~/api/api';
 import { Configuration } from '~/api/configuration';
-import { PluginInjection } from '~/types/utils';
 
 declare module '@nuxt/types' {
   interface Context {
@@ -20,7 +19,7 @@ declare module 'vue/types/vue' {
   }
 }
 
-export default (context: Context, inject: PluginInjection): void => {
+const userViewsApiPlugin: Plugin = (context, inject) => {
   const config = new Configuration();
 
   const userViewsApi = new UserViewsApi(
@@ -30,3 +29,5 @@ export default (context: Context, inject: PluginInjection): void => {
   );
   inject('userViewsApi', userViewsApi);
 };
+
+export default userViewsApiPlugin;

--- a/types/utils.ts
+++ b/types/utils.ts
@@ -1,2 +1,0 @@
-/* eslint-disable-next-line @typescript-eslint/no-explicit-any -- Injected values can be of any type */
-export type PluginInjection = (property: string, value: any) => void;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4144,7 +4144,7 @@ core-js@^2.4.0, core-js@^2.6.5:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
   integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
 
-core-js@^3.6.1:
+core-js@^3.6.1, core-js@^3.6.5:
   version "3.6.5"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.5.tgz#7395dc273af37fb2e50e9bd3d9fe841285231d1a"
   integrity sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==


### PR DESCRIPTION
* Use core-js 3 for polyfills (Nuxt uses 2 by default)
* Fix the card component trying to get images even if there are none, leading to a bunch of 404s and useless requests
* Fix #92 (Changes the way plugin functions are defined to use type inference for parameters and return values)
* Builds and uses a modern bundle in addition to the "old browser" compatibility one. Still needs a bunch of work in regards to defining targets and such, but it's a start.