### PR TITLE
feat(dark-theme): add dark theme colors

### DIFF
--- a/assets/global.scss
+++ b/assets/global.scss
@@ -1,3 +1,4 @@
+@import '~vuetify/src/styles/styles.sass';
 @import '@fontsource/noto-sans/index.css';
 @import '@fontsource/noto-sans-jp/index.css';
 @import '@fontsource/noto-sans-sc/index.css';
@@ -9,8 +10,11 @@ body {
   background-color: var(--v-background-base);
 }
 
-/* W3C standard (Firefox-only for now) */
 * {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+
+  /* W3C standard scrollbars (Firefox-only for now) */
   scrollbar-width: thin;
   scrollbar-color: var(--v-thumb-lighten5) var(--v-track-base);
 }
@@ -81,4 +85,13 @@ body {
 
 .link:hover {
   text-decoration: underline;
+}
+
+/* Customized Vuetify components */
+.v-menu__content .v-list {
+  background: map-get($material-light, 'cards') !important;
+}
+
+.theme--dark .v-menu__content .v-list {
+  background: map-get($material-dark, 'menus') !important;
 }

--- a/assets/styles/HomeHeader.scss
+++ b/assets/styles/HomeHeader.scss
@@ -35,11 +35,9 @@
   background-size: contain;
   background-repeat: no-repeat;
   box-sizing: border-box;
-  mask-image: linear-gradient(
-    180deg,
-    rgba(37, 18, 18, 0.75) 0%,
-    rgba(0, 0, 0, 0) 100%
-  );
+  mask-image: linear-gradient(180deg,
+      rgba(37, 18, 18, 0.75) 0%,
+      rgba(0, 0, 0, 0) 100%);
   z-index: 1;
 }
 
@@ -60,14 +58,41 @@
     margin-right: 0;
     padding-bottom: (9 / 16) * 80%;
     background-position: right center;
