### PR TITLE
build(nuxt): add custom logo and colors to nuxt loading screen

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
 import type { NuxtConfig } from '@nuxt/types';
 
 const config: NuxtConfig = {
@@ -197,6 +198,14 @@ const config: NuxtConfig = {
    ** See https://nuxtjs.org/api/configuration-build/
    */
   build: {
+    // @ts-ignore -- Undocumented options
+    loadingScreen: {
+      image: 'icon.png',
+      colors: {
+        client: '#00A4DC',
+        modern: '#424242'
+      }
+    },
     babel: {
       // envName: server, client, modern
       presets() {


### PR DESCRIPTION
Adds a custom logo and colors to the Nuxt loading screen (Note: These options are somewhat undocumented, currently)

![image](https://user-images.githubusercontent.com/19396809/99297614-cacb2780-2848-11eb-83b9-32e04a4588fc.png)
