### PR TITLE
Add docker manifests to CI to support multi-arch image tags

### DIFF
--- a/.ci/azure-pipelines-build.yml
+++ b/.ci/azure-pipelines-build.yml
@@ -59,18 +59,6 @@ jobs:
             unstable-$(BuildConfiguration)
 
       - task: Docker@2
-        displayName: 'Build and push PR Docker images'
-        condition: startsWith(variables['System.PullRequest.TargetBranch'], 'master')
-        inputs:
-          repository: 'jellyfin/jellyfin-vue'
-          command: buildAndPush
-          buildContext: '.'
-          Dockerfile: 'Dockerfile'
-          containerRegistry: Docker Hub
-          tags: |
-            pr-$(System.PullRequest.PullRequestId)-$(BuildConfiguration)
-
-      - task: Docker@2
         displayName: 'Build and push stable Docker images'
         condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/v')
         inputs:
@@ -116,28 +104,25 @@ jobs:
 
       - script: |
           docker manifest create \
-          jellyfin/jellyfin-vue:pr-$(System.PullRequest.PullRequestId) \
-          --amend jellyfin/jellyfin-vue:pr-$(System.PullRequest.PullRequestId)-armhf \
-          --amend jellyfin/jellyfin-vue:pr-$(System.PullRequest.PullRequestId)-amd64 \
-          --amend jellyfin/jellyfin-vue:pr-$(System.PullRequest.PullRequestId)-arm64
-        displayName: 'Build PR manifest'
-        condition: startsWith(variables['System.PullRequest.TargetBranch'], 'master')
-
-      - script: |
-          docker manifest push jellyfin/jellyfin-vue:$(Version)
-        displayName: 'Push PR manifest'
-        condition: startsWith(variables['System.PullRequest.TargetBranch'], 'master')
-
-      - script: |
-          docker manifest create \
           jellyfin/jellyfin-vue:$(Version) \
           --amend jellyfin/jellyfin-vue:$(Version)-armhf \
           --amend jellyfin/jellyfin-vue:$(Version)-amd64 \
           --amend jellyfin/jellyfin-vue:$(Version)-arm64
-        displayName: 'Build stable manifest'
+          docker manifest create \
+          jellyfin/jellyfin-vue:stable \
+          --amend jellyfin/jellyfin-vue:$(Version)-armhf \
+          --amend jellyfin/jellyfin-vue:$(Version)-amd64 \
+          --amend jellyfin/jellyfin-vue:$(Version)-arm64
+          jellyfin/jellyfin-vue:latest \
+          --amend jellyfin/jellyfin-vue:$(Version)-armhf \
+          --amend jellyfin/jellyfin-vue:$(Version)-amd64 \
+          --amend jellyfin/jellyfin-vue:$(Version)-arm64
+        displayName: 'Build stable manifests'
         condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/tags/v')
 
       - script: |
           docker manifest push jellyfin/jellyfin-vue:$(Version)
-        displayName: 'Push stable manifest'
+          docker manifest push jellyfin/jellyfin-vue:stable
+          docker manifest push jellyfin/jellyfin-vue:latest
+        displayName: 'Push stable manifests'
         condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/tags/v')

--- a/.ci/azure-pipelines-build.yml
+++ b/.ci/azure-pipelines-build.yml
@@ -26,7 +26,7 @@ jobs:
         displayName: 'Build'
 
   - job: BuildDocker
-    displayName: 'Build docker image'
+    displayName: 'Build Docker image'
 
     strategy:
       matrix:
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       - task: Docker@2
-        displayName: 'Build and push unstable docker image'
+        displayName: 'Build and push unstable Docker image'
         condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/master')
         inputs:
           repository: 'jellyfin/jellyfin-vue'
@@ -59,7 +59,7 @@ jobs:
             unstable-$(BuildConfiguration)
 
       - task: Docker@2
-        displayName: 'Build and push PR docker images'
+        displayName: 'Build and push PR Docker images'
         condition: startsWith(variables['System.PullRequest.TargetBranch'], 'refs/heads/master')
         inputs:
           repository: 'jellyfin/jellyfin-vue'
@@ -71,7 +71,7 @@ jobs:
             pr-$(System.PullRequest.PullRequestId)-$(BuildConfiguration)
 
       - task: Docker@2
