### PR TITLE
Various fixes and performance improvements

### DIFF
--- a/assets/global.scss
+++ b/assets/global.scss
@@ -18,3 +18,13 @@
   border-radius: 20px;
   border: 3px solid var(--v-track-base);
 }
+
+.cover-parent {
+  height: 100%;
+  width: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+}

--- a/components/BlurhashImage.vue
+++ b/components/BlurhashImage.vue
@@ -14,7 +14,7 @@
       :punch="punch"
       class="absolute"
     />
-    <LazyImage key="image" class="absolute blurhashImage" :src="image" />
+    <lazy-image key="image" class="absolute blurhashImage" :src="image" />
   </div>
 </template>
 

--- a/components/BlurhashImage.vue
+++ b/components/BlurhashImage.vue
@@ -1,5 +1,5 @@
 <template>
-  <div ref="card" class="absolute">
+  <div ref="card" class="cover-parent">
     <blurhash-canvas
       v-if="
         item.ImageBlurHashes &&
@@ -12,9 +12,9 @@
       :width="width"
       :height="height"
       :punch="punch"
-      class="absolute"
+      class="cover-parent"
     />
-    <lazy-image key="image" class="absolute blurhashImage" :src="image" />
+    <lazy-image key="image" class="cover-parent blurhashImage" :src="image" />
   </div>
 </template>
 
