### PR TITLE
feat: add remember me login feature

### DIFF
--- a/components/LoginForm.vue
+++ b/components/LoginForm.vue
@@ -11,6 +11,7 @@
             v-if="isEmpty(user)"
             v-model="login.username"
             outlined
+            hide-details
             :label="$t('username')"
             :error-messages="errors"
           ></v-text-field>
@@ -18,6 +19,8 @@
         <v-text-field
           v-model="login.password"
           outlined
+          hide-details
+          class="mt-4"
           :label="$t('password')"
           :append-icon="showPassword ? 'mdi-eye-off' : 'mdi-eye'"
           :type="showPassword ? 'text' : 'password'"
@@ -25,7 +28,8 @@
         ></v-text-field>
         <v-checkbox
           v-model="login.rememberMe"
-          class="mb-8"
+          hide-details
+          class="mt-4 mb-8"
           :label="$t('rememberMe')"
         ></v-checkbox>
         <v-row align="center" no-gutters>

--- a/components/LoginForm.vue
+++ b/components/LoginForm.vue
@@ -23,6 +23,11 @@
           :type="showPassword ? 'text' : 'password'"
           @click:append="() => (showPassword = !showPassword)"
         ></v-text-field>
+        <v-checkbox
+          v-model="login.rememberMe"
+          class="mb-8"
+          :label="$t('rememberMe')"
+        ></v-checkbox>
         <v-row align="center" no-gutters>
           <v-col class="mr-2">
             <v-btn v-if="isEmpty(user)" to="/selectServer" nuxt block large>
@@ -71,7 +76,8 @@ export default Vue.extend({
     return {
       login: {
         username: '',
-        password: ''
+        password: '',
+        rememberMe: true
       },
       showPassword: false,
       loading: false,

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -22,6 +22,7 @@
   "dislikes": "Dislikes",
   "endDate": "End date",
   "endsAt": "Ends at {time}",
+  "episodeNumber": "Episode {episodeNumber}",
   "errors": {
     "anErrorHappened": "An error happened",
     "messages": {
@@ -29,7 +30,6 @@
       "videoPlayerError": "The video player encountered an unrecoverable error."
     }
   },
-  "episodeNumber": "Episode {episodeNumber}",
   "failedToRefreshItems": "Failed to refresh items",
   "favorite": "Favorite",
   "features": "Features",
@@ -66,6 +66,7 @@
   "present": "Present",
   "rating": "Rating",
   "releaseDate": "Release date",
+  "rememberMe": "Remember me",
   "resumable": "Resumable",
   "selectServer": "Select server",
   "selectUser": "Select a user",

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -93,7 +93,8 @@ export default Vue.extend({
         this.setDeviceProfile();
         this.$auth.loginWith('jellyfin', {
           username: user.Name,
-          password: ''
+          password: '',
+          rememberMe: true
         });
         return; // Avoid changing the form
       }

--- a/schemes/jellyfinScheme.ts
+++ b/schemes/jellyfinScheme.ts
@@ -32,6 +32,15 @@ export default class JellyfinScheme {
     this.$auth.ctx.app.$axios.setHeader('X-Emby-Authorization', false);
   }
 
+  _setRememberMe(value: boolean): void {
+    // Sets the remember me key which is used to relogin someone
+    this.$auth.$storage.setUniversal('rememberMe', value);
+  }
+
+  _getRememberMe(): boolean {
+    return this.$auth.$storage.getUniversal('rememberMe');
+  }
+
   mounted(): Promise<never> {
     const token = this.$auth.syncToken(this.name);
     this._setToken(token);
@@ -41,10 +50,12 @@ export default class JellyfinScheme {
 
   async login({
     username,
-    password
+    password,
+    rememberMe
   }: {
     username: string;
     password: string;
+    rememberMe: boolean;
   }): Promise<AxiosResponse<AuthenticationResult> | void> {
     // Ditch any leftover local tokens before attempting to log in
     await this.$auth.reset();
@@ -75,8 +86,14 @@ export default class JellyfinScheme {
       this.$auth.setToken(this.name, userToken);
       this._setToken(userToken);
 
+      // Sets the remember me to true in order to first fetch the user once
+      this._setRememberMe(true);
+
       // Fetch the user data
       await this.fetchUser();
+
+      // Set the remember me value
+      this._setRememberMe(rememberMe);
 
       return authenticateResponse;
     } else {
@@ -98,6 +115,11 @@ export default class JellyfinScheme {
       return;
     }
 
+    if (!this._getRememberMe()) {
+      await this.logout();
+      return;
+    }
+
     // Fetch the user, then set it in Nuxt Auth
     const user = (await this.$auth.ctx.app.$api.user.getCurrentUser()).data;
     this.$auth.setUser(user);
@@ -112,6 +134,7 @@ export default class JellyfinScheme {
 
   reset(): Promise<void> {
     this._clearToken();
+    this._setRememberMe(false);
 
     this.$auth.setUser(undefined);
     this.$auth.setToken(this.name, undefined);


### PR DESCRIPTION
fix #137

---
It adds a stored boolean value `rememberMe` which is checked at `fetchUser`. If it is false, it engages the logout procedure. If remember me is set, it acts the same as today, you can refresh whenever you want or come back later and it'll be logging you back. If not set, a single page refresh logs you out.

In the `login` method, I have to set twice the rememberMe value around L90. This is due to the fact we call `fetchUser` which checks the remembeMe flag and disconnects you if it is false. So at first I set it to true then after the user is fetched, the real value is set. I'm all ears for better hacks/solutions.

~~The first picture is how I've put the remember me button (put the checkbox element after the password one and added a bottom margin). It needs work about spacing. I think I'd go with how I did it in the second picture.~~
Here is how it looks now:
![print_screen_2020-12-17-12-31-25](https://user-images.githubusercontent.com/1619359/102482831-1ea57800-4064-11eb-988b-3dd835ff911c.png)