-        displayName: 'Build and push stable docker images'
+        displayName: 'Build and push stable Docker images'
         condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/v')
         inputs:
           repository: 'jellyfin/jellyfin-vue'
@@ -84,7 +84,7 @@ jobs:
             $(Version)-$(BuildConfiguration)
 
   - job: PushManifests
-    displayName: 'Build and publish docker manifests'
+    displayName: 'Build and publish Docker manifests'
 
     pool:
       vmImage: 'ubuntu-latest'
@@ -106,12 +106,12 @@ jobs:
           --amend jellyfin/jellyfin-vue:unstable-armhf \
           --amend jellyfin/jellyfin-vue:unstable-amd64 \
           --amend jellyfin/jellyfin-vue:unstable-arm64
-        displayName: Build unstable manifest
+        displayName: 'Build unstable manifest'
         condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/master')
 
       - script: |
           docker manifest push jellyfin/jellyfin-vue:unstable
-        displayName: Push unstable manifest
+        displayName: 'Push unstable manifest'
         condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/master')
 
       - script: |
@@ -120,13 +120,13 @@ jobs:
           --amend jellyfin/jellyfin-vue:pr-$(System.PullRequest.PullRequestId)-armhf \
           --amend jellyfin/jellyfin-vue:pr-$(System.PullRequest.PullRequestId)-amd64 \
           --amend jellyfin/jellyfin-vue:pr-$(System.PullRequest.PullRequestId)-arm64
-      displayName: Build PR manifest
-      condition: startsWith(variables['System.PullRequest.TargetBranch'], 'refs/heads/master')
+        displayName: 'Build PR manifest'
+        condition: startsWith(variables['System.PullRequest.TargetBranch'], 'refs/heads/master')
 
       - script: |
-        docker manifest push jellyfin/jellyfin-vue:$(Version)
-      displayName: Push PR manifest
-      condition: startsWith(variables['System.PullRequest.TargetBranch'], 'refs/heads/master')
+          docker manifest push jellyfin/jellyfin-vue:$(Version)
+        displayName: 'Push PR manifest'
+        condition: startsWith(variables['System.PullRequest.TargetBranch'], 'refs/heads/master')
 
       - script: |
           docker manifest create \
@@ -134,10 +134,10 @@ jobs:
           --amend jellyfin/jellyfin-vue:$(Version)-armhf \
           --amend jellyfin/jellyfin-vue:$(Version)-amd64 \
           --amend jellyfin/jellyfin-vue:$(Version)-arm64
-        displayName: Build stable manifest
+        displayName: 'Build stable manifest'
         condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/tags/v')
 
       - script: |
           docker manifest push jellyfin/jellyfin-vue:$(Version)
-        displayName: Push stable manifest
+        displayName: 'Push stable manifest'
         condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/tags/v')

--- a/.ci/azure-pipelines-build.yml
+++ b/.ci/azure-pipelines-build.yml
@@ -26,96 +26,42 @@ jobs:
         displayName: 'Build'
 
   - job: BuildDocker
-    displayName: 'Build Docker Image'
-
-    strategy:
-      matrix:
-        amd64:
-          BuildConfiguration: amd64
-        arm64:
-          BuildConfiguration: arm64
-        armhf:
-          BuildConfiguration: armhf
+    displayName: 'Build Docker Images'
 
     pool:
       vmImage: 'ubuntu-latest'
 
     variables:
+      - DOCKER_CLI_EXPERIMENTAL: enabled
       - name: Version
         value: $[replace(variables['Build.SourceBranch'],'refs/tags/v','')]
 
     steps:
-      - task: Docker@2
+      - task: CmdLine@2
+        displayName: 'Register Qemu Binfmt and Docker Buildx Builder'
+        inputs:
+          script: |
+            docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+            docker buildx create --name builder
+            docker buildx use builder
+
+      - task: CmdLine@2
         displayName: 'Build and Push Unstable Docker Image'
         condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/master')
         inputs:
-          repository: 'jellyfin/jellyfin-vue'
-          command: buildAndPush
-          buildContext: '.'
-          Dockerfile: 'Dockerfile'
-          containerRegistry: Docker Hub
-          tags: |
-            unstable-$(Build.BuildNumber)-$(BuildConfiguration)
-            unstable-$(BuildConfiguration)
+          script: |
+            docker buildx build --no-cache --push \
+              --platform linux/arm,linux/arm64,linux/amd64 \
+              --tag jellyfin/jellyfin-vue:unstable-$(Build.BuildNumber) \
+              --tag jellyfin/jellyfin-vue:unstable
 
