### PR TITLE
Refactor user views to use a Vuex store

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -79,21 +79,12 @@
 
 <script lang="ts">
 import Vue from 'vue';
-import { BaseItemDto } from '~/api/api';
-import { getLibraryIcon } from '~/utils/items';
-
-interface NavigationDrawerItem {
-  icon: string | undefined | null;
-  title: string | undefined | null;
-  to: string;
-}
 
 export default Vue.extend({
   data() {
     return {
       clipped: true,
       drawer: true,
-      libraries: {},
       miniVariant: false
     };
   },
@@ -110,6 +101,9 @@ export default Vue.extend({
         }
       ];
     },
+    libraries() {
+      return this.$store.getters['userViews/getNavigationDrawerItems'];
+    },
     configItems() {
       return [
         {
@@ -120,26 +114,8 @@ export default Vue.extend({
       ];
     }
   },
-  async beforeMount() {
-    const userViewsRequest = await this.$userViewsApi.getUserViews({
-      userId: this.$auth.user.Id
-    });
-
-    let userViews: Array<NavigationDrawerItem> = [];
-
-    if (userViewsRequest.data.Items) {
-      userViews = userViewsRequest.data.Items.map(
-        (view: BaseItemDto): NavigationDrawerItem => {
-          return {
-            icon: getLibraryIcon(view.CollectionType),
-            title: view.Name,
-            to: `/library/${view.Id}`
-          };
-        }
-      );
-    }
-
-    this.libraries = userViews;
+  beforeMount() {
+    this.$store.dispatch('userViews/refresh');
   }
 });
 </script>

--- a/plugins/browserDetection.ts
+++ b/plugins/browserDetection.ts
@@ -16,6 +16,12 @@ declare module 'vue/types/vue' {
   }
 }
 
+declare module 'vuex/types/index' {
+  interface Store<S> {
+    $browser: BrowserDetector;
+  }
+}
+
 /**
  * Utilities to detect the browser and get information on the current environment
  * Based on https://github.com/google/shaka-player/blob/master/lib/util/platform.js

--- a/plugins/imageApi.ts
+++ b/plugins/imageApi.ts
@@ -19,6 +19,12 @@ declare module 'vue/types/vue' {
   }
 }
 
+declare module 'vuex/types/index' {
+  interface Store<S> {
+    $imageApi: ImageApi;
+  }
+}
+
 const imageApiPlugin: Plugin = (context, inject) => {
   const config = new Configuration();
 

--- a/plugins/itemsApi.ts
+++ b/plugins/itemsApi.ts
@@ -19,6 +19,12 @@ declare module 'vue/types/vue' {
   }
 }
 
+declare module 'vuex/types/index' {
+  interface Store<S> {
+    $itemsApi: ItemsApi;
+  }
+}
+
 const itemsApiPlugin: Plugin = (context, inject) => {
   const config = new Configuration();
 

--- a/plugins/libraryApi.ts
+++ b/plugins/libraryApi.ts
@@ -19,6 +19,12 @@ declare module 'vue/types/vue' {
   }
 }
 
+declare module 'vuex/types/index' {
+  interface Store<S> {
+    $libraryApi: LibraryApi;
+  }
+}
+
 const libraryApiPlugin: Plugin = (context, inject) => {
   const config = new Configuration();
 

--- a/plugins/playbackProfile.ts
+++ b/plugins/playbackProfile.ts
@@ -22,6 +22,28 @@ import {
   ResponseProfile
 } from '~/api';
 
+declare module '@nuxt/types' {
+  interface Context {
+    $playbackProfile: DeviceProfile;
+  }
+
+  interface NuxtAppOptions {
+    $playbackProfile: DeviceProfile;
+  }
+}
+
+declare module 'vue/types/vue' {
+  interface Vue {
+    $playbackProfile: DeviceProfile;
+  }
+}
+
+declare module 'vuex/types/index' {
+  interface Store<S> {
+    $playbackProfile: DeviceProfile;
+  }
+}
+
 const physicalAudioChannels = browserDetector.isTv() ? 6 : 2;
 
 const videoTestElement = document.createElement('video');
@@ -250,22 +272,6 @@ function getDeviceProfile(): DeviceProfile {
     SubtitleProfiles: getSubtitleProfiles(),
     ResponseProfiles: getResponseProfiles()
   };
-}
-
-declare module '@nuxt/types' {
-  interface Context {
-    $playbackProfile: DeviceProfile;
-  }
-
-  interface NuxtAppOptions {
-    $playbackProfile: DeviceProfile;
-  }
-}
-
-declare module 'vue/types/vue' {
-  interface Vue {
-    $playbackProfile: DeviceProfile;
-  }
 }
 
 const playbackProfilePlugin: Plugin = (_context, inject) => {

--- a/plugins/tvShowsApi.ts
+++ b/plugins/tvShowsApi.ts
@@ -19,6 +19,12 @@ declare module 'vue/types/vue' {
   }
 }
 
+declare module 'vuex/types/index' {
+  interface Store<S> {
+    $tvShowsApi: TvShowsApi;
+  }
+}
+
 const tvShowsApiPlugin: Plugin = (context, inject) => {
   const config = new Configuration();
 

--- a/plugins/userApi.ts
+++ b/plugins/userApi.ts
@@ -19,6 +19,12 @@ declare module 'vue/types/vue' {
   }
 }
 
+declare module 'vuex/types/index' {
+  interface Store<S> {
+    $userApi: UserApi;
+  }
+}
+
 const userApiPlugin: Plugin = (context, inject) => {
   const config = new Configuration();
 

--- a/plugins/userLibraryApi.ts
+++ b/plugins/userLibraryApi.ts
@@ -19,6 +19,12 @@ declare module 'vue/types/vue' {
   }
 }
 
+declare module 'vuex/types/index' {
+  interface Store<S> {
+    $userLibraryApi: UserLibraryApi;
+  }
+}
+
 const userLibraryApiPlugin: Plugin = (context, inject) => {
   const config = new Configuration();
 

--- a/plugins/userViewsApi.ts
+++ b/plugins/userViewsApi.ts
@@ -19,6 +19,12 @@ declare module 'vue/types/vue' {
   }
 }
 
+declare module 'vuex/types/index' {
+  interface Store<S> {
+    $userViewsApi: UserViewsApi;
+  }
+}
+
 const userViewsApiPlugin: Plugin = (context, inject) => {
   const config = new Configuration();
 

--- a/store/userViews.ts
+++ b/store/userViews.ts
@@ -1,0 +1,45 @@
+import { ActionTree, GetterTree, MutationTree } from 'vuex';
+import { BaseItemDto } from '~/api';
+import { getLibraryIcon } from '~/utils/items';
+
+export interface UserViewsState {
+  views: BaseItemDto[];
+}
+
+export const state = (): UserViewsState => ({
+  views: []
+});
+
+interface MutationPayload {
+  userViews: BaseItemDto[];
+}
+
+export const getters: GetterTree<UserViewsState, UserViewsState> = {
+  getNavigationDrawerItems: (state) => {
+    return state.views.map((view: BaseItemDto) => {
+      return {
+        icon: getLibraryIcon(view.CollectionType),
+        title: view.Name,
+        to: `/library/${view.Id}`
+      };
+    });
+  }
+};
+
+export const mutations: MutationTree<UserViewsState> = {
+  SET_USER_VIEWS(state: UserViewsState, { userViews }: MutationPayload) {
+    state.views = userViews;
+  }
+};
+
+export const actions: ActionTree<UserViewsState, UserViewsState> = {
+  async refresh({ commit }) {
+    const userViewsResponse = await this.$userViewsApi.getUserViews({
+      userId: this.$auth.user.Id
+    });
+
+    const userViews = userViewsResponse.data.Items;
+
+    commit('SET_USER_VIEWS', { userViews });
+  }
+};


### PR DESCRIPTION
* Moves the API call for user views into a store
* Adds a getter for navigation drawer items
* Fixes most plugins not being exposed to Vuex
* Changes the default page template to use the Vuex store as a data source instead of the straight API call