### PR TITLE
Set PWA manifest and meta tags settings

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -32,6 +32,18 @@ const config: NuxtConfig = {
     failedColor: '#FF5252',
     height: '4px'
   },
+  pwa: {
+    meta: {
+      nativeUI: true,
+      appleStatusBarStyle: 'dark',
+      name: 'Jellyfin',
+      theme_color: '#424242'
+    },
+    manifest: {
+      name: 'Jellyfin',
+      background_color: '#101010'
+    }
+  },
   /*
    ** Headers of the page
    ** See https://nuxtjs.org/api/configuration-head

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "jellyfin-vue",
+  "author": "Jellyfin Team",
   "version": "0.0.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Sets a bunch of PWA manifest and meta tags settings in Nuxt in order to feel more native on mobile devices.

![image](https://user-images.githubusercontent.com/19396809/102555924-06ffdb00-40c8-11eb-978a-adc9252280e7.png) 
![image](https://user-images.githubusercontent.com/19396809/102555927-0a936200-40c8-11eb-9bf1-6b3684e854a7.png)
