### PR TITLE
build(): disable modern and target static

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -17,12 +17,12 @@ const config: NuxtConfig = {
    ** Nuxt target
    ** See https://nuxtjs.org/api/configuration-target
    */
-  target: 'server',
+  target: 'static',
   /*
    ** Module loading mode
    ** See https://nuxtjs.org/api/configuration-modern
    */
-  modern: 'client',
+  modern: false,
   /*
    ** Progress bar between routes
    ** See https://nuxtjs.org/api/configuration-loading

--- a/package.json
+++ b/package.json
@@ -4,9 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "nuxt-ts",
-    "build": "nuxt-ts build",
+    "build": "nuxt-ts generate",
     "start": "nuxt-ts start",
-    "generate": "nuxt-ts generate",
     "lint:js": "eslint --ext .ts,.js,.vue .",
     "lint:style": "stylelint **/*.{vue,css} --ignore-path .gitignore",
     "lint": "yarn lint:js && yarn lint:style",


### PR DESCRIPTION
I don't know if we had modern enabled for an special reason but, with it disabled, I get production and dev builds in half of the time, while maximizing compatibility with older browsers. Usability-wise, I don't find a worse performance as the docs claim (in fact, I think it has better performance while switching between routes)

We were also targeting server for some reason while our client is purely static