-    mask-image: linear-gradient(
-        180deg,
-        rgba(0, 0, 0, 1) 60%,
-        rgba(0, 0, 0, 0) 100%
-      ),
-      linear-gradient(90deg, rgba(0, 0, 0, 1) 0%, rgba(0, 0, 0, 0) 40%);
-    mask-composite: subtract;
-    -webkit-mask-composite: source-out; // This is needed due to autoprefixed not converting subtract to the proper webkit equivalent
+    mask-image: linear-gradient(to right,
+        hsla(0, 0%, 0%, 0) 0%,
+        hsla(0, 0%, 0%, 0.182) 5.6%,
+        hsla(0, 0%, 0%, 0.34) 9.9%,
+        hsla(0, 0%, 0%, 0.476) 13.1%,
+        hsla(0, 0%, 0%, 0.593) 15.7%,
+        hsla(0, 0%, 0%, 0.69) 17.9%,
+        hsla(0, 0%, 0%, 0.771) 20.2%,
+        hsla(0, 0%, 0%, 0.836) 22.9%,
+        hsla(0, 0%, 0%, 0.888) 26.3%,
+        hsla(0, 0%, 0%, 0.927) 30.8%,
+        hsla(0, 0%, 0%, 0.956) 36.7%,
+        hsla(0, 0%, 0%, 0.976) 44.4%,
+        hsla(0, 0%, 0%, 0.989) 54.3%,
+        hsla(0, 0%, 0%, 0.996) 66.6%,
+        hsla(0, 0%, 0%, 0.999) 81.7%,
+        hsl(0, 0%, 0%) 100%),
+      linear-gradient(to top,
+        hsla(0, 0%, 0%, 0) 0%,
+        hsla(0, 0%, 0%, 0.182) 5.6%,
+        hsla(0, 0%, 0%, 0.34) 9.9%,
+        hsla(0, 0%, 0%, 0.476) 13.1%,
+        hsla(0, 0%, 0%, 0.593) 15.7%,
+        hsla(0, 0%, 0%, 0.69) 17.9%,
+        hsla(0, 0%, 0%, 0.771) 20.2%,
+        hsla(0, 0%, 0%, 0.836) 22.9%,
+        hsla(0, 0%, 0%, 0.888) 26.3%,
+        hsla(0, 0%, 0%, 0.927) 30.8%,
+        hsla(0, 0%, 0%, 0.956) 36.7%,
+        hsla(0, 0%, 0%, 0.976) 44.4%,
+        hsla(0, 0%, 0%, 0.989) 54.3%,
+        hsla(0, 0%, 0%, 0.996) 66.6%,
+        hsla(0, 0%, 0%, 0.999) 81.7%,
+        hsl(0, 0%, 0%) 100%);
+    mask-composite: intersect;
   }
 
   .swiper {

--- a/assets/variables.scss
+++ b/assets/variables.scss
@@ -3,8 +3,6 @@
 // The variables you want to modify
 // $font-size-root: 20px;
 
-@import '~vuetify/src/styles/styles.sass';
-
 // Globals
 $heading-font-family: 'Noto Sans',
 'Noto Sans HK',
@@ -13,17 +11,18 @@ $heading-font-family: 'Noto Sans',
 'Noto Sans SC',
 sans-serif !default;
 $body-font-family: $heading-font-family;
+
 $font-size-root: 14px;
 $input-font-size: 14px;
 $btn-font-weight: 500;
 
-$material-light: map-merge($material-light, ('background': #f2f2f2));
+$material-light: ('background': #f2f2f2);
 
-$material-dark: map-merge($material-dark, ('background': #121721,
-    'navigation-drawer': #1c2331,
-    'app-bar': #1c2331,
-    'dividers': #233543,
-    'cards': #1c2331,
-    'chips': #2b4355,
-    'menus': #252e41,
-    'text': ('primary': #edf2f7)))
+$material-dark: ('background': #121721,
+  'navigation-drawer': #1c2331,
+  'app-bar': #1c2331,
+  'dividers': #233543,
+  'cards': #1c2331,
+  'chips': #2b4355,
+  'menus': #252e41,
+  'text': ('primary': #edf2f7));

--- a/assets/variables.scss
+++ b/assets/variables.scss
@@ -3,17 +3,27 @@
 // The variables you want to modify
 // $font-size-root: 20px;
 
+@import '~vuetify/src/styles/styles.sass';
+
 // Globals
-$heading-font-family: 'Noto Sans', 'Noto Sans HK', 'Noto Sans JP',
-  'Noto Sans KR', 'Noto Sans SC', sans-serif !default;
+$heading-font-family: 'Noto Sans',
+'Noto Sans HK',
+'Noto Sans JP',
+'Noto Sans KR',
+'Noto Sans SC',
+sans-serif !default;
 $body-font-family: $heading-font-family;
 $font-size-root: 14px;
 $input-font-size: 14px;
+$btn-font-weight: 500;
 
-$material-light: (
-  'background': #f2f2f2
-);
+$material-light: map-merge($material-light, ('background': #f2f2f2));
 
-$material-dark: (
-  'background': #101010
-);
+$material-dark: map-merge($material-dark, ('background': #121721,
+    'navigation-drawer': #1c2331,
+    'app-bar': #1c2331,
+    'dividers': #233543,
+    'cards': #1c2331,
+    'chips': #2b4355,
+    'menus': #252e41,
+    'text': ('primary': #edf2f7)))

--- a/components/Buttons/UserButton.vue
+++ b/components/Buttons/UserButton.vue
@@ -2,15 +2,19 @@
   <v-menu offset-y>
     <template #activator="{ on, attrs }">
       <div
-        class="d-flex align-center no-overflow space-evenly"
+        v-ripple
+        class="d-flex align-center full-width py-8 px-4 no-overflow"
         v-bind="attrs"
         v-on="on"
       >
         <user-image />
-        <h1 v-if="$auth.user" class="font-weight-light pb-1 text-truncate">
+        <h1
+          v-if="$auth.user"
+          class="flex-grow-1 font-weight-light ml-3 pb-1 text-truncate user-select-none"
+        >
           {{ $auth.user.Name }}
         </h1>
-        <v-icon>mdi-chevron-down</v-icon>
+        <v-icon>mdi-dots-horizontal</v-icon>
       </div>
     </template>
     <v-list dense>
@@ -42,14 +46,32 @@ export default Vue.extend({
   },
   computed: {
     menuItems(): MenuItem[] {
-      return [
-        {
-          title: this.$t('logout'),
+      const menuItems = [];
+
+      if (this.$auth.$state.user.Policy.IsAdministrator) {
+        menuItems.push({
+          title: this.$t('metadata'),
           action: (): void => {
-            this.logoutUser();
+            this.$router.push('/metadata');
           }
+        });
+      }
+
+      menuItems.push({
+        title: this.$t('settings'),
+        action: (): void => {
+          this.$router.push('/settings');
         }
-      ];
+      });
+
+      menuItems.push({
+        title: this.$t('logout'),
+        action: (): void => {
+          this.logoutUser();
+        }
+      });
+
+      return menuItems;
     }
   },
   methods: {

--- a/components/Buttons/UserButton.vue
+++ b/components/Buttons/UserButton.vue
@@ -50,7 +50,7 @@ export default Vue.extend({
 
       if (this.$auth.$state.user.Policy.IsAdministrator) {
         menuItems.push({
-          title: this.$t('metadata'),
+          title: this.$t('metadataEditor'),
           action: (): void => {
             this.$router.push('/metadata');
           }

--- a/components/Item/Card.vue
+++ b/components/Item/Card.vue
@@ -3,7 +3,7 @@
     <div class="card-box" :class="{ 'card-margin': !noMargin }">
       <div :class="shape || cardType" class="elevation-3">
         <div
-          class="card-content card-content-button d-flex justify-center align-center primary darken-4"
+          class="card-content card-content-button d-flex justify-center align-center darken-4"
         >
           <blurhash-image
             v-if="!imageLoadError && item.ImageTags && item.ImageTags.Primary"
@@ -42,9 +42,10 @@
               !item.ImageTags ||
               (item.ImageTags && !item.ImageTags.Primary)
             "
-            class="card-image absolute"
+            class="card-image absolute text--disabled"
             size="96"
-            color="primary darken-2"
+            color="white"
+            dark
           >
             {{ itemIcon }}
           </v-icon>
@@ -233,7 +234,7 @@ export default Vue.extend({
             episodeNumber: this.item.IndexNumber
           })} - ${this.item.Name}`;
         case 'MusicAlbum':
-          return `${this.item.AlbumArtist}`;
+          return `${this.item.AlbumArtist || ''}`;
         case 'Series': {
           if (this.item.Status === 'Continuing') {
             return `${this.item.ProductionYear} - ${this.$t('present')}`;
@@ -323,6 +324,7 @@ export default Vue.extend({
 }
 
 .card-content {
+  background-color: #{map-get($material-dark, 'menus')};
   overflow: hidden;
   position: absolute;
   top: 0;
@@ -338,6 +340,9 @@ export default Vue.extend({
   background-clip: content-box;
   background-position: center center;
   -webkit-tap-highlight-color: transparent;
+}
+.theme--dark .card-content {
+  background-color: #{map-get($material-dark, 'menus')};
 }
 
 .card-image {

--- a/components/Layout/AudioControls.vue
+++ b/components/Layout/AudioControls.vue
@@ -27,6 +27,7 @@
             </v-btn>
           </span>
           <nuxt-link
+            v-if="getCurrentItem.AlbumArtists[0].Id"
             tag="span"
             class="text--secondary text-caption text-truncate mt-md-n2 link"
             :to="`/artist/${getCurrentItem.AlbumArtists[0].Id}`"

--- a/components/Layout/Backdrop.vue
+++ b/components/Layout/Backdrop.vue
@@ -42,11 +42,13 @@ export default Vue.extend({
     left: 0;
     right: 0;
     background-color: #{map-get($material-light, 'background')};
-    opacity: 0.75;
+    mix-blend-mode: screen;
+    opacity: 0.85;
   }
 }
 
 .theme--dark .backdrop::after {
   background-color: #{map-get($material-dark, 'background')};
+  mix-blend-mode: multiply;
 }
 </style>

--- a/components/Layout/HomeHeader/HomeHeaderItems.vue
+++ b/components/Layout/HomeHeader/HomeHeaderItems.vue
@@ -10,6 +10,22 @@
     >
       <swiper-slide v-for="item in items" :key="item.Id">
         <div class="slide-backdrop" data-swiper-parallax="-100">
+          <div
+            v-if="
+              !item.BackdropImageTags ||
+              (item.ImageTags && !item.ImageTags.Backdrop)
+            "
+            class="default-icon"
+          >
+            <v-icon
+              :size="$vuetify.breakpoint.mdAndUp ? 256 : 128"
+              class="text--disabled"
+              color="white"
+              dark
+            >
+              {{ getItemIcon(item) }}
+            </v-icon>
+          </div>
           <blurhash-image
             :key="`${item.Id}-image`"
             :item="getRelatedItem(item)"
@@ -191,6 +207,34 @@ export default Vue.extend({
   },
   methods: {
     ...mapActions('playbackManager', ['play']),
+    getItemIcon(item: BaseItemDto): string {
+      switch (item.Type) {
+        case 'Audio':
+          return 'mdi-music-note';
+        case 'Book':
+          return 'mdi-book-open-page-variant';
+        case 'BoxSet':
+          return 'mdi-folder-multiple';
+        case 'Folder':
+        case 'CollectionFolder':
+          return 'mdi-folder';
+        case 'Movie':
+          return 'mdi-filmstrip';
+        case 'MusicAlbum':
+          return 'mdi-album';
+        case 'MusicArtist':
+        case 'Person':
+          return 'mdi-account';
+        case 'PhotoAlbum':
+          return 'mdi-image-multiple';
+        case 'Playlist':
+          return 'mdi-playlist-play';
+        case 'Series':
+          return 'mdi-television-classic';
+        default:
+          return '';
+      }
+    },
     getRelatedItem(item: BaseItemDto): BaseItemDto {
       const rItem = this.relatedItems[this.items.indexOf(item)];
       if (!rItem) {
@@ -238,4 +282,21 @@ export default Vue.extend({
 
 <style lang="scss" scoped>
 @import '~/assets/styles/HomeHeader.scss';
+
+.default-icon {
+  display: flex;
+  align-content: center;
+  justify-content: center;
+  height: 100%;
+  width: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+}
+
+.slide-backdrop {
+  background-color: #{map-get($material-dark, 'menus')};
+}
 </style>

--- a/components/Layout/Images/BlurhashImage.vue
+++ b/components/Layout/Images/BlurhashImage.vue
@@ -166,6 +166,7 @@ export default Vue.extend({
   bottom: 0;
 }
 img {
+  color: transparent;
   object-fit: cover;
 }
 </style>

--- a/components/System/DarkModeToggle.vue
+++ b/components/System/DarkModeToggle.vue
@@ -1,5 +1,22 @@
 <template>
-  <v-switch v-model="darkMode" :label="$t('darkModeToggle')"></v-switch>
+  <v-tooltip bottom>
+    <template #activator="{ on, attrs }">
+      <v-btn
+        :icon="!fab"
+        :fab="fab"
+        :small="fab"
+        :class="{ 'mr-n1': !fab }"
+        v-bind="attrs"
+        v-on="on"
+        @click="darkMode = !darkMode"
+      >
+        <v-icon>{{
+          darkMode ? 'mdi-weather-sunny' : 'mdi-weather-night'
+        }}</v-icon>
+      </v-btn>
+    </template>
+    <span>{{ $t('tooltips.toggleDarkMode') }}</span>
+  </v-tooltip>
 </template>
 
 <script lang="ts">
@@ -7,6 +24,12 @@ import Vue from 'vue';
 import { mapGetters, mapActions } from 'vuex';
 
 export default Vue.extend({
+  props: {
+    fab: {
+      type: Boolean,
+      required: true
+    }
+  },
   computed: {
     ...mapGetters('displayPreferences', ['getBooleanCustomPref']),
     darkMode: {

--- a/components/System/LocaleSwitcher.vue
+++ b/components/System/LocaleSwitcher.vue
@@ -1,9 +1,21 @@
 <template>
   <v-menu offset-y>
-    <template #activator="{ on, attrs }">
-      <v-btn icon size="36" v-bind="attrs" v-on="on">
-        <v-icon>mdi-web</v-icon>
-      </v-btn>
+    <template #activator="{ on: onMenu, attrs: attrsMenu }">
+      <v-tooltip bottom>
+        <template #activator="{ on: onTooltip, attrsTooltip }">
+          <v-btn
+            :icon="!fab"
+            :fab="fab"
+            :small="fab"
+            :class="{ 'mr-n1': !fab, 'ml-1': fab }"
+            v-bind="{ ...attrsMenu, ...attrsTooltip }"
+            v-on="{ ...onMenu, ...onTooltip }"
+          >
+            <v-icon>mdi-web</v-icon>
+          </v-btn>
+        </template>
+        <span>{{ $t('tooltips.changeLanguage') }}</span>
+      </v-tooltip>
     </template>
     <v-list class="overflow-y-auto">
       <v-list-item
@@ -22,6 +34,12 @@ import Vue from 'vue';
 import { mapActions } from 'vuex';
 
 export default Vue.extend({
+  props: {
+    fab: {
+      type: Boolean,
+      required: true
+    }
+  },
   methods: {
     ...mapActions('displayPreferences', ['editCustomPref'])
   }

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -62,8 +62,8 @@
   "features": "Features",
   "filter": "Filter",
   "filtersNotFound": "Unable to load filters",
-  "general": "General",
   "fullScreen": "Full screen",
+  "general": "General",
   "genres": "Genres",
   "guestStar": "Guest Star",
   "headerExternalIds": "External IDs",
@@ -249,6 +249,10 @@
   "themeVideo": "Theme Video",
   "thumb": "Thumb",
   "title": "Title",
+  "tooltips": {
+    "changeLanguage": "Language",
+    "toggleDarkMode": "Toggle dark mode"
+  },
   "trailer": "Trailer",
   "type": "Type",
   "unableGetPublicUsers": "Unable to get users",

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -43,7 +43,6 @@
   "discNumber": "Disc {discNumber}",
   "dislikes": "Dislikes",
   "edit": "Edit",
-  "editMetadata": "Edit metadata",
   "editPerson": "Edit person",
   "endDate": "End date",
   "endsAt": "Ends at {time}",
@@ -85,9 +84,9 @@
   "jellyfinLogo": "Jellyfin logo",
   "latestLibrary": "Latest {libraryName}",
   "libraries": "Libraries",
-  "libraryRefreshQueued": "Library refresh queued",
   "libraryEmpty": "This library is empty",
   "libraryNotFound": "Library not found",
+  "libraryRefreshQueued": "Library refresh queued",
   "liked": "Liked",
   "likes": "Likes",
   "links": {
@@ -110,7 +109,7 @@
   },
   "manualLogin": "Manual login",
   "menu": "Menu",
-  "metadata": "Metadata",
+  "metadataEditor": "Metadata editor",
   "metadataNoResultsMatching": "No results matching \"{search}\". Press enter to create a new one.",
   "more": "More",
   "moreLikeArtist": "More like {artist}",
@@ -254,11 +253,12 @@
     "toggleDarkMode": "Toggle dark mode"
   },
   "trailer": "Trailer",
+  "tvShowAbbrev": "S{seasonNumber} E{episodeNumber}",
   "type": "Type",
   "unableGetPublicUsers": "Unable to get users",
-  "unableToRefreshLibrary": "Unable to refresh library",
   "unableGetRelated": "Unable to get related items",
   "unableGetServerConfiguration": "Unable to get server configuration",
+  "unableToRefreshLibrary": "Unable to refresh library",
   "undefined": "Undefined",
   "unexpectedError": "Unexpected error",
   "unhandledException": "Unhandled exception",
@@ -280,6 +280,5 @@
   "writing": "Writing",
   "year": "Year",
   "years": "Years",
-  "youMayAlsoLike": "You may also like",
-  "tvShowAbbrev": "S{seasonNumber} E{episodeNumber}"
+  "youMayAlsoLike": "You may also like"
 }

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -211,16 +211,16 @@ const config: NuxtConfig = {
       disable: false,
       themes: {
         dark: {
-          primary: '#00A4DC',
-          secondary: '#424242',
+          primary: '#0086b3',
+          secondary: '#2f3951',
           accent: '#FF4081',
           info: '#0099CC',
           warning: '#FB8C00',
           error: '#FF5252',
           success: '#4CAF50',
-          background: '#101010',
-          track: '#272727',
-          thumb: '#303030'
+          background: '#14141F',
+          track: '#1c2331',
+          thumb: '#252e41'
         },
         light: {
           primary: '#00A4DC',

--- a/pages/artist/_itemId/index.vue
+++ b/pages/artist/_itemId/index.vue
@@ -121,6 +121,11 @@ export default Vue.extend({
       appearances: [] as BaseItemDto[]
     };
   },
+  head() {
+    return {
+      title: this.$store.state.page.title
+    };
+  },
   computed: {
     overview(): string {
       if (this.$data.item.Overview) {
@@ -139,7 +144,9 @@ export default Vue.extend({
     ).data;
 
     if (item) {
+      this.setPageTitle({ title: item.Name });
       this.setBackdrop({ item });
+      this.setAppBarOpacity({ opaqueAppBar: false });
       this.item = item;
     }
 
@@ -157,9 +164,11 @@ export default Vue.extend({
     }
   },
   destroyed() {
+    this.setAppBarOpacity({ opaqueAppBar: true });
     this.clearBackdrop();
   },
   methods: {
+    ...mapActions('page', ['setPageTitle', 'setAppBarOpacity']),
     ...mapActions('backdrop', ['setBackdrop', 'clearBackdrop']),
     getImageUrl(itemId: string | undefined, type: string): string {
       if (itemId) {

--- a/pages/item/_itemId/index.vue
+++ b/pages/item/_itemId/index.vue
@@ -460,6 +460,11 @@ export default Vue.extend({
       currentSubtitleTrack: {} as MediaStream
     };
   },
+  head() {
+    return {
+      title: this.$store.state.page.title
+    };
+  },
   computed: {
     isPlayable: {
       get(): boolean {
@@ -508,6 +513,8 @@ export default Vue.extend({
     ).data;
 
     if (this.item) {
+      this.setPageTitle({ title: this.item.Name });
+      this.setAppBarOpacity({ opaqueAppBar: false });
       this.setBackdrop({ item: this.item });
 
       if (this.item.MediaSources) {
@@ -566,10 +573,12 @@ export default Vue.extend({
     }
   },
   destroyed() {
+    this.setAppBarOpacity({ opaqueAppBar: true });
     this.clearBackdrop();
   },
   methods: {
     ...mapActions('playbackManager', ['play']),
+    ...mapActions('page', ['setPageTitle', 'setAppBarOpacity']),
     ...mapActions('backdrop', ['setBackdrop', 'clearBackdrop']),
     getLanguageName(code?: string): string {
       if (!code) {

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -1,6 +1,9 @@
 module.exports = {
+  syntax: 'scss',
   extends: ['stylelint-config-standard', 'stylelint-config-prettier'],
   // add your custom config here
   // https://stylelint.io/user-guide/configuration
-  rules: {}
+  rules: {
+    'at-rule-no-unknown': null
+  }
 };


### PR DESCRIPTION
* Sets a bunch of colors for the dark Vuetify theme
* Moves some menus and buttons around, adds tooltips
* Improve readability of the app bar buttons when the bar is transparent, by using floating action buttons

**Updated 2020/01/08**
![image](https://user-images.githubusercontent.com/19396809/103963183-ef60c300-5158-11eb-9757-ca0ad6c80535.png)