-      - task: Docker@2
+      - task: CmdLine@2
         displayName: 'Build and Push Stable Docker Image'
         condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/v')
         inputs:
-          repository: 'jellyfin/jellyfin-vue'
-          command: buildAndPush
-          buildContext: '.'
-          Dockerfile: 'Dockerfile'
-          containerRegistry: Docker Hub
-          tags: |
-            stable-$(Build.BuildNumber)-$(BuildConfiguration)
-            $(Version)-$(BuildConfiguration)
-
-  - job: PushManifests
-    displayName: 'Build and Publish Docker Manifests'
-
-    pool:
-      vmImage: 'ubuntu-latest'
-
-    variables:
-      DOCKER_CLI_EXPERIMENTAL: enabled
-
-    steps:
-      - script: |
-          docker manifest create \
-          jellyfin/jellyfin-vue:unstable \
-          --amend jellyfin/jellyfin-vue:unstable-armhf \
-          --amend jellyfin/jellyfin-vue:unstable-amd64 \
-          --amend jellyfin/jellyfin-vue:unstable-arm64
-        displayName: 'Build Unstable Manifest'
-        condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/master')
-
-      - script: |
-          docker manifest push jellyfin/jellyfin-vue:unstable
-        displayName: 'Push Unstable Manifest'
-        condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/master')
-
-      - script: |
-          docker manifest create \
-          jellyfin/jellyfin-vue:$(Version) \
-          --amend jellyfin/jellyfin-vue:$(Version)-armhf \
-          --amend jellyfin/jellyfin-vue:$(Version)-amd64 \
-          --amend jellyfin/jellyfin-vue:$(Version)-arm64
-          docker manifest create \
-          jellyfin/jellyfin-vue:stable \
-          --amend jellyfin/jellyfin-vue:$(Version)-armhf \
-          --amend jellyfin/jellyfin-vue:$(Version)-amd64 \
-          --amend jellyfin/jellyfin-vue:$(Version)-arm64
-          jellyfin/jellyfin-vue:latest \
-          --amend jellyfin/jellyfin-vue:$(Version)-armhf \
-          --amend jellyfin/jellyfin-vue:$(Version)-amd64 \
-          --amend jellyfin/jellyfin-vue:$(Version)-arm64
-        displayName: 'Build Stable Manifests'
-        condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/tags/v')
-
-      - script: |
-          docker manifest push jellyfin/jellyfin-vue:$(Version)
-          docker manifest push jellyfin/jellyfin-vue:stable
-          docker manifest push jellyfin/jellyfin-vue:latest
-        displayName: 'Push Stable Manifests'
-        condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/tags/v')
+          script: |
+            docker buildx build --no-cache --push \
+              --platform linux/arm,linux/arm64,linux/amd64 \
+              --tag jellyfin/jellyfin-vue:$(Version) \
+              --tag jellyfin/jellyfin-vue:stable \
+              --tag jellyfin/jellyfin-vue:latest

--- a/.ci/azure-pipelines-build.yml
+++ b/.ci/azure-pipelines-build.yml
@@ -47,6 +47,15 @@ jobs:
             docker buildx use builder
 
       - task: CmdLine@2
+        displayName: 'Build PR Docker Image'
+        condition: startsWith(variables['System.PullRequest.TargetBranch'], 'master')
+        inputs:
+          script: |
+            docker buildx build --no-cache \
+              --platform linux/arm,linux/arm64,linux/amd64 \
+              --tag pr-$(System.PullRequest.PullRequestId)
+
+      - task: CmdLine@2
         displayName: 'Build and Push Unstable Docker Image'
         condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/master')
         inputs:

--- a/.ci/azure-pipelines-build.yml
+++ b/.ci/azure-pipelines-build.yml
@@ -19,7 +19,7 @@ jobs:
           cacheHitVar: CACHE_RESTORED
 
       - script: 'yarn install --frozen-lockfile'
-        displayName: 'Install dependencies'
+        displayName: 'Install Dependencies'
         condition: ne(variables.CACHE_RESTORED, 'true')
 
       - script: 'yarn build'

