### PR TITLE
fix(_viewid): do not show item count while loading items

### DIFF
--- a/pages/library/_viewId.vue
+++ b/pages/library/_viewId.vue
@@ -4,7 +4,9 @@
       <span class="text-h6 hidden-sm-and-down">
         {{ collectionInfo.Name }}
       </span>
-      <v-chip small class="ma-2 hidden-sm-and-down">{{ itemsCount }}</v-chip>
+      <v-chip v-if="!loading" small class="ma-2 hidden-sm-and-down">
+        {{ itemsCount }}
+      </v-chip>
       <v-divider inset vertical class="mx-2 hidden-sm-and-down" />
       <type-button
         v-if="collectionInfo.CollectionType"


### PR DESCRIPTION
Since there is a `skeleton-card` displaying empty place holders while the data is being loaded, removing the `0` item count is less confusing.

It will be shown once the loading is complete - and show `0` only when needed.

![image](https://user-images.githubusercontent.com/11581433/100751361-366ad400-33b5-11eb-9cad-1a9e339e191a.png)
