### PR TITLE
feat(ci): add docker image pipeline

### DIFF
--- a/.ci/azure-pipelines-build.yml
+++ b/.ci/azure-pipelines-build.yml
@@ -24,3 +24,62 @@ jobs:
 
       - script: 'yarn build'
         displayName: 'Build'
+
+  - job: BuildDocker
+    displayName: 'Build Docker'
+
+    strategy:
+      matrix:
+        amd64:
+          BuildConfiguration: amd64
+        arm64:
+          BuildConfiguration: arm64
+        armhf:
+          BuildConfiguration: armhf
+
+    pool:
+      vmImage: 'ubuntu-latest'
+
+    variables:
+      - name: Version
+        value: 0.0.0
+
+    steps:
+      - script: echo "##vso[task.setvariable variable=Version]$( awk -F '/' '{ print $NF }' <<<'$(Build.SourceBranch)' | sed 's/^v//' )"
+        displayName: Set release version (stable)
+        condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/v')
+
+    steps:
+      - task: Docker@2
+        displayName: 'Push Unstable Image'
+        condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/master')
+        inputs:
+          repository: 'jellyfin/jellyfin-vue'
+          command: buildAndPush
+          buildContext: '.'
+          Dockerfile: 'Dockerfile'
+          containerRegistry: Docker Hub
+          tags: |
+            unstable-$(Build.BuildNumber)-$(BuildConfiguration)
+            unstable-$(BuildConfiguration)
+
+      - task: Docker@2
+        displayName: 'Push Stable Image'
+        condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/v')
+        inputs:
+          repository: 'jellyfin/jellyfin-vue'
+          command: buildAndPush
+          buildContext: '.'
+          Dockerfile: 'Dockerfile'
+          containerRegistry: Docker Hub
+          tags: |
+            stable-$(Build.BuildNumber)-$(BuildConfiguration)
+            $(Version)-$(BuildConfiguration)
+
+  - job: CollectArtifacts
+    timeoutInMinutes: 20
+    displayName: 'Collect Artifacts'
+    continueOnError: true
+    dependsOn:
+      - BuildDocker
+    condition: and(succeeded('Build), succeeded('BuildDocker'))

--- a/.ci/azure-pipelines-build.yml
+++ b/.ci/azure-pipelines-build.yml
@@ -42,13 +42,9 @@ jobs:
 
     variables:
       - name: Version
-        value: 0.0.0
+        value: $[replace(variables['Build.SourceBranch'],'refs/tags/v','')]
 
     steps:
-      - script: echo "##vso[task.setvariable variable=Version]$( awk -F '/' '{ print $NF }' <<<'$(Build.SourceBranch)' | sed 's/^v//' )"
-        displayName: Set release version (stable)
-        condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/v')
-
       - task: Docker@2
         displayName: 'Push Unstable Image'
         condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/master')

--- a/.ci/azure-pipelines-build.yml
+++ b/.ci/azure-pipelines-build.yml
@@ -74,11 +74,3 @@ jobs:
           tags: |
             stable-$(Build.BuildNumber)-$(BuildConfiguration)
             $(Version)-$(BuildConfiguration)
-
-  - job: CollectArtifacts
-    timeoutInMinutes: 20
-    displayName: 'Collect Artifacts'
-    continueOnError: true
-    dependsOn:
-      - BuildDocker
-    condition: and(succeeded('Build), succeeded('BuildDocker'))

--- a/.ci/azure-pipelines-build.yml
+++ b/.ci/azure-pipelines-build.yml
@@ -49,7 +49,6 @@ jobs:
         displayName: Set release version (stable)
         condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/v')
 
-    steps:
       - task: Docker@2
         displayName: 'Push Unstable Image'
         condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/master')


### PR DESCRIPTION
What this PR should accomplish:
* Build unstable image after every commit to master
* Build stable image whenever we have a versioned git tag
* Images are built for amd64, armhf and arm64 architectures
* Push images to `jellyfin/jellyfin-vue` on docker hub

It's my first time doing azure ci (code originates from the jellyfin server ci configs with some changes by me) so this may not work as intended - comments are welcome.

An optimized approach could be to create the static files in their own job and not within the Dockerfile and to just copy them over into the different base images in the Dockerfile, but this would prevent users from easily building the image by building the Dockerfile.