--- a/.ci/azure-pipelines-build.yml
+++ b/.ci/azure-pipelines-build.yml
@@ -32,7 +32,8 @@ jobs:
       vmImage: 'ubuntu-latest'
 
     variables:
-      - DOCKER_CLI_EXPERIMENTAL: enabled
+      - name: DOCKER_CLI_EXPERIMENTAL:
+        value: 'enabled'
       - name: Version
         value: $[replace(variables['Build.SourceBranch'],'refs/tags/v','')]
 

--- a/.ci/azure-pipelines-build.yml
+++ b/.ci/azure-pipelines-build.yml
@@ -25,8 +25,16 @@ jobs:
       - script: 'yarn build'
         displayName: 'Build'
 
+      - task: PublishPipelineArtifact@1
+        displayName: 'Publish Generated Static Pages as Artifact'
+        inputs:
+          targetPath: $(System.DefaultWorkingDirectory)/dist
+          artifactName: dist
+
   - job: BuildDocker
     displayName: 'Build Docker Images'
+    dependsOn: Build
+    condition: succeeded()
 
     pool:
       vmImage: 'ubuntu-latest'
@@ -34,24 +42,31 @@ jobs:
     variables:
       - name: DOCKER_CLI_EXPERIMENTAL
         value: 'enabled'
+
       - name: Version
         value: $[replace(variables['Build.SourceBranch'],'refs/tags/v','')]
 
     steps:
+      - task: DownloadPipelineArtifact@2
+        displayName: 'Download Artifact from Build Job'
+        inputs:
+          source: current
+          artifact: dist
+          path: $(System.DefaultWorkingDirectory)/dist
+
       - task: CmdLine@2
         displayName: 'Register Qemu Binfmt and Docker Buildx Builder'
         inputs:
           script: |
             docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-            docker buildx create --name builder
-            docker buildx use builder
+            docker buildx create --use
 
       - task: CmdLine@2
         displayName: 'Build PR Docker Image'
         condition: startsWith(variables['System.PullRequest.TargetBranch'], 'master')
         inputs:
           script: |
-            docker buildx build --no-cache \
+            docker buildx build --file ./Dockerfile.dev --no-cache \
               --platform linux/arm,linux/arm64,linux/amd64 \
               --tag pr-$(System.PullRequest.PullRequestId) .
 
@@ -60,7 +75,7 @@ jobs:
         condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/master')
         inputs:
           script: |
-            docker buildx build --no-cache --push \
+            docker buildx build --file ./Dockerfile.dev --no-cache --push \
               --platform linux/arm,linux/arm64,linux/amd64 \
               --tag jellyfin/jellyfin-vue:unstable-$(Build.BuildNumber) \
               --tag jellyfin/jellyfin-vue:unstable .
@@ -70,7 +85,7 @@ jobs:
         condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/v')
         inputs:
           script: |
-            docker buildx build --no-cache --push \
+            docker buildx build --file ./Dockerfile.dev --no-cache --push \
               --platform linux/arm,linux/arm64,linux/amd64 \
               --tag jellyfin/jellyfin-vue:$(Version) \
               --tag jellyfin/jellyfin-vue:stable \

--- a/.ci/azure-pipelines-build.yml
+++ b/.ci/azure-pipelines-build.yml
@@ -7,26 +7,26 @@ jobs:
 
     steps:
       - task: NodeTool@0
-        displayName: 'Install Node'
+        displayName: 'Install node'
         inputs:
           versionSpec: '12.x'
 
       - task: Cache@2
-        displayName: 'Check Cache'
+        displayName: 'Check cache'
         inputs:
           key: 'yarn | yarn.lock'
           path: 'node_modules'
           cacheHitVar: CACHE_RESTORED
 
       - script: 'yarn install --frozen-lockfile'
-        displayName: 'Install Dependencies'
+        displayName: 'Install dependencies'
         condition: ne(variables.CACHE_RESTORED, 'true')
 
       - script: 'yarn build'
         displayName: 'Build'
 
   - job: BuildDocker
-    displayName: 'Build Docker'
+    displayName: 'Build docker images'
 
     strategy:
       matrix:
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       - task: Docker@2
-        displayName: 'Push Unstable Image'
+        displayName: 'Build and push unstable docker image'
         condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/master')
         inputs:
           repository: 'jellyfin/jellyfin-vue'
@@ -59,7 +59,7 @@ jobs:
             unstable-$(BuildConfiguration)
 
       - task: Docker@2
