### PR TITLE
feat(images): unload not visible images using Intersection observer

### DIFF
--- a/components/Layout/Images/BlurhashCanvas.vue
+++ b/components/Layout/Images/BlurhashCanvas.vue
@@ -1,5 +1,13 @@
 <template>
-  <canvas v-if="validHash" ref="canvas" :width="width" :height="height" />
+  <transition name="fade" mode="in-out">
+    <canvas
+      v-if="validHash"
+      v-show="!loading"
+      ref="canvas"
+      :width="width"
+      :height="height"
+    />
+  </transition>
 </template>
 
 <script lang="ts">
@@ -27,7 +35,8 @@ export default Vue.extend({
   },
   data() {
     return {
-      validHash: true
+      validHash: true,
+      loading: true
     };
   },
   watch: {
@@ -45,10 +54,16 @@ export default Vue.extend({
       const ctx = (this.$refs.canvas as HTMLCanvasElement).getContext('2d');
       const imageData = ctx?.createImageData(this.width, this.height);
       try {
-        const pixels = await getPixels(this.hash, this.width, this.height);
+        const pixels = await getPixels(
+          this.hash,
+          this.width,
+          this.height,
+          this.punch
+        );
         if (imageData) {
           imageData.data.set(pixels);
           ctx?.putImageData(imageData, 0, 0);
+          this.loading = false;
         }
       } catch {
         this.validHash = false;
@@ -57,3 +72,15 @@ export default Vue.extend({
   }
 });
 </script>
+
+<style scoped>
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.25s;
+}
+
+.fade-enter,
+.fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/components/Layout/Images/BlurhashImage.vue
+++ b/components/Layout/Images/BlurhashImage.vue
@@ -11,12 +11,14 @@
         class="absolute"
       />
       <img
+        v-show="!loading"
         key="image"
         class="absolute"
         :src="image"
         v-bind="$attrs"
         :alt="alt"
         @error="onError"
+        @load="loading = false"
       />
     </transition-group>
   </div>
@@ -63,7 +65,8 @@ export default Vue.extend({
   },
   data() {
     return {
-      image: ''
+      image: '',
+      loading: true
     };
   },
   mounted(): void {
@@ -145,7 +148,7 @@ export default Vue.extend({
 <style scoped>
 .fade-enter-active,
 .fade-leave-active {
-  transition: opacity 0.5s;
+  transition: opacity 0.25s;
 }
 
 .fade-enter,

--- a/plugins/workers/blurhash.worker.ts
+++ b/plugins/workers/blurhash.worker.ts
@@ -5,16 +5,18 @@ import { decode } from 'blurhash';
  *
  * @param {string} hash - Hash to decode.
  * @param {number} width - Width of the decoded pixel array
- * @param {height} height - Height of the decoded pixel array
+ * @param {number} height - Height of the decoded pixel array.
+ * @param {number} punch - Contrast of the decoded pixels
  * @returns {Uint8ClampedArray} - Returns the decoded pixels in the proxied response by Comlink
  */
 export default function getPixels(
   hash: string,
   width: number,
-  height: number
+  height: number,
+  punch: number
 ): Uint8ClampedArray {
   try {
-    return decode(hash, width, height);
+    return decode(hash, width, height, punch);
   } catch {
     throw new TypeError(`Blurhash ${hash} is not valid`);
   }


### PR DESCRIPTION
Cherry-picked from #275

Everything from the original PR is here, but the use of Intersection Observer on places where the virtual scroller is being used (until we find a solution for all the scrolling performance issues)