### PR TITLE
fix(relateditems): hide related items when relevant

### DIFF
--- a/components/RelatedItems.vue
+++ b/components/RelatedItems.vue
@@ -40,7 +40,7 @@
           {{ $t('youMayAlsoLike') }}
         </slot>
       </h2>
-      <v-skeleton-loader v-else type="heading" />
+      <v-skeleton-loader v-else-if="loading" type="heading" />
       <v-list color="transparent" two-line>
         <div v-if="!loading && relatedItems.length > 0">
           <v-list-item
@@ -64,7 +64,7 @@
         </div>
         <div
           v-for="index in skeletonLength"
-          v-else
+          v-else-if="loading"
           :key="index"
           class="d-flex align-center mt-5 mb-5"
         >

--- a/components/RelatedItems.vue
+++ b/components/RelatedItems.vue
@@ -1,6 +1,9 @@
 <template>
   <div>
-    <div v-if="!vertical" class="related-items">
+    <div
+      v-if="!vertical && !loading && relatedItems.length > 0"
+      class="related-items"
+    >
       <slot>
         <h1 class="text-h5 mb-2 ml-2 header">
           <span>{{ $t('youMayAlsoLike') }}</span>
@@ -34,7 +37,7 @@
         </template>
       </vueper-slides>
     </div>
-    <div v-else>
+    <div v-else-if="vertical">
       <h2 v-if="!loading && relatedItems.length > 0">
         <slot>
           {{ $t('youMayAlsoLike') }}


### PR DESCRIPTION
Hide related items, when finished loading but no related items are found. Previously, the skeleton
loader would continue to show even when no data was returned from the server