-        displayName: 'Push Stable Image'
+        displayName: 'Build and push stable docker images'
         condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/v')
         inputs:
           repository: 'jellyfin/jellyfin-vue'
@@ -70,3 +70,48 @@ jobs:
           tags: |
             stable-$(Build.BuildNumber)-$(BuildConfiguration)
             $(Version)-$(BuildConfiguration)
+
+  - job: PushManifests
+    displayName: 'Build and publish docker manifests'
+
+    pool:
+      vmImage: 'ubuntu-latest'
+
+    variables:
+      DOCKER_CLI_EXPERIMENTAL: enabled
+
+    steps:
+      - script: |
+          # sudo sed -i '$s/}/,\n"experimental": true\n}/' /etc/docker/daemon.json
+          echo '{"experimental": true}' | sudo tee /etc/docker/daemon.json
+          sudo systemctl restart docker
+          docker version
+        displayName: 'Enable experimental features in Docker server'
+
+      - script: |
+          docker manifest create \
+          jellyfin/jellyfin-vue:unstable \
+          --amend jellyfin/jellyfin-vue:unstable-armhf \
+          --amend jellyfin/jellyfin-vue:unstable-amd64 \
+          --amend jellyfin/jellyfin-vue:unstable-arm64
+        displayName: Build unstable manifest
+        condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/master')
+
+      - script: |
+          docker manifest push jellyfin/jellyfin-vue:unstable
+        displayName: Push unstable manifest
+        condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/master')
+
+      - script: |
+          docker manifest create \
+          jellyfin/jellyfin-vue:$(Version) \
+          --amend jellyfin/jellyfin-vue:$(Version)-armhf \
+          --amend jellyfin/jellyfin-vue:$(Version)-amd64 \
+          --amend jellyfin/jellyfin-vue:$(Version)-arm64
+        displayName: Build stable manifest
+        condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/tags/v')
+
+      - script: |
+          docker manifest push jellyfin/jellyfin-vue:$(Version)
+        displayName: Push stable manifest
+        condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/tags/v')

--- a/.ci/azure-pipelines-build.yml
+++ b/.ci/azure-pipelines-build.yml
@@ -115,11 +115,11 @@ jobs:
         condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/master')
 
       - script: |
-        docker manifest create \
-        jellyfin/jellyfin-vue:pr-$(System.PullRequest.PullRequestId) \
-        --amend jellyfin/jellyfin-vue:pr-$(System.PullRequest.PullRequestId)-armhf \
-        --amend jellyfin/jellyfin-vue:pr-$(System.PullRequest.PullRequestId)-amd64 \
-        --amend jellyfin/jellyfin-vue:pr-$(System.PullRequest.PullRequestId)-arm64
+          docker manifest create \
+          jellyfin/jellyfin-vue:pr-$(System.PullRequest.PullRequestId) \
+          --amend jellyfin/jellyfin-vue:pr-$(System.PullRequest.PullRequestId)-armhf \
+          --amend jellyfin/jellyfin-vue:pr-$(System.PullRequest.PullRequestId)-amd64 \
+          --amend jellyfin/jellyfin-vue:pr-$(System.PullRequest.PullRequestId)-arm64
       displayName: Build PR manifest
       condition: startsWith(variables['System.PullRequest.TargetBranch'], 'refs/heads/master')
 

--- a/.ci/azure-pipelines-build.yml
+++ b/.ci/azure-pipelines-build.yml
@@ -82,13 +82,6 @@ jobs:
 
     steps:
       - script: |
-          # sudo sed -i '$s/}/,\n"experimental": true\n}/' /etc/docker/daemon.json
-          echo '{"experimental": true}' | sudo tee /etc/docker/daemon.json
-          sudo systemctl restart docker
-          docker version
-        displayName: 'Enable Experimental Features in Docker Server'
-
-      - script: |
           docker manifest create \
           jellyfin/jellyfin-vue:unstable \
           --amend jellyfin/jellyfin-vue:unstable-armhf \

--- a/.ci/azure-pipelines-build.yml
+++ b/.ci/azure-pipelines-build.yml
@@ -26,7 +26,7 @@ jobs:
         displayName: 'Build'
 
   - job: BuildDocker
-    displayName: 'Build docker images'
+    displayName: 'Build docker image'
 
     strategy:
       matrix:
