### PR TITLE
fix(card): properly handle image load failure in cards

### DIFF
--- a/components/BlurhashImage.vue
+++ b/components/BlurhashImage.vue
@@ -21,6 +21,7 @@
         class="absolute"
         :src="image"
         v-bind="$attrs"
+        @error="$emit('error')"
       />
     </transition-group>
   </div>

--- a/components/Card.vue
+++ b/components/Card.vue
@@ -6,9 +6,10 @@
           class="card-content card-content-button d-flex justify-center align-center primary darken-4"
         >
           <blurhash-image
-            v-if="item.ImageTags && item.ImageTags.Primary"
+            v-if="!imageLoadError && item.ImageTags && item.ImageTags.Primary"
             :item="item"
             class="card-image"
+            @error="imageLoadError = true"
           />
           <v-chip
             v-if="item.UserData && item.UserData.Played"
@@ -28,7 +29,9 @@
           </v-chip>
           <v-icon
             v-if="
-              !item.ImageTags || (item.ImageTags && !item.ImageTags.Primary)
+              imageLoadError ||
+              !item.ImageTags ||
+              (item.ImageTags && !item.ImageTags.Primary)
             "
             size="96"
             color="primary darken-2"
@@ -107,6 +110,11 @@ export default Vue.extend({
         return false;
       }
     }
+  },
+  data() {
+    return {
+      imageLoadError: false
+    };
   },
   computed: {
     itemLink: {


### PR DESCRIPTION
During the initial scan, image loads can fail. Currently, we just show a standard broken image from the browser.

This catches the `error` event of the `ìmg` element used by `blurhash-image` and re-emits it to the parent component, which allows the cards to fallback to icons in case an error happens when loading the image.

![image](https://user-images.githubusercontent.com/19396809/101241068-58d15a00-36f3-11eb-87b0-cf1029977005.png)