### PR TITLE
Fix/skell card sized - Fixes incorrect skeleton card sizes in some libraries

### DIFF
--- a/components/SkeletonCard.vue
+++ b/components/SkeletonCard.vue
@@ -25,7 +25,9 @@ export default Vue.extend({
     },
     cardShape: {
       type: String,
-      default: () => 'portrait-card'
+      default: () => 'portrait-card',
+      validator: (value) =>
+        ['square-card', 'portrait-card', 'thumb-card'].includes(value)
     }
   }
 });

--- a/components/SkeletonItemGrid.vue
+++ b/components/SkeletonItemGrid.vue
@@ -40,10 +40,12 @@ export default Vue.extend({
         case 'PhotoAlbum':
         case 'Playlist':
         case 'Video':
-          return 'square-card';
+          this.skeletonCardShape = 'square-card';
+          return;
         case 'Episode':
         case 'Studio':
-          return 'thumb-card';
+          this.skeletonCardShape = 'thumb-card';
+          return;
         case 'Book':
         case 'BoxSet':
         case 'Genre':
@@ -51,7 +53,7 @@ export default Vue.extend({
         case 'Person':
         case 'Series':
         default:
-          return 'portrait-card';
+          this.skeletonCardShape = 'portrait-card';
       }
     }
   }


### PR DESCRIPTION
Continues work from #318

Fixes card sizes in libraries that do not have use portrait cards

Also add props validation to `SkeletonCard`