### PR TITLE
refactor(navigation): rework navigation sidebar

### DIFF
--- a/components/UserButton.vue
+++ b/components/UserButton.vue
@@ -1,23 +1,26 @@
 <template>
   <v-menu offset-y>
     <template #activator="{ on, attrs }">
-      <v-btn icon v-bind="attrs" v-on="on">
-        <v-avatar>
-          <v-img
-            v-if="userImage"
-            :src="userImage"
-            :alt="$auth.user.Name"
-          ></v-img>
-          <v-icon v-else dark>mdi-account</v-icon>
-        </v-avatar>
-      </v-btn>
+      <div class="d-flex" v-bind="attrs" v-on="on">
+        <div class="mr-4">
+          <v-btn icon>
+            <v-avatar>
+              <v-img
+                v-if="userImage"
+                :src="userImage"
+                :alt="$auth.user.Name"
+              ></v-img>
+              <v-icon v-else dark>mdi-account</v-icon>
+            </v-avatar>
+          </v-btn>
+        </div>
+        <h1 class="font-weight-light">
+          {{ $auth.user.Name }}
+          <v-icon>mdi-chevron-down</v-icon>
+        </h1>
+      </div>
     </template>
-    <v-list>
-      <v-list-item @click="switchColodScheme">
-        <v-switch>
-          <template #label>Toggle dark mode</template>
-        </v-switch>
-      </v-list-item>
+    <v-list dense>
       <v-list-item
         v-for="(item, index) in menuItems"
         :key="index"
@@ -62,9 +65,6 @@ export default Vue.extend({
   methods: {
     ...mapActions('user', ['setUser', 'clearUser']),
     ...mapActions('deviceProfile', ['clearDeviceProfile']),
-    switchColodScheme() {
-      this.$vuetify.theme.dark = !this.$vuetify.theme.dark;
-    },
     logoutUser() {
       this.$auth.logout();
       this.clearDeviceProfile();

--- a/components/UserButton.vue
+++ b/components/UserButton.vue
@@ -1,20 +1,16 @@
 <template>
   <v-menu offset-y>
     <template #activator="{ on, attrs }">
-      <div class="d-flex" v-bind="attrs" v-on="on">
-        <div class="mr-4">
-          <v-btn icon>
-            <v-avatar>
-              <v-img
-                v-if="userImage"
-                :src="userImage"
-                :alt="$auth.user.Name"
-              ></v-img>
-              <v-icon v-else dark>mdi-account</v-icon>
-            </v-avatar>
-          </v-btn>
-        </div>
-        <h1 class="font-weight-light">
+      <div class="d-flex align-center" v-bind="attrs" v-on="on">
+        <v-avatar size="48" color="primary" class="mr-4">
+          <v-img
+            v-if="userImage"
+            :src="userImage"
+            :alt="$auth.user.Name"
+          ></v-img>
+          <v-icon v-else dark>mdi-account</v-icon>
+        </v-avatar>
+        <h1 class="font-weight-light pb-1">
           {{ $auth.user.Name }}
           <v-icon>mdi-chevron-down</v-icon>
         </h1>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -8,18 +8,7 @@
     >
       <template #prepend>
         <div class="d-flex align-center full-width pa-6">
-          <v-avatar size="48" color="primary" class="mr-4">
-            <img
-              v-if="$auth.user.PrimaryImageTag"
-              :src="`${$axios.defaults.baseURL}/Users/${$auth.user.Id}/Images/Primary/?tag=${$auth.user.PrimaryImageTag}&maxWidth=64`"
-            />
-            <span v-else class="white--text">
-              {{ $auth.user.Name.charAt(0) }}
-            </span>
-          </v-avatar>
-          <h1 class="font-weight-light">
-            {{ $auth.user.Name }}
-          </h1>
+          <user-button />
           <connection-monitor class="ml-auto" />
         </div>
         <v-divider></v-divider>
@@ -39,9 +28,7 @@
             <v-list-item-title v-text="item.title" />
           </v-list-item-content>
         </v-list-item>
-      </v-list>
-      <v-divider v-if="libraries.length > 0"></v-divider>
-      <v-list>
+        <v-subheader>{{ $t('libraries') }}</v-subheader>
         <v-list-item
           v-for="(library, i) in libraries"
           :key="i"
@@ -57,23 +44,29 @@
           </v-list-item-content>
         </v-list-item>
       </v-list>
-      <v-divider></v-divider>
-      <v-list>
-        <v-list-item
-          v-for="(item, i) in configItems"
-          :key="i"
-          :to="item.to"
-          router
-          exact
-        >
-          <v-list-item-action>
-            <v-icon>{{ item.icon }}</v-icon>
-          </v-list-item-action>
-          <v-list-item-content>
-            <v-list-item-title v-text="item.title" />
-          </v-list-item-content>
-        </v-list-item>
-      </v-list>
+      <template #append>
+        <v-list>
+          <v-list-item @click="$vuetify.theme.dark = !$vuetify.theme.dark">
+            <v-switch>
+              <template #label>Toggle dark mode</template>
+            </v-switch>
+          </v-list-item>
+          <v-list-item
+            v-for="(item, i) in configItems"
+            :key="i"
+            :to="item.to"
+            router
+            exact
+          >
+            <v-list-item-action>
+              <v-icon>{{ item.icon }}</v-icon>
+            </v-list-item-action>
+            <v-list-item-content>
+              <v-list-item-title v-text="item.title" />
+            </v-list-item-content>
+          </v-list-item>
+        </v-list>
+      </template>
     </v-navigation-drawer>
     <v-app-bar
       :clipped-left="$vuetify.breakpoint.mobile"
@@ -108,7 +101,6 @@
       />
       <v-spacer />
       <locale-switcher class="mr-2" />
-      <user-button v-if="$auth.loggedIn" />
     </v-app-bar>
     <v-main>
       <nuxt />

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -46,8 +46,8 @@
       </v-list>
       <template #append>
         <v-list>
-          <v-list-item @click="$vuetify.theme.dark = !$vuetify.theme.dark">
-            <v-switch>
+          <v-list-item>
+            <v-switch v-model="$vuetify.theme.dark">
               <template #label>Toggle dark mode</template>
             </v-switch>
           </v-list-item>

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -17,6 +17,7 @@
   "home": "Home",
   "incorrectUsernameOrPassword": "Incorrect username or password",
   "itemNotFound": "Item not found",
+  "libraries": "Libraries",
   "libraryEmpty": "This library is empty",
   "libraryNotFound": "Library not found",
   "login": "Login",


### PR DESCRIPTION
Reworks the navigation drawer a bit to look nicer and removes the duplicate user icon (Note: The screenshots were taken before adding the translation key for the header).

![Screenshot_2020-11-29 jellyfin-vue](https://user-images.githubusercontent.com/19396809/100540237-5b880700-323c-11eb-8c05-b9a4e0e3fdd7.png) ![Screenshot_2020-11-29 jellyfin-vue(1)](https://user-images.githubusercontent.com/19396809/100540238-5cb93400-323c-11eb-8138-9740d2458fb6.png) ![Screenshot_2020-11-29 jellyfin-vue(2)](https://user-images.githubusercontent.com/19396809/100540240-5dea6100-323c-11eb-845b-ee0320498234.png)

Edit: Added a chevron next to the user name, to indicate the menu
![image](https://user-images.githubusercontent.com/19396809/100541492-97bf6580-3244-11eb-84ce-1fc5e07acd85.png)
