### PR TITLE
Add websocket support

### DIFF
--- a/components/UserButton.vue
+++ b/components/UserButton.vue
@@ -62,6 +62,7 @@ export default Vue.extend({
     ...mapActions('user', ['clearUser']),
     ...mapActions('deviceProfile', ['clearDeviceProfile']),
     logoutUser() {
+      this.$disconnect();
       this.$auth.logout();
       this.clearDeviceProfile();
       this.clearUser();

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -123,7 +123,7 @@ export default Vue.extend({
     return {
       drawer: true,
       opacity: 0,
-      keepAliveInterval: null
+      keepAliveInterval: undefined as number | undefined
     };
   },
   computed: {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -74,6 +74,7 @@ const config: NuxtConfig = {
     // General
     'plugins/appInitPlugin.ts',
     'plugins/veeValidate.ts',
+    'plugins/nativeWebsocketPlugin.ts',
     // Components
     'plugins/components/swiper.ts',
     'plugins/components/vueperSlides.ts',

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "uuid": "^8.3.2",
     "vee-validate": "^3.4.5",
     "vue-awesome-swiper": "^4.1.1",
+    "vue-native-websocket": "^2.0.14",
     "vue-virtual-scroller": "^1.0.10",
     "vueperslides": "^2.12.1"
   },

--- a/plugins/nativeWebsocketPlugin.ts
+++ b/plugins/nativeWebsocketPlugin.ts
@@ -1,0 +1,36 @@
+import { Plugin } from '@nuxt/types';
+import Vue from 'vue';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- Need to build a Type package for the module
+// @ts-ignore
+import VueNativeSock from 'vue-native-websocket';
+
+declare module '@nuxt/types' {
+  interface Context {
+    $connect: (url: string) => void;
+    $disconnect: () => void;
+  }
+
+  interface NuxtAppOptions {
+    $connect: (url: string) => void;
+    $disconnect: () => void;
+  }
+}
+
+declare module 'vue/types/vue' {
+  interface Vue {
+    $connect: (url: string) => void;
+    $disconnect: () => void;
+  }
+}
+
+const nativeSocketPlugin: Plugin = ({ store }) => {
+  Vue.use(VueNativeSock, 'ws://localhost', {
+    connectManually: true,
+    reconnection: true,
+    reconnectionAttempts: 5,
+    store,
+    format: 'json'
+  });
+};
+
+export default nativeSocketPlugin;

--- a/plugins/nativeWebsocketPlugin.ts
+++ b/plugins/nativeWebsocketPlugin.ts
@@ -24,7 +24,7 @@ declare module 'vue/types/vue' {
 }
 
 const nativeSocketPlugin: Plugin = ({ store }) => {
-  Vue.use(VueNativeSock, 'ws://localhost', {
+  Vue.use(VueNativeSock, 'ws://127.0.0.1', {
     connectManually: true,
     reconnection: true,
     reconnectionAttempts: 5,

--- a/schemes/jellyfinScheme.ts
+++ b/schemes/jellyfinScheme.ts
@@ -15,6 +15,7 @@ export default class JellyfinScheme {
   $auth: NuxtAuth;
   name = 'jellyfin';
   options: Record<string, unknown>;
+  rawToken: '';
 
   constructor(auth: NuxtAuth, options: Record<string, unknown>) {
     this.$auth = auth;
@@ -85,6 +86,10 @@ export default class JellyfinScheme {
       const userToken = `MediaBrowser Client="${this.$auth.ctx.app.store.state.deviceProfile.clientName}", Device="${this.$auth.ctx.app.store.state.deviceProfile.deviceName}", DeviceId="${this.$auth.ctx.app.store.state.deviceProfile.deviceId}", Version="${this.$auth.ctx.app.store.state.deviceProfile.clientVersion}", Token="${authenticateResponse.data.AccessToken}"`;
       this.$auth.setToken(this.name, userToken);
       this._setToken(userToken);
+      this.$auth.ctx.app.store.commit('user/SET_USER', {
+        id: authenticateResponse.data.User?.Id,
+        accessToken: authenticateResponse.data.AccessToken
+      });
 
       // Sets the remember me to true in order to first fetch the user once
       this._setRememberMe(true);
@@ -122,6 +127,7 @@ export default class JellyfinScheme {
 
     // Fetch the user, then set it in Nuxt Auth
     const user = (await this.$auth.ctx.app.$api.user.getCurrentUser()).data;
+
     this.$auth.setUser(user);
     await this.$auth.ctx.app.store.dispatch('displayPreferences/initState');
   }

--- a/store/index.ts
+++ b/store/index.ts
@@ -1,3 +1,5 @@
+import Vue from 'vue';
+import { MutationTree } from 'vuex';
 import { TvShowsState } from './tvShows';
 import { ServerState } from './servers';
 import { PageState } from './page';
@@ -21,3 +23,45 @@ export interface AppState {
   device: DeviceState;
   displayPreferences: DisplayPreferencesState;
 }
+
+export interface RootState {
+  socket: {
+    instance: WebSocket | null;
+    isConnected: boolean;
+    message: Record<string, never>;
+    reconnectError: boolean;
+  };
+}
+
+export const state = (): RootState => ({
+  socket: {
+    instance: null,
+    isConnected: false,
+    message: {},
+    reconnectError: false
+  }
+});
+
+export const mutations: MutationTree<RootState> = {
+  SOCKET_ONOPEN(state: RootState, event: Event) {
+    const socketInstance = event.currentTarget;
+    Vue.set(state.socket, 'instance', socketInstance);
+    Vue.set(state.socket, 'isConnected', true);
+    Vue.set(state.socket, 'reconnectError', false);
+  },
+  SOCKET_ONCLOSE(state: RootState, _event: CloseEvent) {
+    Vue.set(state.socket, 'isConnected', false);
+  },
+  SOCKET_ONERROR(state: RootState, event: Event) {
+    console.error(state, event);
+  },
+  SOCKET_ONMESSAGE(state: RootState, message) {
+    Vue.set(state.socket, 'message', message);
+  },
+  SOCKET_RECONNECT(state: RootState, count: number) {
+    console.info(state, count);
+  },
+  SOCKET_RECONNECT_ERROR(state: RootState) {
+    Vue.set(state.socket, 'reconnectError', true);
+  }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -12873,6 +12873,11 @@ vue-meta@^2.4.0:
   dependencies:
     deepmerge "^4.2.2"
 
+vue-native-websocket@^2.0.14:
+  version "2.0.14"
+  resolved "https://registry.yarnpkg.com/vue-native-websocket/-/vue-native-websocket-2.0.14.tgz#fddb56f9f93d2ecc861486ee3c8f29506ea2a168"
+  integrity sha512-oK8+xG1gmqRs4JngHGwEc4zWoRjsdMB20Sz8pemkh4lW2Vr2676/cDRtd30aGnO2xF7Oxf003wS5JO0kypUsCw==
+
 vue-no-ssr@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/vue-no-ssr/-/vue-no-ssr-1.1.1.tgz#875f3be6fb0ae41568a837f3ac1a80eaa137b998"


### PR DESCRIPTION
Adds a websocket connection to the client using vue-native-websocket.

Messages get sent to the root store, in a `socket` object in the state, which contains the socket instances, connection status, message and error status.

Components can then subscribe to these messages and filter them based on type.

An implementation of ForceKeepAlive and KeepAlive is provided in the default layout.