### PR TITLE
feat(validation): support for vee-validate

### DIFF
--- a/components/AddServerForm.vue
+++ b/components/AddServerForm.vue
@@ -40,13 +40,8 @@
 <script lang="ts">
 import Vue from 'vue';
 import { mapActions } from 'vuex';
-import { ValidationObserver, ValidationProvider } from 'vee-validate';
 
 export default Vue.extend({
-  components: {
-    ValidationObserver,
-    ValidationProvider
-  },
   data() {
     return {
       serverUrl: '',

--- a/components/AddServerForm.vue
+++ b/components/AddServerForm.vue
@@ -6,14 +6,20 @@
       :disabled="loading"
       @submit.prevent="connectToServer"
     >
-      <v-text-field
-        v-model="serverUrl"
-        outlined
-        :label="$t('serverAddress')"
-        type="url"
-        :rules="rules.serverUrlTest"
-        required
-      ></v-text-field>
+      <validation-provider
+        v-slot="{ errors }"
+        name="serverUrl"
+        :rules="rules.serverUrl"
+      >
+        <v-text-field
+          v-model="serverUrl"
+          outlined
+          :label="$t('serverAddress')"
+          type="url"
+          :error-messages="errors"
+          required
+        ></v-text-field>
+      </validation-provider>
       <v-row align="center" no-gutters>
         <v-col class="mr-2">
           <v-btn
@@ -37,20 +43,30 @@
 <script lang="ts">
 import Vue from 'vue';
 import { mapActions } from 'vuex';
+import { ValidationProvider } from 'vee-validate';
 
 export default Vue.extend({
+  components: {
+    ValidationProvider
+  },
   data() {
     return {
       serverUrl: '',
       validInputs: false,
       loading: false,
       rules: {
-        serverUrlTest: [
-          (v: string) => !!v || this.$t('serverAddressRequired'),
-          (v: string) =>
-            /^https?:\/\/.+/.test(v) || this.$t('serverAddressMustBeUrl')
-        ]
+        serverUrl: {
+          required: true,
+          mustBeUrl: true
+        }
       }
+      // rules: {
+      //   serverUrlTest: [
+      //     (v: string) => !!v || this.$t('serverAddressRequired'),
+      //     (v: string) =>
+      //       /^https?:\/\/.+/.test(v) || this.$t('serverAddressMustBeUrl')
+      //   ]
+      // }
     };
   },
   methods: {

--- a/components/AddServerForm.vue
+++ b/components/AddServerForm.vue
@@ -1,58 +1,55 @@
 <template>
   <div>
-    <v-form
-      ref="form"
-      v-model="validInputs"
-      :disabled="loading"
-      @submit.prevent="connectToServer"
-    >
-      <validation-provider
-        v-slot="{ errors }"
-        name="serverUrl"
-        :rules="rules.serverUrl"
-      >
-        <v-text-field
-          v-model="serverUrl"
-          outlined
-          :label="$t('serverAddress')"
-          type="url"
-          :error-messages="errors"
-          required
-        ></v-text-field>
-      </validation-provider>
-      <v-row align="center" no-gutters>
-        <v-col class="mr-2">
-          <v-btn
-            :disabled="!validInputs"
-            :loading="loading"
-            block
-            large
-            color="primary"
-            type="submit"
-            >{{ $t('connect') }}</v-btn
-          >
-        </v-col>
-        <v-col cols="auto">
-          <locale-switcher />
-        </v-col>
-      </v-row>
-    </v-form>
+    <validation-observer v-slot="{ invalid }">
+      <v-form ref="form" :disabled="loading" @submit.prevent="connectToServer">
+        <validation-provider
+          v-slot="{ errors }"
+          name="serverUrl"
+          :rules="rules.serverUrl"
+        >
+          <v-text-field
+            v-model="serverUrl"
+            outlined
+            :label="$t('serverAddress')"
+            type="url"
+            :error-messages="errors"
+            required
+          ></v-text-field>
+        </validation-provider>
+        <v-row align="center" no-gutters>
+          <v-col class="mr-2">
+            <v-btn
+              :disabled="invalid"
+              :loading="loading"
+              block
+              large
+              color="primary"
+              type="submit"
+              >{{ $t('connect') }}</v-btn
+            >
+          </v-col>
+          <v-col cols="auto">
+            <locale-switcher />
+          </v-col>
+        </v-row>
+      </v-form>
+    </validation-observer>
   </div>
 </template>
 
 <script lang="ts">
 import Vue from 'vue';
 import { mapActions } from 'vuex';
-import { ValidationProvider } from 'vee-validate';
+import { ValidationObserver, ValidationProvider } from 'vee-validate';
 
 export default Vue.extend({
   components: {
+    ValidationObserver,
     ValidationProvider
   },
   data() {
     return {
       serverUrl: '',
-      validInputs: false,
       loading: false,
       rules: {
         serverUrl: {
@@ -60,13 +57,6 @@ export default Vue.extend({
           mustBeUrl: true
         }
       }
-      // rules: {
-      //   serverUrlTest: [
-      //     (v: string) => !!v || this.$t('serverAddressRequired'),
-      //     (v: string) =>
-      //       /^https?:\/\/.+/.test(v) || this.$t('serverAddressMustBeUrl')
-      //   ]
-      // }
     };
   },
   methods: {

--- a/components/LoginForm.vue
+++ b/components/LoginForm.vue
@@ -6,14 +6,26 @@
       :disabled="loading"
       @submit.prevent="userLogin"
     >
-      <v-text-field
-        v-if="isEmpty(user)"
+      <validation-provider
+        v-slot="{ errors }"
+        name="login.username"
+        :rules="rules.username"
+      >
+        <v-text-field
+          v-if="isEmpty(user)"
+          v-model="login.username"
+          outlined
+          :label="$t('username')"
+          :error-messages="errors"
+        ></v-text-field>
+      </validation-provider>
+      <!-- <v-text-field
         v-model="login.username"
         outlined
         :label="$t('username')"
         :rules="[(v) => !!v || $t('usernameRequired')]"
         required
-      ></v-text-field>
+      ></v-text-field> -->
       <v-text-field
         v-model="login.password"
         outlined
@@ -54,9 +66,13 @@
 import { isEmpty } from 'lodash';
 import Vue from 'vue';
 import { mapActions } from 'vuex';
+import { ValidationProvider } from 'vee-validate';
 import { UserDto } from '~/api';
 
 export default Vue.extend({
+  components: {
+    ValidationProvider
+  },
   props: {
     user: {
       type: Object as () => UserDto,
@@ -73,7 +89,12 @@ export default Vue.extend({
       },
       showPassword: false,
       validInputs: false,
-      loading: false
+      loading: false,
+      rules: {
+        username: {
+          required: true
+        }
+      }
     };
   },
   methods: {
@@ -85,6 +106,7 @@ export default Vue.extend({
         // If we have a user from the public user selector, set it as login
         this.login.username = this.user.Name || '';
       }
+
       this.loading = true;
       this.setDeviceProfile();
       await this.loginRequest(this.login);

--- a/components/LoginForm.vue
+++ b/components/LoginForm.vue
@@ -56,14 +56,9 @@
 import { isEmpty } from 'lodash';
 import Vue from 'vue';
 import { mapActions } from 'vuex';
-import { ValidationObserver, ValidationProvider } from 'vee-validate';
 import { UserDto } from '~/api';
 
 export default Vue.extend({
-  components: {
-    ValidationObserver,
-    ValidationProvider
-  },
   props: {
     user: {
       type: Object as () => UserDto,

--- a/components/LoginForm.vue
+++ b/components/LoginForm.vue
@@ -1,64 +1,54 @@
 <template>
   <div>
-    <v-form
-      ref="form"
-      v-model="validInputs"
-      :disabled="loading"
-      @submit.prevent="userLogin"
-    >
-      <validation-provider
-        v-slot="{ errors }"
-        name="login.username"
-        :rules="rules.username"
-      >
+    <validation-observer v-slot="{ invalid }">
+      <v-form ref="form" :disabled="loading" @submit.prevent="userLogin">
+        <validation-provider
+          v-slot="{ errors }"
+          name="username"
+          :rules="rules.username"
+        >
+          <v-text-field
+            v-if="isEmpty(user)"
+            v-model="login.username"
+            outlined
+            :label="$t('username')"
+            :error-messages="errors"
+          ></v-text-field>
+        </validation-provider>
         <v-text-field
-          v-if="isEmpty(user)"
-          v-model="login.username"
+          v-model="login.password"
           outlined
-          :label="$t('username')"
-          :error-messages="errors"
+          :label="$t('password')"
+          :append-icon="showPassword ? 'mdi-eye-off' : 'mdi-eye'"
+          :type="showPassword ? 'text' : 'password'"
+          @click:append="() => (showPassword = !showPassword)"
         ></v-text-field>
-      </validation-provider>
-      <!-- <v-text-field
-        v-model="login.username"
-        outlined
-        :label="$t('username')"
-        :rules="[(v) => !!v || $t('usernameRequired')]"
-        required
-      ></v-text-field> -->
-      <v-text-field
-        v-model="login.password"
-        outlined
-        :label="$t('password')"
-        :append-icon="showPassword ? 'mdi-eye-off' : 'mdi-eye'"
-        :type="showPassword ? 'text' : 'password'"
-        @click:append="() => (showPassword = !showPassword)"
-      ></v-text-field>
-      <v-row align="center" no-gutters>
-        <v-col class="mr-2">
-          <v-btn v-if="isEmpty(user)" to="/selectServer" nuxt block large>
-            {{ $t('changeServer') }}
-          </v-btn>
-          <v-btn v-else block large @click="$emit('change')">
-            {{ $t('changeUser') }}
-          </v-btn>
-        </v-col>
-        <v-col class="mr-2">
-          <v-btn
-            :disabled="!validInputs"
-            :loading="loading"
-            block
-            large
-            color="primary"
-            type="submit"
-            >{{ $t('signIn') }}</v-btn
-          >
-        </v-col>
-        <v-col cols="auto">
-          <locale-switcher />
-        </v-col>
-      </v-row>
-    </v-form>
+        <v-row align="center" no-gutters>
+          <v-col class="mr-2">
+            <v-btn v-if="isEmpty(user)" to="/selectServer" nuxt block large>
+              {{ $t('changeServer') }}
+            </v-btn>
+            <v-btn v-else block large @click="$emit('change')">
+              {{ $t('changeUser') }}
+            </v-btn>
+          </v-col>
+          <v-col class="mr-2">
+            <v-btn
+              :disabled="invalid"
+              :loading="loading"
+              block
+              large
+              color="primary"
+              type="submit"
+              >{{ $t('signIn') }}</v-btn
+            >
+          </v-col>
+          <v-col cols="auto">
+            <locale-switcher />
+          </v-col>
+        </v-row>
+      </v-form>
+    </validation-observer>
   </div>
 </template>
 
@@ -66,11 +56,12 @@
 import { isEmpty } from 'lodash';
 import Vue from 'vue';
 import { mapActions } from 'vuex';
-import { ValidationProvider } from 'vee-validate';
+import { ValidationObserver, ValidationProvider } from 'vee-validate';
 import { UserDto } from '~/api';
 
 export default Vue.extend({
   components: {
+    ValidationObserver,
     ValidationProvider
   },
   props: {
@@ -88,7 +79,6 @@ export default Vue.extend({
         password: ''
       },
       showPassword: false,
-      validInputs: false,
       loading: false,
       rules: {
         username: {

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -58,7 +58,7 @@
   "series": "Series",
   "selectUser": "Select a user",
   "serverAddress": "Server address",
-  "serverAddressMustBeUrl": "Server address must be a valid URL",
+  "serverAddressMustBeUrl": "Server address must be a valid address",
   "serverAddressRequired": "Server address is required",
   "serverNotFound": "Server not found",
   "serverVersionTooLow": "Server version needs to be 10.7.0 or higher",
@@ -82,6 +82,10 @@
   "upNext": "Up next",
   "username": "Username",
   "usernameRequired": "Username is required",
+  "validation": {
+    "required": "This field is required",
+    "mustBeUrl": "This field must be a valid URL"
+  },
   "videoTypes": "Video Types",
   "years": "Years",
   "youMayAlsoLike": "You may also like"

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -60,6 +60,7 @@ const config: NuxtConfig = {
   plugins: [
     // General
     'plugins/appInitPlugin.ts',
+    'plugins/veeValidate.ts',
     // Components
     'plugins/components/vueperSlides.ts',
     'plugins/components/vueVirtualScroller.ts',
@@ -225,7 +226,7 @@ const config: NuxtConfig = {
         ];
       }
     },
-    transpile: ['@nuxtjs/auth']
+    transpile: ['@nuxtjs/auth', 'vee-validate/dist/rules']
   },
 
   /**

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -64,6 +64,7 @@ const config: NuxtConfig = {
     // Components
     'plugins/components/vueperSlides.ts',
     'plugins/components/vueVirtualScroller.ts',
+    'plugins/components/veeValidate.ts',
     // Utility
     'plugins/browserDetection.ts',
     'plugins/playbackProfile.ts',

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "qs": "^6.9.4",
     "shaka-player": "^3.0.6",
     "uuid": "^8.3.1",
+    "vee-validate": "^3.4.5",
     "vue-virtual-scroller": "^1.0.10",
     "vueperslides": "^2.12.1"
   },

--- a/plugins/components/veeValidate.ts
+++ b/plugins/components/veeValidate.ts
@@ -1,0 +1,5 @@
+import Vue from 'vue';
+import { ValidationProvider, ValidationObserver } from 'vee-validate';
+
+Vue.component('ValidationProvider', ValidationProvider);
+Vue.component('ValidationObserver', ValidationObserver);

--- a/plugins/veeValidate.ts
+++ b/plugins/veeValidate.ts
@@ -3,28 +3,20 @@ import { configure, extend } from 'vee-validate';
 import { required } from 'vee-validate/dist/rules';
 
 extend('required', {
-  ...required,
-  message: 'staticmsg - This field is required [vee-validate]'
+  ...required
 });
 
 extend('mustBeUrl', (value: string): boolean => {
   return /^https?:\/\/.+/.test(value);
 });
 
-export default function ({ app }): any {
+const veeValidate: Plugin = ({ app }) => {
   configure({
+    // FIXME: Ts doesn't like the returned value to defaultMessage
     defaultMessage: (field, values) => {
       values._field_ = app.i18n.t(`fields.${field}`);
       return app.i18n.t(`validation.${values._rule_}`, values);
     }
   });
-}
-// const veeValidate: Plugin = ({ app }) => {
-//   configure({
-//     defaultMessage: (field, values) => {
-//       values._field_ = app.i18n.t(`fields.${field}`);
-//       return app.i18n.t(`validation.${values._rule_}`, values);
-//     }
-//   });
-// };
-// export default veeValidate;
+};
+export default veeValidate;

--- a/plugins/veeValidate.ts
+++ b/plugins/veeValidate.ts
@@ -2,9 +2,8 @@ import { Plugin } from '@nuxt/types/app';
 import { configure, extend } from 'vee-validate';
 import { required } from 'vee-validate/dist/rules';
 
-extend('required', {
-  ...required
-});
+// Rules
+extend('required', required);
 
 extend('mustBeUrl', (value: string): boolean => {
   return /^https?:\/\/.+/.test(value);
@@ -13,8 +12,8 @@ extend('mustBeUrl', (value: string): boolean => {
 const veeValidate: Plugin = ({ app }) => {
   configure({
     // FIXME: Ts doesn't like the returned value to defaultMessage
-    defaultMessage: (field, values) => {
-      values._field_ = app.i18n.t(`fields.${field}`);
+    defaultMessage: (_field, values) => {
+      // values._field_ = app.i18n.t(`fields.${field}`);
       return app.i18n.t(`validation.${values._rule_}`, values);
     }
   });

--- a/plugins/veeValidate.ts
+++ b/plugins/veeValidate.ts
@@ -11,7 +11,6 @@ extend('mustBeUrl', (value: string): boolean => {
 
 const veeValidate: Plugin = ({ app }) => {
   configure({
-    // FIXME: Ts doesn't like the returned value to defaultMessage
     defaultMessage: (_field, values) => {
       // values._field_ = app.i18n.t(`fields.${field}`);
       return app.i18n.t(`validation.${values._rule_}`, values).toString();

--- a/plugins/veeValidate.ts
+++ b/plugins/veeValidate.ts
@@ -14,7 +14,7 @@ const veeValidate: Plugin = ({ app }) => {
     // FIXME: Ts doesn't like the returned value to defaultMessage
     defaultMessage: (_field, values) => {
       // values._field_ = app.i18n.t(`fields.${field}`);
-      return app.i18n.t(`validation.${values._rule_}`, values);
+      return app.i18n.t(`validation.${values._rule_}`, values).toString();
     }
   });
 };

--- a/plugins/veeValidate.ts
+++ b/plugins/veeValidate.ts
@@ -1,0 +1,30 @@
+import { Plugin } from '@nuxt/types/app';
+import { configure, extend } from 'vee-validate';
+import { required } from 'vee-validate/dist/rules';
+
+extend('required', {
+  ...required,
+  message: 'staticmsg - This field is required [vee-validate]'
+});
+
+extend('mustBeUrl', (value: string): boolean => {
+  return /^https?:\/\/.+/.test(value);
+});
+
+export default function ({ app }): any {
+  configure({
+    defaultMessage: (field, values) => {
+      values._field_ = app.i18n.t(`fields.${field}`);
+      return app.i18n.t(`validation.${values._rule_}`, values);
+    }
+  });
+}
+// const veeValidate: Plugin = ({ app }) => {
+//   configure({
+//     defaultMessage: (field, values) => {
+//       values._field_ = app.i18n.t(`fields.${field}`);
+//       return app.i18n.t(`validation.${values._rule_}`, values);
+//     }
+//   });
+// };
+// export default veeValidate;

--- a/yarn.lock
+++ b/yarn.lock
@@ -12747,6 +12747,11 @@ vary@^1.1.2, vary@~1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
 
+vee-validate@^3.4.5:
+  version "3.4.5"
+  resolved "https://registry.yarnpkg.com/vee-validate/-/vee-validate-3.4.5.tgz#96a456c309f7bdb2cce62c3b554f96d893e9f6ae"
+  integrity sha512-ZEcLqOAZzSkMhDvPcTx0xcwVOijFnMW9J+BA20j+rDmo24T8RCCqVQyRwwrDrcWJZV2dRYl/yYNa2GB6UCoBvg==
+
 vendors@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/vendors/-/vendors-1.0.4.tgz#e2b800a53e7a29b93506c3cf41100d16c4c4ad8e"


### PR DESCRIPTION
Initial support for vee-validate.

Validation messages have their translations in the `validation` object in the locales files.

A user suggested that the following was too repetitive (Form fields had their translations in the `fields` object. )
![image](https://user-images.githubusercontent.com/11581433/100908032-0137b200-3499-11eb-9378-0bc92ba09308.png)

So I removed the field name from the translation.

Rules must be imported in `plugin/veeValidate.ts` or customized in the script section.

Import ValidationObserver, ValidationProvider component:
```
import { ValidationObserver, ValidationProvider } from 'vee-validate';
export default Vue.extend({
  components: {
    ValidationObserver,
    ValidationProvider
  },
...
```

Wrap the form and fields:
```
<validation-observer v-slot="{ invalid }">
      <v-form ref="form" :disabled="loading" @submit.prevent="userLogin">
            <validation-provider
              v-slot="{ errors }"
              name="username"
              :rules="rules.username"
            >
              <v-text-field
                v-model="login.username"
                outlined
                :label="$t('username')"
                :error-messages="errors"
              ></v-text-field>
            </validation-provider>
        <v-btn
              :disabled="invalid"
              color="primary"
              type="submit"
              >{{ $t('signIn') }}</v-btn>
```

Define rules:
```
rules: {
        username: {
          required: true
        }
}
```

For more info on how to use vee-validate, [refer to the official documentation](https://vee-validate.logaretm.com/v3/guide/forms.html#basic-example).