### PR TITLE
fix(home-header): fix logo display for MusicAlbum items

### DIFF
--- a/components/HomeHeader.vue
+++ b/components/HomeHeader.vue
@@ -17,7 +17,13 @@
           <v-row>
             <v-col cols="5">
               <v-img
-                v-if="item.ImageTags && item.ImageTags.Logo"
+                v-if="
+                  item.ParentLogoImageTag ||
+                  (item.ImageTags && item.ImageTags.Logo)
+                "
+                max-width="50%"
+                aspect-ratio="2.58"
+                contain
                 :src="getLogo(item)"
               />
               <h1
@@ -139,6 +145,8 @@ export default Vue.extend({
       // TODO: Improve the image mixin and move this there
       if (item.Type === 'Episode') {
         return `${this.$axios.defaults.baseURL}/Items/${item.SeriesId}/Images/Logo`;
+      } else if (item.Type === 'MusicAlbum') {
+        return `${this.$axios.defaults.baseURL}/Items/${item.ParentLogoItemId}/Images/Logo`;
       } else {
         return `${this.$axios.defaults.baseURL}/Items/${item.Id}/Images/Logo`;
       }


### PR DESCRIPTION
Since I noticed that the Fanart plugin is now working on 10.7 (probably has been for a while), this fixes some oversights in regards to how logos are handled on the home header (Size, but also actually using them for music...)

![image](https://user-images.githubusercontent.com/19396809/102270319-24914100-3f1e-11eb-8e8c-f9d8b24d30db.png)