@@ -57,6 +57,18 @@ jobs:
           tags: |
             unstable-$(Build.BuildNumber)-$(BuildConfiguration)
             unstable-$(BuildConfiguration)
+
+      - task: Docker@2
+        displayName: 'Build and push PR docker images'
+        condition: startsWith(variables['System.PullRequest.TargetBranch'], 'refs/heads/master')
+        inputs:
+          repository: 'jellyfin/jellyfin-vue'
+          command: buildAndPush
+          buildContext: '.'
+          Dockerfile: 'Dockerfile'
+          containerRegistry: Docker Hub
+          tags: |
+            pr-$(System.PullRequest.PullRequestId)-$(BuildConfiguration)
 
       - task: Docker@2
         displayName: 'Build and push stable docker images'
@@ -101,6 +113,20 @@ jobs:
           docker manifest push jellyfin/jellyfin-vue:unstable
         displayName: Push unstable manifest
         condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/master')
+
+      - script: |
+        docker manifest create \
+        jellyfin/jellyfin-vue:pr-$(System.PullRequest.PullRequestId) \
+        --amend jellyfin/jellyfin-vue:pr-$(System.PullRequest.PullRequestId)-armhf \
+        --amend jellyfin/jellyfin-vue:pr-$(System.PullRequest.PullRequestId)-amd64 \
+        --amend jellyfin/jellyfin-vue:pr-$(System.PullRequest.PullRequestId)-arm64
+      displayName: Build PR manifest
+      condition: startsWith(variables['System.PullRequest.TargetBranch'], 'refs/heads/master')
+
+      - script: |
+        docker manifest push jellyfin/jellyfin-vue:$(Version)
+      displayName: Push PR manifest
+      condition: startsWith(variables['System.PullRequest.TargetBranch'], 'refs/heads/master')
 
       - script: |
           docker manifest create \

--- a/.ci/azure-pipelines-build.yml
+++ b/.ci/azure-pipelines-build.yml
@@ -32,7 +32,7 @@ jobs:
       vmImage: 'ubuntu-latest'
 
     variables:
-      - name: DOCKER_CLI_EXPERIMENTAL:
+      - name: DOCKER_CLI_EXPERIMENTAL
         value: 'enabled'
       - name: Version
         value: $[replace(variables['Build.SourceBranch'],'refs/tags/v','')]

--- a/.ci/azure-pipelines-build.yml
+++ b/.ci/azure-pipelines-build.yml
@@ -53,7 +53,7 @@ jobs:
           script: |
             docker buildx build --no-cache \
               --platform linux/arm,linux/arm64,linux/amd64 \
-              --tag pr-$(System.PullRequest.PullRequestId)
+              --tag pr-$(System.PullRequest.PullRequestId) .
 
       - task: CmdLine@2
         displayName: 'Build and Push Unstable Docker Image'
@@ -63,7 +63,7 @@ jobs:
             docker buildx build --no-cache --push \
               --platform linux/arm,linux/arm64,linux/amd64 \
               --tag jellyfin/jellyfin-vue:unstable-$(Build.BuildNumber) \
-              --tag jellyfin/jellyfin-vue:unstable
+              --tag jellyfin/jellyfin-vue:unstable .
 
       - task: CmdLine@2
         displayName: 'Build and Push Stable Docker Image'
@@ -74,4 +74,4 @@ jobs:
               --platform linux/arm,linux/arm64,linux/amd64 \
               --tag jellyfin/jellyfin-vue:$(Version) \
               --tag jellyfin/jellyfin-vue:stable \
-              --tag jellyfin/jellyfin-vue:latest
+              --tag jellyfin/jellyfin-vue:latest .

--- a/.ci/azure-pipelines-build.yml
+++ b/.ci/azure-pipelines-build.yml
@@ -7,12 +7,12 @@ jobs:
 
     steps:
       - task: NodeTool@0
-        displayName: 'Install node'
+        displayName: 'Install Node'
         inputs:
           versionSpec: '12.x'
 
       - task: Cache@2
-        displayName: 'Check cache'
+        displayName: 'Check Cache'
         inputs:
           key: 'yarn | yarn.lock'
           path: 'node_modules'
@@ -26,7 +26,7 @@ jobs:
         displayName: 'Build'
 
   - job: BuildDocker