@@ -62,15 +62,6 @@ export default Vue.extend({
 </script>
 
 <style lang="scss" scoped>
-.absolute {
-  height: 100%;
-  width: 100%;
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-}
 .blurhashImage {
   background-position: center;
   background-size: cover;

--- a/components/BlurhashImage.vue
+++ b/components/BlurhashImage.vue
@@ -1,28 +1,25 @@
 <template>
   <div ref="card" class="absolute">
-    <transition-group mode="in-out" name="fade" class="absolute">
-      <blurhash-canvas
-        v-if="
-          item.ImageBlurHashes &&
-          item.ImageBlurHashes.Primary &&
-          item.ImageTags &&
-          item.ImageTags.Primary
-        "
-        key="canvas"
-        :hash="item.ImageBlurHashes.Primary[item.ImageTags.Primary]"
-        :width="width"
-        :height="height"
-        :punch="punch"
-        class="absolute"
-      />
-      <img
-        v-if="item.ImageTags && item.ImageTags.Primary"
-        key="image"
-        class="absolute"
-        :src="image"
-        v-bind="$attrs"
-      />
-    </transition-group>
+    <blurhash-canvas
+      v-if="
+        item.ImageBlurHashes &&
+        item.ImageBlurHashes.Primary &&
+        item.ImageTags &&
+        item.ImageTags.Primary
+      "
+      key="canvas"
+      :hash="item.ImageBlurHashes.Primary[item.ImageTags.Primary]"
+      :width="width"
+      :height="height"
+      :punch="punch"
+      class="absolute"
+    />
+    <LazyImage
+      key="image"
+      class="absolute blurhashImage"
+      :src="image"
+      :item="item"
+    />
   </div>
 </template>
 
@@ -69,7 +66,7 @@ export default Vue.extend({
 });
 </script>
 
-<style scoped>
+<style lang="scss" scoped>
 .absolute {
   height: 100%;
   width: 100%;
@@ -79,7 +76,8 @@ export default Vue.extend({
   right: 0;
   bottom: 0;
 }
-img {
-  object-fit: cover;
+.blurhashImage {
+  background-position: center;
+  background-size: cover;
 }
 </style>

--- a/components/BlurhashImage.vue
+++ b/components/BlurhashImage.vue
@@ -14,12 +14,7 @@
       :punch="punch"
       class="absolute"
     />
-    <LazyImage
-      key="image"
-      class="absolute blurhashImage"
-      :src="image"
-      :item="item"
-    />
+    <LazyImage key="image" class="absolute blurhashImage" :src="image" />
   </div>
 </template>
 

--- a/components/LazyCards.vue
+++ b/components/LazyCards.vue
@@ -1,0 +1,56 @@
+<template>
+  <div class="lazyScroll">
+    <card
+      :item="item"
+      :shape="shape"
+      :episode="episode"
+      :overlay="overlay"
+      :no-text="noText"
+      :no-margin="noMargin"
+    />
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import { BaseItemDto } from '~/api';
+
+export default Vue.extend({
+  props: {
+    item: {
+      type: Object as () => BaseItemDto,
+      required: true
+    },
+    shape: {
+      type: [String, Boolean],
+      default: () => {
+        return false;
+      }
+    },
+    episode: {
+      type: Boolean,
+      default: () => {
+        return false;
+      }
+    },
+    overlay: {
+      type: Boolean,
+      default: () => {
+        return true;
+      }
+    },
+    noText: {
+      type: Boolean,
+      default: () => {
+        return false;
+      }
+    },
+    noMargin: {
+      type: Boolean,
+      default: () => {
+        return false;
+      }
+    }
+  }
+});
+</script>

--- a/components/LazyImage.vue
+++ b/components/LazyImage.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :data-src="src" class="absolute lazyImage lazy-hidden" />
+  <div :data-src="src" class="cover-parent lazy-image lazy-hidden" />
 </template>
 
 <script lang="ts">
@@ -188,8 +188,8 @@ export default Vue.extend({
 });
 </script>
 
-<style lang="scss">
-.lazyImage {
+<style lang="scss" scoped>
+.lazy-image {
   background-position: center;
   background-size: cover;
   background-repeat: no-repeat;

--- a/components/LazyImage.vue
+++ b/components/LazyImage.vue
@@ -1,0 +1,107 @@
+<template>
+  <div :data-src="src" class="absolute lazyImage lazy-hidden" />
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+
+let observerInterface: IntersectionObserver;
+
+export default Vue.extend({
+  props: {
+    src: {
+      type: String,
+      default: ''
+    }
+  },
+  data() {
+    return {
+      observer: observerInterface,
+      intersected: false
+    };
+  },
+  mounted() {
+    this.observer = new IntersectionObserver(this.onIntersect, {
+      rootMargin: '25%'
+    });
+    this.observer.observe(this.$el);
+  },
+  destroyed() {
+    this.observer.disconnect();
+  },
+  methods: {
+    fillImageElement(elem: HTMLElement, url: string) {
+      const preloaderImg = new Image();
+      preloaderImg.src = url;
+
+      preloaderImg.addEventListener('load', () => {
+        requestAnimationFrame(() => {
+          elem.style.backgroundImage = "url('" + url + "')";
+          elem.removeAttribute('data-src');
+          elem.classList.remove('lazy-hidden');
+          elem.classList.add('lazy-image-fadein');
+        });
+      });
+    },
+    emptyImageElement(elem: HTMLElement) {
+      const url = elem.style.backgroundImage.slice(4, -1).replace(/"/g, '');
+      elem.style.backgroundImage = 'none';
+      elem.setAttribute('data-src', url);
+      elem.classList.remove('lazy-image-fadein');
+      elem.classList.add('lazy-hidden');
+    },
+    onIntersect(entryArray: Array<IntersectionObserverEntry>) {
+      for (const entry of entryArray) {
+        const target = entry.target as HTMLElement;
+        const isIntersecting = entry.isIntersecting;
+
+        if (target) {
+          const source = target.getAttribute('data-src');
+          if (!isIntersecting && !source) {
+            requestAnimationFrame(() => {
+              this.emptyImageElement(target);
+            });
+          } else if (source && isIntersecting) {
+            this.fillImageElement(target, source);
+          }
+        }
+      }
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.absolute {
+  height: 100%;
+  width: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+}
+.lazy-image {
+  background-position: center;
+  background-size: cover;
+}
+
+.lazy-image-fadein {
+  opacity: 1;
+  transition: opacity 0.15s;
+}
+
+.lazy-hidden {
+  opacity: 0;
+}
+
+@keyframes fadein {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+</style>

--- a/components/PersonList.vue
+++ b/components/PersonList.vue
@@ -8,7 +8,7 @@
         :to="`/person/${item.Id}`"
       >
         <v-list-item-avatar>
-          <LazyImage
+          <lazy-image
             v-if="item.PrimaryImageTag"
             :src="`${$axios.defaults.baseURL}/Items/${item.Id}/Images/Primary`"
           />

--- a/components/PersonList.vue
+++ b/components/PersonList.vue
@@ -8,7 +8,7 @@
         :to="`/person/${item.Id}`"
       >
         <v-list-item-avatar>
-          <v-img
+          <LazyImage
             v-if="item.PrimaryImageTag"
             :src="`${$axios.defaults.baseURL}/Items/${item.Id}/Images/Primary`"
           />

--- a/components/RelatedItems.vue
+++ b/components/RelatedItems.vue
@@ -44,7 +44,7 @@
             :to="`/item/${relatedItem.Id}`"
           >
             <v-list-item-avatar>
-              <LazyImage
+              <lazy-image
                 :src="`${$axios.defaults.baseURL}/Items/${relatedItem.Id}/Images/Primary`"
               />
             </v-list-item-avatar>

--- a/components/RelatedItems.vue
+++ b/components/RelatedItems.vue
@@ -44,7 +44,7 @@
             :to="`/item/${relatedItem.Id}`"
           >
             <v-list-item-avatar>
-              <v-img
+              <LazyImage
                 :src="`${$axios.defaults.baseURL}/Items/${relatedItem.Id}/Images/Primary`"
               />
             </v-list-item-avatar>

--- a/components/UserButton.vue
+++ b/components/UserButton.vue
@@ -2,18 +2,11 @@
   <v-menu offset-y>
     <template v-slot:activator="{ on, attrs }">
       <v-btn icon v-bind="attrs" v-on="on">
-        <v-avatar>
-          <v-img
-            v-if="userImage"
-            :src="userImage"
-            :alt="$auth.user.Name"
-          ></v-img>
-          <v-icon v-else dark>mdi-account</v-icon>
-        </v-avatar>
+        <UserImage />
       </v-btn>
     </template>
     <v-list>
-      <v-list-item @click="switchColodScheme">
+      <v-list-item @click="switchColorScheme">
         <v-switch>
           <template #label>Toggle dark mode</template>
         </v-switch>
@@ -48,21 +41,10 @@ export default Vue.extend({
       ]
     };
   },
-  computed: {
-    userImage: {
-      get() {
-        if (this.$auth.user?.PrimaryImageTag) {
-          return `${this.$axios.defaults.baseURL}/Users/${this.$auth.user.Id}/Images/Primary/?tag=${this.$auth.user.PrimaryImageTag}&maxWidth=36`;
-        } else {
-          return '';
-        }
-      }
-    }
-  },
   methods: {
     ...mapActions('user', ['setUser', 'clearUser']),
     ...mapActions('deviceProfile', ['clearDeviceProfile']),
-    switchColodScheme() {
+    switchColorScheme() {
       this.$vuetify.theme.dark = !this.$vuetify.theme.dark;
     },
     logoutUser() {

--- a/components/UserImage.vue
+++ b/components/UserImage.vue
@@ -1,6 +1,6 @@
 <template>
   <v-avatar>
-    <LazyImage v-if="userImage" :src="userImage" />
+    <lazy-image v-if="userImage" :src="userImage" />
     <v-icon v-else dark>mdi-account</v-icon>
   </v-avatar>
 </template>

--- a/components/UserImage.vue
+++ b/components/UserImage.vue
@@ -1,0 +1,24 @@
+<template>
+  <v-avatar>
+    <v-img v-if="userImage" :src="userImage" :alt="$auth.user.Name"></v-img>
+    <v-icon v-else dark>mdi-account</v-icon>
+  </v-avatar>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+
+export default Vue.extend({
+  computed: {
+    userImage: {
+      get() {
+        if (this.$auth.user?.PrimaryImageTag) {
+          return `${this.$axios.defaults.baseURL}/Users/${this.$auth.user.Id}/Images/Primary/?tag=${this.$auth.user.PrimaryImageTag}`;
+        } else {
+          return '';
+        }
+      }
+    }
+  }
+});
+</script>

--- a/components/UserImage.vue
+++ b/components/UserImage.vue
@@ -1,6 +1,6 @@
 <template>
   <v-avatar>
-    <v-img v-if="userImage" :src="userImage" :alt="$auth.user.Name"></v-img>
+    <LazyImage v-if="userImage" :src="userImage" />
     <v-icon v-else dark>mdi-account</v-icon>
   </v-avatar>
 </template>
@@ -13,7 +13,7 @@ export default Vue.extend({
     userImage: {
       get() {
         if (this.$auth.user?.PrimaryImageTag) {
-          return `${this.$axios.defaults.baseURL}/Users/${this.$auth.user.Id}/Images/Primary/?tag=${this.$auth.user.PrimaryImageTag}`;
+          return `${this.$axios.defaults.baseURL}/Users/${this.$auth.user.Id}/Images/Primary/?tag=${this.$auth.user.PrimaryImageTag}&quality=90`;
         } else {
           return '';
         }

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -7,16 +7,10 @@
       app
     >
       <template v-slot:prepend>
-        <div class="d-flex align-center full-width pa-6">
-          <v-avatar size="48" color="primary" class="mr-4">
-            <img
-              v-if="$auth.user.PrimaryImageTag"
-              :src="`${$axios.defaults.baseURL}/Users/${$auth.user.Id}/Images/Primary/?tag=${$auth.user.PrimaryImageTag}&maxWidth=64`"
-            />
-            <span v-else class="white--text">
-              {{ $auth.user.Name.charAt(0) }}
-            </span>
-          </v-avatar>
+        <div
+          class="d-flex align-center justify-content-space-evenly full-width pa-6"
+        >
+          <UserImage />
           <h1 class="font-weight-light">
             {{ $auth.user.Name }}
           </h1>
@@ -177,5 +171,10 @@ export default Vue.extend({
 
 .search-input {
   max-width: 15em;
+}
+</style>
+<style lang="scss">
+.justify-content-space-evenly {
+  justify-content: space-evenly;
 }
 </style>

--- a/mixins/imageHelper.ts
+++ b/mixins/imageHelper.ts
@@ -83,9 +83,9 @@ const imageHelper = Vue.extend({
         quality: 90
       };
       if (limitByWidth) {
-        params.maxWidth = element.clientWidth.toString();
+        params.maxWidth = Math.round(element.clientWidth * 1.7);
       } else {
-        params.maxHeight = element.clientHeight.toString();
+        params.maxHeight = Math.round(element.clientHeight * 1.7);
       }
       url.search = stringify(params);
 

--- a/pages/library/_viewId.vue
+++ b/pages/library/_viewId.vue
@@ -32,7 +32,7 @@
     </v-row>
     <v-row v-if="items.length">
       <v-col cols="12" class="card-grid-container">
-        <card v-for="item in items" :key="item.Id" :item="item" />
+        <lazy-cards v-for="item in items" :key="item.Id" :item="item" />
       </v-col>
     </v-row>
     <v-row v-else-if="loaded" justify="center">

--- a/pages/library/_viewId.vue
+++ b/pages/library/_viewId.vue
@@ -30,25 +30,11 @@
         <skeleton-card v-for="n in 24" :key="n" />
       </v-col>
     </v-row>
-    <dynamic-scroller
-      v-if="items.length"
-      class="scroller"
-      :items="itemsChunks"
-      :min-item-size="350"
-      :buffer="$vuetify.breakpoint.height * 1.5"
-      page-mode
-    >
-      <template v-slot="{ item, index, active }">
-        <dynamic-scroller-item
-          :item="item"
-          :active="active"
-          :data-index="index"
-          class="card-grid-container"
-        >
-          <card v-for="card of item.chunk" :key="card.Id" :item="card" />
-        </dynamic-scroller-item>
-      </template>
-    </dynamic-scroller>
+    <v-row v-if="items.length">
+      <v-col cols="12" class="card-grid-container">
+        <card v-for="item in items" :key="item.Id" :item="item" />
+      </v-col>
+    </v-row>
     <v-row v-else-if="loaded" justify="center">
       <v-col cols="12" class="card-grid-container empty-card-container">
         <skeleton-card v-for="n in 24" :key="n" boilerplate />

--- a/pages/library/_viewId.vue
+++ b/pages/library/_viewId.vue
@@ -117,6 +117,9 @@ export default Vue.extend({
     }
   },
   async beforeMount() {
+    this.$nextTick(() => {
+      this.$nuxt.$loading.start();
+    });
     try {
       const collectionInfo = await this.$api.items.getItems({
         uId: this.$auth.user.Id,
@@ -160,6 +163,7 @@ export default Vue.extend({
 
         if (itemsResponse.data) {
           this.loaded = true;
+          this.$nuxt.$loading.finish();
         }
 
         this.items = itemsResponse.data.Items || [];

--- a/pages/person/_itemId/index.vue
+++ b/pages/person/_itemId/index.vue
@@ -4,7 +4,7 @@
       <v-col cols="12">
         <v-row>
           <v-col cols="2">
-            <LazyImage
+            <lazy-image
               class="person-image elevation-2 ml-2"
               cover
               aspect-ratio="1"

--- a/pages/person/_itemId/index.vue
+++ b/pages/person/_itemId/index.vue
@@ -4,7 +4,7 @@
       <v-col cols="12">
         <v-row>
           <v-col cols="2">
-            <v-img
+            <LazyImage
               class="person-image elevation-2 ml-2"
               cover
               aspect-ratio="1"


### PR DESCRIPTION
### What's done

* Increased image resolution based on the values used in current web.

* ~~Unload images when they're outside the viewport to save memory, as it's done in the current web client. This is handled by a new ``LazyImage`` component that we're using everywhere now (instead of ``<img>`` and ``<v-img>``.)~~ (Moved to #408)

* Stop rendering and observing when scrolling is happening too fast. This is handled by a ``LazyCard`` component that wraps the ``Card one``. (First seconds unloading image behaviour appears, at the last is where the scrolling magic happens)

![fast_scroll](https://user-images.githubusercontent.com/10274099/99068943-ad2e6180-25ad-11eb-8d28-8133a73aa112.gif)

* ~~Fixed duplicated keys in ``PersonList`` component~~ (moved to #366)

* Fixed images overlapping in the ``PersonList`` component.

* ~~Created ``UserImage`` component (before, we had two images, one for the top bar and one for the sidebar). The profile photo will be fetched in full resolution, so browser doesn't need to cache two versions of the same image and we can still reuse the component once we have a "Profile" page or something like that, where the image size will likely be much bigger.~~  (Moved to #407)

* ~~Transitions between layouts and routes (moved to #352)~~
![page_switching](https://user-images.githubusercontent.com/10274099/99069260-4c535900-25ae-11eb-8f4d-aab75c14d4d2.gif)

* Minor refactor in library, card component and UserButton.

* Removed virtual scroller, as it was causing issues with IntersectionObserver.

* ~~Reorganised components~~ (moved to #353)

### Performance improvements

**My branch**

![new_performance](https://user-images.githubusercontent.com/10274099/99069447-a9e7a580-25ae-11eb-81f6-8d71b4808f92.png)

**HEAD at 5b24f57 (without the virtual scroller, to be in equality)**

![old_performance](https://user-images.githubusercontent.com/10274099/99069453-aa803c00-25ae-11eb-9357-3605db94353e.png)

Although the effects and scrolling detection required some scripting, my branch seems to perform much better than current master. And it still might be improved (**see below**). Paint and representation times grew up a little bit due to the CSS effects (which seems to be much faster than the Vue's transitions in this situation). However, the **blocked time** difference between my branch and the tested master is around **1 second** less in my branch.

### To Do & discuss

* **Keep trying measuring the scroll speed using the LazyImage's Intersectionobserver**: The ``scroll`` event handler runs in the main JS thread, unlike the IntersectionObserver. I tried to measure the scroll delta using the Intersection's Observer's callbacks for an entire day, but I wasn't really happy with the results, they were not that reliable and results (seemingly) depended too much in the client's resulotion.

I wanted to have this PR out relatively fast as soon I might not have as much free time as this week and I wanted to discuss hereabout approaches and best practices of everything I've done, so I decided to leave it with ``scroll`` event handler for now. Probably, with a few more days of fine tuning and testing, we can get a reliable implementation working. 

However, the current one actually surprised me, as it doesn't seem to be really heavy. Heavier than IntersectionObserver but nothing to worry about. In reality, **most of the scripting time was taken by the Vuetify's components used, something they hopefully solve for v3**. **Any idea in how I can measure scroll speed better than mine is welcome!**

* **Refactor the scroll speed detection & "hide on fast scroll" logic**:  Same as above, I wanted to get this up quickly and I was not that sure on how this can be implemented in amore elegant way. The scroll measure speed should go into its own plugin probably and somehow we want the ``isScrollingFast`` inside Vue (and not only inside ``window``), so Vue can react itself to the changes. **The current ``getElementByClassName`` method must go away**.

* Custom virtual scroller: While working on this, I got more convinced that we need a custom DOM recycling approach. Although switching from **DynamicScroller** to **RecycleScroller** might have better performance, I think we can squeeze it much more. [This has it's own discussion here](https://github.com/jellyfin/jellyfin-vue/discussions/274)

* Tailor even more the resolution detection logic for the images.