### PR TITLE
fix(blurhash): fix blurhash throwing errors

### DIFF
--- a/components/BlurhashImage.vue
+++ b/components/BlurhashImage.vue
@@ -6,7 +6,8 @@
           item.ImageBlurHashes &&
           item.ImageBlurHashes.Primary &&
           item.ImageTags &&
-          item.ImageTags.Primary
+          item.ImageTags.Primary &&
+          item.ImageBlurHashes.Primary[item.ImageTags.Primary]
         "
         key="canvas"
         :hash="item.ImageBlurHashes.Primary[item.ImageTags.Primary]"


### PR DESCRIPTION
In cases where there is both a primary image tag, and blurhash primary image tags, but the tags are not
equal, it will throw errors.

To fix this, I have introduced a check to identify if there is a blurhash with that primary image tag