### PR TITLE
feat(card): add blurhash images

### DIFF
--- a/components/BlurhashCanvas.vue
+++ b/components/BlurhashCanvas.vue
@@ -1,0 +1,50 @@
+<template>
+  <canvas ref="canvas" :width="width" :height="height" />
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import { decode } from 'blurhash';
+
+export default Vue.extend({
+  props: {
+    hash: {
+      type: String,
+      required: true
+    },
+    width: {
+      type: Number,
+      default: 32
+    },
+    height: {
+      type: Number,
+      default: 32
+    },
+    punch: {
+      type: Number,
+      default: 1
+    }
+  },
+  watch: {
+    hash() {
+      this.$nextTick(() => {
+        this.draw();
+      });
+    }
+  },
+  mounted() {
+    this.draw();
+  },
+  methods: {
+    draw() {
+      const pixels = decode(this.hash, this.width, this.height, this.punch);
+      const ctx = (this.$refs.canvas as HTMLCanvasElement).getContext('2d');
+      const imageData = ctx?.createImageData(this.width, this.height);
+      if (imageData) {
+        imageData.data.set(pixels);
+        ctx?.putImageData(imageData, 0, 0);
+      }
+    }
+  }
+});
+</script>

--- a/components/BlurhashImage.vue
+++ b/components/BlurhashImage.vue
@@ -1,0 +1,98 @@
+<template>
+  <div ref="card">
+    <transition-group
+      mode="in-out"
+      name="fade"
+      style="
+        height: 100%;
+        width: 100%;
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+      "
+    >
+      <blurhash-canvas
+        v-if="
+          item.ImageBlurHashes &&
+          item.ImageBlurHashes.Primary &&
+          item.ImageTags &&
+          item.ImageTags.Primary
+        "
+        key="canvas"
+        :hash="item.ImageBlurHashes.Primary[item.ImageTags.Primary]"
+        :width="width"
+        :height="height"
+        :punch="punch"
+        style="
+          height: 100%;
+          width: 100%;
+          position: absolute;
+          top: 0;
+          left: 0;
+          right: 0;
+          bottom: 0;
+        "
+      />
+      <v-img
+        v-if="item.ImageTags && item.ImageTags.Primary"
+        key="image"
+        style="
+          height: 100%;
+          width: 100%;
+          position: absolute;
+          top: 0;
+          left: 0;
+          right: 0;
+          bottom: 0;
+        "
+        :src="image"
+        v-bind="$attrs"
+      />
+    </transition-group>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import { BaseItemDto, ImageType } from '~/api';
+import imageHelper from '~/mixins/imageHelper';
+
+export default Vue.extend({
+  mixins: [imageHelper],
+  props: {
+    item: {
+      type: Object as () => BaseItemDto,
+      required: true
+    },
+    width: {
+      type: Number,
+      default: 32
+    },
+    height: {
+      type: Number,
+      default: 32
+    },
+    punch: {
+      type: Number,
+      default: 1
+    }
+  },
+  data() {
+    return {
+      image: ''
+    };
+  },
+  mounted(): void {
+    if (this.item.ImageTags && this.item.ImageTags.Primary) {
+      const card = this.$refs.card as HTMLElement;
+      this.image = this.getImageUrlForElement(
+        card,
+        this.item,
+        ImageType.Primary
+      );
+    }
+  }
+});
+</script>

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@nuxtjs/pwa": "^3.0.0-beta.20",
     "@types/lodash": "^4.14.161",
     "@types/uuid": "^8.3.0",
+    "blurhash": "^1.1.3",
     "lodash": "^4.17.20",
     "nuxt": "^2.14.5",
     "nuxt-i18n": "^6.15.1",

--- a/pages/item/_itemId/index.vue
+++ b/pages/item/_itemId/index.vue
@@ -43,7 +43,7 @@
 import Vue from 'vue';
 import { BaseItemDto } from '~/api';
 import imageHelper from '~/mixins/imageHelper';
-import timeUtils from '~/mixins/timeUtils.ts';
+import timeUtils from '~/mixins/timeUtils';
 
 export default Vue.extend({
   mixins: [imageHelper, timeUtils],

--- a/yarn.lock
+++ b/yarn.lock
@@ -3179,6 +3179,11 @@ bluebird@^3.1.1, bluebird@^3.5.5:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
+blurhash@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/blurhash/-/blurhash-1.1.3.tgz#dc325af7da836d07a0861d830bdd63694382483e"
+  integrity sha512-yUhPJvXexbqbyijCIE/T2NCXcj9iNPhWmOKbPTuR/cm7Q5snXYIfnVnz6m7MWOXxODMz/Cr3UcVkRdHiuDVRDw==
+
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.4.0:
   version "4.11.9"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.9.tgz#26d556829458f9d1e81fc48952493d0ba3507828"


### PR DESCRIPTION
Adds two new components:

* BlurhashCanvas - Renders a hash to a canvas with a set size
* BlurhashImage - Takes an item and renders the BlurhashCanvas and a v-img

![Screenshot_2020-09-20 jellyfin-vue](https://user-images.githubusercontent.com/19396809/93711942-5fb7ea00-fb52-11ea-994f-c217423a69d0.png)