-    displayName: 'Build Docker image'
+    displayName: 'Build Docker Image'
 
     strategy:
       matrix:
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       - task: Docker@2
-        displayName: 'Build and push unstable Docker image'
+        displayName: 'Build and Push Unstable Docker Image'
         condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/master')
         inputs:
           repository: 'jellyfin/jellyfin-vue'
@@ -59,7 +59,7 @@ jobs:
             unstable-$(BuildConfiguration)
 
       - task: Docker@2
-        displayName: 'Build and push stable Docker images'
+        displayName: 'Build and Push Stable Docker Image'
         condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/v')
         inputs:
           repository: 'jellyfin/jellyfin-vue'
@@ -72,7 +72,7 @@ jobs:
             $(Version)-$(BuildConfiguration)
 
   - job: PushManifests
-    displayName: 'Build and publish Docker manifests'
+    displayName: 'Build and Publish Docker Manifests'
 
     pool:
       vmImage: 'ubuntu-latest'
@@ -86,7 +86,7 @@ jobs:
           echo '{"experimental": true}' | sudo tee /etc/docker/daemon.json
           sudo systemctl restart docker
           docker version
-        displayName: 'Enable experimental features in Docker server'
+        displayName: 'Enable Experimental Features in Docker Server'
 
       - script: |
           docker manifest create \
@@ -94,12 +94,12 @@ jobs:
           --amend jellyfin/jellyfin-vue:unstable-armhf \
           --amend jellyfin/jellyfin-vue:unstable-amd64 \
           --amend jellyfin/jellyfin-vue:unstable-arm64
-        displayName: 'Build unstable manifest'
+        displayName: 'Build Unstable Manifest'
         condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/master')
 
       - script: |
           docker manifest push jellyfin/jellyfin-vue:unstable
-        displayName: 'Push unstable manifest'
+        displayName: 'Push Unstable Manifest'
         condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/master')
 
       - script: |
@@ -117,12 +117,12 @@ jobs:
           --amend jellyfin/jellyfin-vue:$(Version)-armhf \
           --amend jellyfin/jellyfin-vue:$(Version)-amd64 \
           --amend jellyfin/jellyfin-vue:$(Version)-arm64
-        displayName: 'Build stable manifests'
+        displayName: 'Build Stable Manifests'
         condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/tags/v')
 
       - script: |
           docker manifest push jellyfin/jellyfin-vue:$(Version)
           docker manifest push jellyfin/jellyfin-vue:stable
           docker manifest push jellyfin/jellyfin-vue:latest
-        displayName: 'Push stable manifests'
+        displayName: 'Push Stable Manifests'
         condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/tags/v')

--- a/.ci/azure-pipelines-build.yml
+++ b/.ci/azure-pipelines-build.yml
@@ -60,7 +60,7 @@ jobs:
 
       - task: Docker@2
         displayName: 'Build and push PR Docker images'
-        condition: startsWith(variables['System.PullRequest.TargetBranch'], 'refs/heads/master')
+        condition: startsWith(variables['System.PullRequest.TargetBranch'], 'master')
         inputs:
           repository: 'jellyfin/jellyfin-vue'
           command: buildAndPush
@@ -121,12 +121,12 @@ jobs:
           --amend jellyfin/jellyfin-vue:pr-$(System.PullRequest.PullRequestId)-amd64 \
           --amend jellyfin/jellyfin-vue:pr-$(System.PullRequest.PullRequestId)-arm64
         displayName: 'Build PR manifest'
-        condition: startsWith(variables['System.PullRequest.TargetBranch'], 'refs/heads/master')
+        condition: startsWith(variables['System.PullRequest.TargetBranch'], 'master')
 
       - script: |
           docker manifest push jellyfin/jellyfin-vue:$(Version)
         displayName: 'Push PR manifest'
-        condition: startsWith(variables['System.PullRequest.TargetBranch'], 'refs/heads/master')
+        condition: startsWith(variables['System.PullRequest.TargetBranch'], 'master')
 
       - script: |
           docker manifest create \

--- a/.ci/azure-pipelines-lint.yml
+++ b/.ci/azure-pipelines-lint.yml
@@ -1,29 +1,29 @@
 jobs:
   - job: Lint
-    displayName: "Lint"
+    displayName: 'Lint'
 
     pool:
-      vmImage: "ubuntu-latest"
+      vmImage: 'ubuntu-latest'
 
     steps:
       - task: NodeTool@0
