### PR TITLE
Dockerfile: fix SPA build, add compression, mime types and routing

### DIFF
--- a/.docker/mime.types
+++ b/.docker/mime.types
@@ -1,0 +1,105 @@
+types {
+
+  # Data interchange
+
+    application/atom+xml                  atom;
+    application/json                      json map topojson;
+    application/ld+json                   jsonld;
+    application/rss+xml                   rss;
+    # Normalize to standard type.
+    # https://tools.ietf.org/html/rfc7946#section-12
+    application/geo+json                  geojson;
+    application/xml                       xml;
+    # Normalize to standard type.
+    # https://tools.ietf.org/html/rfc3870#section-2
+    application/rdf+xml                   rdf;
+
+
+  # JavaScript
+
+    # Servers should use text/javascript for JavaScript resources.
+    # https://html.spec.whatwg.org/multipage/scripting.html#scriptingLanguages
+    text/javascript                       js mjs;
+    application/wasm                      wasm;
+
+
+  # Manifest files
+
+    application/manifest+json             webmanifest;
+    application/x-web-app-manifest+json   webapp;
+    text/cache-manifest                   appcache;
+
+
+  # Media files
+
+    audio/midi                            mid midi kar;
+    audio/mp4                             aac f4a f4b m4a;
+    audio/mpeg                            mp3;
+    audio/ogg                             oga ogg opus;
+    audio/wav                             wav;
+    audi/webm                             weba;
+    audio/x-realaudio                     ra;
+    audio/x-matroska                      mka;
+    image/bmp                             bmp;
+    image/gif                             gif;
+    image/jpeg                            jpeg jpg;
+    image/jxr                             jxr hdp wdp;
+    image/png                             png;
+    image/svg+xml                         svg svgz;
+    image/tiff                            tif tiff;
+    image/vnd.wap.wbmp                    wbmp;
+    image/webp                            webp;
+    image/x-jng                           jng;
+    video/3gpp                            3gp 3gpp;
+    video/mp2t                            ts;
+    video/mp4                             f4p f4v m4v mp4;
+    video/mpeg                            mpeg mpg;
+    video/ogg                             ogv;
+    video/quicktime                       mov;
+    video/webm                            webm;
+    video/x-flv                           flv;
+    video/x-mng                           mng;
+    video/x-ms-asf                        asf asx;
+    video/x-ms-wmv                        wmv;
+    video/x-msvideo                       avi;
+    video/x-matroska                      mkv mk3d;
+
+    # Serving `.ico` image files with a different media type
+    # prevents Internet Explorer from displaying then as images:
+    # https://github.com/h5bp/html5-boilerplate/commit/37b5fec090d00f38de64b591bcddcb205aadf8ee
+
+    image/x-icon                          cur ico;
+
+
+  # Subtitles
+    application/subrip                    sub;
+    text/plain                            txt ass ssa srt;
+    text/vtt                              vtt;
+
+
+  # Web fonts
+
+    font/woff                             woff;
+    font/woff2                            woff2;
+    application/vnd.ms-fontobject         eot;
+    font/ttf                              ttf;
+    font/collection                       ttc;
+    font/otf                              otf;
+
+
+  # Other
+
+    application/epub+zip                  epub;
+    application/gzip                      gz;
+    application/pdf                       pdf;
+    application/ttml+xml                  ttml;
+    application/x-7z-compressed           7z;
+    application/x-bzip                    bz;
+    application/x-bzip2                   bz2:
+    application/x-mpegURL                 m3u m3u8;
+    application/x-rar-compressed          rar;
+    application/zip                       zip;
+    text/css                              css;
+    text/html                             htm html shtml;
+
+}

--- a/.docker/nginx.conf
+++ b/.docker/nginx.conf
@@ -1,0 +1,19 @@
+server {
+  listen 80 default_server;
+
+  root /usr/share/nginx/html;
+  index index.html;
+
+  gzip on;
+  gzip_vary on;
+  gzip_min_length 1024;
+  gzip_proxied expired no-cache no-store private auth;
+  gzip_types application/javascript application/json application/geo+json application/ld+json application/manifest+json application/rdf+xml application/rss+xml application/ttml+xml application/xml application/x-mpegURL text/css text/javascript text/plain text/vtt text/xml;
+  gzip_disable "MSIE [1-6]\.";
+
+  location / {
+    root /usr/share/nginx/html;
+    index index.html;
+    try_files $uri $uri/ /index.html;
+  }
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,10 @@ RUN yarn install
 ADD . .
 
 # Build static site
-RUN yarn generate
+RUN yarn build
 
 # Deploy built distribution to nginx
 FROM nginx:alpine
 COPY --from=build /app/dist/ /usr/share/nginx/html/
+COPY .docker/nginx.conf /etc/nginx/conf.d/default.conf
+COPY .docker/mime.types /etc/nginx/mime.types


### PR DESCRIPTION
This PR fixes/changes the following:
* Switch from `yarn generate` to `yarn build` to build proper SPA
* add more MIME types potentially used by jellyfin to nginx config
* enable gzip compression in nginx for selected MIME types
* fix routing in nginx