### PR TITLE
feat(library): add card skeletons to the empty library placeholder

### DIFF
--- a/components/SkeletonCard.vue
+++ b/components/SkeletonCard.vue
@@ -1,9 +1,22 @@
 <template>
   <div class="skeleton-card">
-    <v-skeleton-loader type="image" />
-    <v-skeleton-loader type="heading" class="mt-1" />
+    <v-skeleton-loader type="image" :boilerplate="boilerplate" />
+    <v-skeleton-loader type="heading" class="mt-1" :boilerplate="boilerplate" />
   </div>
 </template>
+
+<script lang="ts">
+import Vue from 'vue';
+
+export default Vue.extend({
+  props: {
+    boilerplate: {
+      type: Boolean,
+      default: false
+    }
+  }
+});
+</script>
 
 <style scoped>
 .skeleton-card {

--- a/pages/library/_viewId.vue
+++ b/pages/library/_viewId.vue
@@ -32,7 +32,6 @@
         <h1 class="text-h5">
           {{ $t('libraryEmpty') }}
         </h1>
-        <p></p>
       </div>
     </v-row>
   </v-container>

--- a/pages/library/_viewId.vue
+++ b/pages/library/_viewId.vue
@@ -25,7 +25,15 @@
       </template>
     </dynamic-scroller>
     <v-row v-else-if="loaded" justify="center">
-      <h1 class="text-h4 text-center">{{ $t('libraryEmpty') }}</h1>
+      <v-col cols="12" class="card-grid-container empty-card-container">
+        <skeleton-card v-for="n in 24" :key="n" boilerplate />
+      </v-col>
+      <div class="empty-message text-center">
+        <h1 class="text-h5">
+          {{ $t('libraryEmpty') }}
+        </h1>
+        <p></p>
+      </div>
     </v-row>
   </v-container>
 </template>
@@ -138,6 +146,19 @@ export default Vue.extend({
 <style lang="scss" scoped>
 .scroller {
   max-height: 100%;
+}
+
+.empty-card-container {
+  max-height: 90vh;
+  overflow: hidden;
+  mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0));
+}
+
+.empty-message {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
 }
 
 @import '~vuetify/src/styles/styles.sass';


### PR DESCRIPTION
Slightly redesigns the empty library placeholder to look nicer.

![image](https://user-images.githubusercontent.com/19396809/94995223-3315c080-059d-11eb-9eb1-0c8d8090eee0.png)