-        displayName: "Install Node"
+        displayName: 'Install Node'
         inputs:
-          versionSpec: "12.x"
+          versionSpec: '12.x'
 
       - task: Cache@2
-        displayName: "Check Cache"
+        displayName: 'Check Cache'
         inputs:
-          key: "yarn | yarn.lock"
-          path: "node_modules"
+          key: 'yarn | yarn.lock'
+          path: 'node_modules'
           cacheHitVar: CACHE_RESTORED
 
-      - script: "yarn install --frozen-lockfile"
-        displayName: "Install Dependencies"
+      - script: 'yarn install --frozen-lockfile'
+        displayName: 'Install Dependencies'
         condition: ne(variables.CACHE_RESTORED, 'true')
 
-      - script: "yarn run lint:js"
-        displayName: "Run ESLint"
+      - script: 'yarn run lint:js'
+        displayName: 'Run ESLint'
 
-      - script: "yarn run lint:style"
-        displayName: "Run Stylelint"
+      - script: 'yarn run lint:style'
+        displayName: 'Run Stylelint'

--- a/.ci/azure-pipelines-test.yml
+++ b/.ci/azure-pipelines-test.yml
@@ -1,32 +1,32 @@
 jobs:
   - job: Test
-    displayName: "Test"
+    displayName: 'Test'
 
     pool:
-      vmImage: "ubuntu-latest"
+      vmImage: 'ubuntu-latest'
 
     steps:
       - task: NodeTool@0
-        displayName: "Install Node"
+        displayName: 'Install Node'
         inputs:
-          versionSpec: "12.x"
+          versionSpec: '12.x'
 
       - task: Cache@2
-        displayName: "Check Cache"
+        displayName: 'Check Cache'
         inputs:
-          key: "yarn | yarn.lock"
-          path: "node_modules"
+          key: 'yarn | yarn.lock'
+          path: 'node_modules'
           cacheHitVar: CACHE_RESTORED
 
-      - script: "yarn install --frozen-lockfile"
-        displayName: "Install Dependencies"
+      - script: 'yarn install --frozen-lockfile'
+        displayName: 'Install Dependencies'
         condition: ne(variables.CACHE_RESTORED, 'true')
 
-      - script: "yarn run test"
-        displayName: "Run Jest"
+      - script: 'yarn run test'
+        displayName: 'Run Jest'
 
       - task: PublishCodeCoverageResults@1
-        displayName: "Publish Coverage Results"
+        displayName: 'Publish Coverage Results'
         inputs:
           codeCoverageTool: Cobertura
           summaryFileLocation: $(System.DefaultWorkingDirectory)/coverage/cobertura-coverage.xml

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -1,14 +1,14 @@
 trigger:
   branches:
     include:
-      - "*"
+      - '*'
   tags:
     include:
-      - "*"
+      - '*'
 pr:
   branches:
     include:
-      - "*"
+      - '*'
 jobs:
   - template: azure-pipelines-lint.yml
   - template: azure-pipelines-test.yml

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 # Dockerfile
 Dockerfile
+Dockerfile.dev
 
 # Created by .ignore support plugin (hsz.mobi)
 ### Node template
@@ -70,9 +71,6 @@ typings/
 
 # nuxt.js build output
 .nuxt
-
-# Nuxt generate
-dist
 
 # vuepress build output
 .vuepress/dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:13-alpine AS build
+FROM node:12-alpine AS build
 
 # Install build dependencies for node modules
 RUN apk add git python make g++

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,4 @@
+FROM nginx:alpine
+COPY dist/ /usr/share/nginx/html/
+COPY .docker/nginx.conf /etc/nginx/conf.d/default.conf
+COPY .docker/mime.types /etc/nginx/mime.types


### PR DESCRIPTION
This changes should accomplish the following while CI builds (un)stable images:
* additionally push a manifest referring the latest builds:
  * `jellyfin/jellyfin-vue:unstable` should be multi-arch and always reference the latest unstable images
  * `jellyfin/jellyfin-vue:<version>` should be multi-arch and always reference the corresponding versioned images

Comments are welcome, I have no idea if this works as intended since I can't test it locally.

Based upon [this](https://gist.github.com/awesomebytes/16d0a5fcc4f368a43ac21e5cf3000034) and [this](https://github.com/vslepakov/iot-edge/blob/master/MultiArch/azure-pipelines.yml).