### PR TITLE
Another attempt on fixing the Docker CI

### DIFF
--- a/.ci/azure-pipelines-build.yml
+++ b/.ci/azure-pipelines-build.yml
@@ -54,13 +54,6 @@ jobs:
           artifact: dist
           path: $(System.DefaultWorkingDirectory)/dist
 
-      - task: CmdLine@2
-        displayName: 'Register Qemu Binfmt and Docker Buildx Builder'
-        inputs:
-          script: |
-            docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-            docker buildx create --use
-
       - task: Docker@2
         displayName: 'Login to Docker Hub'
         condition: or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'], 'refs/tags/v'))
@@ -69,10 +62,19 @@ jobs:
           containerRegistry: 'Docker Hub'
 
       - task: CmdLine@2
+        displayName: 'Register Qemu Binfmt and Docker Buildx Builder'
+        inputs:
+          script: |
+            docker version
+            docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+            docker buildx create --name builder --driver docker-container
+
+      - task: CmdLine@2
         displayName: 'Build PR Docker Image'
         condition: eq(variables['System.PullRequest.TargetBranch'], 'master')
         inputs:
           script: |
+            docker buildx use --builder builder
             docker buildx build --file ./Dockerfile.dev --no-cache \
               --platform linux/arm,linux/arm64,linux/amd64 \
               --tag pr-$(System.PullRequest.PullRequestId) .
@@ -82,6 +84,7 @@ jobs:
         condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
         inputs:
           script: |
+            docker buildx use --builder builder
             docker buildx build --file ./Dockerfile.dev --no-cache --push \
               --platform linux/arm,linux/arm64,linux/amd64 \
               --tag jellyfin/jellyfin-vue:unstable-$(Build.BuildNumber) \
@@ -92,6 +95,7 @@ jobs:
         condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/v')
         inputs:
           script: |
+            docker buildx use --builder builder
             docker buildx build --file ./Dockerfile.dev --no-cache --push \
               --platform linux/arm,linux/arm64,linux/amd64 \
               --tag jellyfin/jellyfin-vue:$(Version) \


### PR DESCRIPTION
Seems like the CI loses docker context between tasks and the wrong builder was used (even though the new one was set as default). Changes should make sure that the correct builder is used.

I'm not sure if this works since the PR CI seemed to use the correct driver (images built fine).