### PR TITLE
Add virtual scroller to library view

### DIFF
--- a/components/BlurhashCanvas.vue
+++ b/components/BlurhashCanvas.vue
@@ -4,7 +4,7 @@
 
 <script lang="ts">
 import Vue from 'vue';
-import { decode } from 'blurhash';
+import { decode } from 'blurhash-wasm/blurhash_wasm';
 
 export default Vue.extend({
   props: {
@@ -37,12 +37,14 @@ export default Vue.extend({
   },
   methods: {
     draw() {
-      const pixels = decode(this.hash, this.width, this.height, this.punch);
-      const ctx = (this.$refs.canvas as HTMLCanvasElement).getContext('2d');
-      const imageData = ctx?.createImageData(this.width, this.height);
-      if (imageData) {
-        imageData.data.set(pixels);
-        ctx?.putImageData(imageData, 0, 0);
+      const pixels = decode(this.hash, this.width, this.height);
+      if (pixels) {
+        const ctx = (this.$refs.canvas as HTMLCanvasElement).getContext('2d');
+        const imageData = ctx?.createImageData(this.width, this.height);
+        if (imageData) {
+          imageData.data.set(pixels);
+          ctx?.putImageData(imageData, 0, 0);
+        }
       }
     }
   }

--- a/components/BlurhashImage.vue
+++ b/components/BlurhashImage.vue
@@ -21,6 +21,7 @@
         class="absolute"
         :src="image"
         v-bind="$attrs"
+        :alt="item.Name || ''"
       />
     </transition-group>
   </div>

--- a/components/BlurhashImage.vue
+++ b/components/BlurhashImage.vue
@@ -79,4 +79,7 @@ export default Vue.extend({
   right: 0;
   bottom: 0;
 }
+img {
+  object-fit: cover;
+}
 </style>

--- a/components/BlurhashImage.vue
+++ b/components/BlurhashImage.vue
@@ -15,7 +15,7 @@
         :punch="punch"
         class="absolute"
       />
-      <v-img
+      <img
         v-if="item.ImageTags && item.ImageTags.Primary"
         key="image"
         class="absolute"

--- a/components/BlurhashImage.vue
+++ b/components/BlurhashImage.vue
@@ -21,7 +21,6 @@
         class="absolute"
         :src="image"
         v-bind="$attrs"
-        :alt="item.Name || ''"
       />
     </transition-group>
   </div>

--- a/components/Card.vue
+++ b/components/Card.vue
@@ -228,15 +228,6 @@ export default Vue.extend({
 .card-image {
   width: 100%;
   height: 100%;
-  & img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-  }
-  & canvas {
-    width: 100%;
-    height: 100%;
-  }
 }
 .card-chip {
   position: absolute;

--- a/components/Card.vue
+++ b/components/Card.vue
@@ -1,7 +1,7 @@
 <template>
   <nuxt-link :to="itemLink" style="text-decoration: none; color: inherit">
     <div class="card-box">
-      <div :class="shape || cardType">
+      <div :class="shape || cardType" class="elevation-3">
         <div
           class="card-content card-content-button d-flex justify-center align-center primary darken-4"
         >
@@ -194,16 +194,19 @@ export default Vue.extend({
   position: relative;
   padding-bottom: 150%;
   contain: strict;
+  border-radius: 0.3em;
 }
 .thumb-card {
   position: relative;
   padding-bottom: 56.25%;
   contain: strict;
+  border-radius: 0.3em;
 }
 .square-card {
   position: relative;
   padding-bottom: 100%;
   contain: strict;
+  border-radius: 0.3em;
 }
 .card-content {
   overflow: hidden;
@@ -216,7 +219,6 @@ export default Vue.extend({
   height: 100%;
   width: 100%;
   contain: strict;
-  border-radius: 0.3em;
   background-size: cover;
   background-repeat: no-repeat;
   background-clip: content-box;

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -45,6 +45,7 @@ const config: NuxtConfig = {
   plugins: [
     // Components
     'plugins/components/vueperSlides.ts',
+    'plugins/components/vueVirtualScroller.ts',
     // Utility
     'plugins/browserDetection.ts',
     'plugins/deviceProfile.ts',

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "nuxt-vuex-localstorage": "^1.2.7",
     "qs": "^6.9.4",
     "uuid": "^8.3.0",
+    "vue-virtual-scroller": "^1.0.10",
     "vueperslides": "^2.10.8"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@nuxtjs/pwa": "^3.0.0-beta.20",
     "@types/lodash": "^4.14.161",
     "@types/uuid": "^8.3.0",
-    "blurhash": "^1.1.3",
+    "blurhash-wasm": "^0.2.0",
     "lodash": "^4.17.20",
     "nuxt": "^2.14.6",
     "nuxt-i18n": "^6.15.1",

--- a/pages/library/_viewId.vue
+++ b/pages/library/_viewId.vue
@@ -10,6 +10,7 @@
       class="scroller"
       :items="itemsChunks"
       :min-item-size="350"
+      :buffer="600"
       page-mode
     >
       <template v-slot="{ item, index, active }">
@@ -44,7 +45,23 @@ export default Vue.extend({
   computed: {
     itemsChunks: {
       get() {
-        const chunks = chunk(this.$data.items, 8);
+        let cardsPerLine = 8;
+
+        if (this.$vuetify.breakpoint.smAndDown) {
+          cardsPerLine = 3;
+        } else if (
+          this.$vuetify.breakpoint.smAndUp &&
+          !this.$vuetify.breakpoint.lgAndUp
+        ) {
+          cardsPerLine = 4;
+        } else if (
+          this.$vuetify.breakpoint.lgAndUp &&
+          !this.$vuetify.breakpoint.xlOnly
+        ) {
+          cardsPerLine = 6;
+        }
+
+        const chunks = chunk(this.$data.items, cardsPerLine);
 
         const keyedChunks = chunks.map((itemChunk, index) => {
           return {

--- a/pages/library/_viewId.vue
+++ b/pages/library/_viewId.vue
@@ -5,11 +5,24 @@
         <skeleton-card v-for="n in 24" :key="n" />
       </v-col>
     </v-row>
-    <v-row v-if="items.length">
-      <v-col cols="12" class="card-grid-container">
-        <card v-for="item in items" :key="item.Id" :item="item" />
-      </v-col>
-    </v-row>
+    <dynamic-scroller
+      v-if="items.length"
+      class="scroller"
+      :items="itemsChunks"
+      :min-item-size="350"
+      page-mode
+    >
+      <template v-slot="{ item, index, active }">
+        <dynamic-scroller-item
+          :item="item"
+          :active="active"
+          :data-index="index"
+          class="card-grid-container"
+        >
+          <card v-for="card of item.chunk" :key="card.Id" :item="card" />
+        </dynamic-scroller-item>
+      </template>
+    </dynamic-scroller>
     <v-row v-else-if="loaded" justify="center">
       <h1 class="text-h4 text-center">{{ $t('libraryEmpty') }}</h1>
     </v-row>
@@ -18,6 +31,7 @@
 
 <script lang="ts">
 import Vue from 'vue';
+import { chunk } from 'lodash';
 import { BaseItemDto } from '../../api';
 
 export default Vue.extend({
@@ -27,6 +41,22 @@ export default Vue.extend({
       loaded: false
     };
   },
+  computed: {
+    itemsChunks: {
+      get() {
+        const chunks = chunk(this.$data.items, 8);
+
+        const keyedChunks = chunks.map((itemChunk, index) => {
+          return {
+            id: index,
+            chunk: itemChunk
+          };
+        });
+
+        return keyedChunks;
+      }
+    }
+  },
   async beforeMount() {
     try {
       const collectionInfo = await this.$itemsApi.getItems({
@@ -34,8 +64,6 @@ export default Vue.extend({
         userId: this.$auth.user.Id,
         ids: this.$route.params.viewId
       });
-
-      console.dir(collectionInfo.data.Items);
 
       if (
         collectionInfo.data.Items &&
@@ -89,6 +117,10 @@ export default Vue.extend({
 </script>
 
 <style lang="scss" scoped>
+.scroller {
+  max-height: 100%;
+}
+
 @import '~vuetify/src/styles/styles.sass';
 .card-grid-container {
   display: grid;

--- a/pages/library/_viewId.vue
+++ b/pages/library/_viewId.vue
@@ -10,7 +10,7 @@
       class="scroller"
       :items="itemsChunks"
       :min-item-size="350"
-      :buffer="600"
+      :buffer="$vuetify.breakpoint.height * 1.5"
       page-mode
     >
       <template v-slot="{ item, index, active }">

--- a/plugins/components/vueVirtualScroller.ts
+++ b/plugins/components/vueVirtualScroller.ts
@@ -1,0 +1,8 @@
+import Vue from 'vue';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- Need to build a Type package for the module
+// @ts-ignore
+import { DynamicScroller, DynamicScrollerItem } from 'vue-virtual-scroller';
+import 'vue-virtual-scroller/dist/vue-virtual-scroller.css';
+
+Vue.component('dynamic-scroller', DynamicScroller);
+Vue.component('dynamic-scroller-item', DynamicScrollerItem);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3179,10 +3179,10 @@ bluebird@^3.1.1, bluebird@^3.5.5:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
-blurhash@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/blurhash/-/blurhash-1.1.3.tgz#dc325af7da836d07a0861d830bdd63694382483e"
-  integrity sha512-yUhPJvXexbqbyijCIE/T2NCXcj9iNPhWmOKbPTuR/cm7Q5snXYIfnVnz6m7MWOXxODMz/Cr3UcVkRdHiuDVRDw==
+blurhash-wasm@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/blurhash-wasm/-/blurhash-wasm-0.2.0.tgz#cca79e72f70d19923b4446308a1ea87b44a21f01"
+  integrity sha512-d/jOMANMlth4VNQRs3Xr/bDj7K3S2/QuRvrwC3QldeOTX9/5MLHUn2+JQV11Ja2J4/kY+HbRJOCGCy9T4BBvJw==
 
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.4.0:
   version "4.11.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10933,6 +10933,11 @@ schema-utils@^2.0.0, schema-utils@^2.5.0, schema-utils@^2.6.1, schema-utils@^2.6
     ajv "^6.12.4"
     ajv-keywords "^3.5.2"
 
+scrollparent@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/scrollparent/-/scrollparent-2.0.1.tgz#715d5b9cc57760fb22bdccc3befb5bfe06b1a317"
+  integrity sha1-cV1bnMV3YPsivczDvvtb/gaxoxc=
+
 semver-compare@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
@@ -12579,6 +12584,16 @@ vue-no-ssr@^1.1.1:
   resolved "https://registry.yarnpkg.com/vue-no-ssr/-/vue-no-ssr-1.1.1.tgz#875f3be6fb0ae41568a837f3ac1a80eaa137b998"
   integrity sha512-ZMjqRpWabMPqPc7gIrG0Nw6vRf1+itwf0Itft7LbMXs2g3Zs/NFmevjZGN1x7K3Q95GmIjWbQZTVerxiBxI+0g==
 
+vue-observe-visibility@^0.4.4:
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/vue-observe-visibility/-/vue-observe-visibility-0.4.6.tgz#878cb8ebcf3078e40807af29774e97105ebd519e"
+  integrity sha512-xo0CEVdkjSjhJoDdLSvoZoQrw/H2BlzB5jrCBKGZNXN2zdZgMuZ9BKrxXDjNP2AxlcCoKc8OahI3F3r3JGLv2Q==
+
+vue-resize@^0.4.5:
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/vue-resize/-/vue-resize-0.4.5.tgz#4777a23042e3c05620d9cbda01c0b3cc5e32dcea"
+  integrity sha512-bhP7MlgJQ8TIkZJXAfDf78uJO+mEI3CaLABLjv0WNzr4CcGRGPIAItyWYnP6LsPA4Oq0WE+suidNs6dgpO4RHg==
+
 vue-router@^3.4.3:
   version "3.4.3"
   resolved "https://registry.yarnpkg.com/vue-router/-/vue-router-3.4.3.tgz#fa93768616ee338aa174f160ac965167fa572ffa"
@@ -12618,6 +12633,15 @@ vue-template-es2015-compiler@^1.6.0, vue-template-es2015-compiler@^1.9.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz#1ee3bc9a16ecbf5118be334bb15f9c46f82f5825"
   integrity sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==
+
+vue-virtual-scroller@^1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/vue-virtual-scroller/-/vue-virtual-scroller-1.0.10.tgz#fdf243240001f05bd79aa77f2e2e60403760e2fb"
+  integrity sha512-Hn4qSBDhRY4XdngPioYy/ykDjrLX/NMm1fQXm/4UQQ/Xv1x8JbHGFZNftQowTcfICgN7yc31AKnUk1UGLJ2ndA==
+  dependencies:
+    scrollparent "^2.0.1"
+    vue-observe-visibility "^0.4.4"
+    vue-resize "^0.4.5"
 
 vue@^2.6.12:
   version "2.6.12"


### PR DESCRIPTION
* Adds a responsive virtual scroller to the library pages
* Fixes performance issues with the card component

To get around the limitations of the virtual scroller not supporting grids, we use lodash's `chunk` function to transform the items array with chunks of items (the length of which depends on the breakpoint we're at).

This essentially gives us a bunch of rows of items to pass to the virtual scroll, simulating a grid.

The current implementation of BlurhashImage was somewhat slow in this scenario, so I switched the library to use `blurhash-wasm`, which is a Web Assembly decoder in Rust (@sparky8251 will be happy :smile: ).  
Further performance issues lead to a profiling of the view and I discovered that `v-img` is quite slow in this scenario. I replaced it with `img`, since we're not using the features of `v-img` in this case, which gives us a significant performance boost.