### PR TITLE
Remove Vueper Slides & replace with Swiper

### DIFF
--- a/components/Item/RelatedItems.vue
+++ b/components/Item/RelatedItems.vue
@@ -1,41 +1,7 @@
 <template>
   <div>
-    <div
-      v-if="!vertical && !loading && relatedItems.length > 0"
-      class="related-items"
-    >
-      <slot>
-        <h1 class="text-h5 mb-2 ml-2 header">
-          <span>{{ $t('youMayAlsoLike') }}</span>
-        </h1>
-      </slot>
-      <vueper-slides
-        :bullets="false"
-        :bullets-outside="false"
-        :arrows-outside="false"
-        :visible-slides="6"
-        :slide-multiple="true"
-        :breakpoints="breakpoints"
-        fixed-height="true"
-      >
-        <vueper-slide v-for="relatedItem in relatedItems" :key="relatedItem.Id">
-          <template #content>
-            <card :item="relatedItem" />
-          </template>
-        </vueper-slide>
-
-        <template #arrow-left>
-          <v-btn icon large>
-            <v-icon>mdi-arrow-left</v-icon>
-          </v-btn>
-        </template>
-
-        <template #arrow-right>
-          <v-btn icon large>
-            <v-icon>mdi-arrow-right</v-icon>
-          </v-btn>
-        </template>
-      </vueper-slides>
+    <div v-if="!vertical" class="related-items">
+      <swiper-section :title="title" :items="relatedItems" :loading="loading" />
     </div>
     <div v-else-if="vertical">
       <h2 v-if="!loading && relatedItems.length > 0">
@@ -80,6 +46,7 @@
 <script lang="ts">
 import Vue from 'vue';
 import { mapActions } from 'vuex';
+import { SwiperOptions } from 'swiper';
 import { BaseItemDto, ImageType } from '@jellyfin/client-axios';
 import imageHelper from '~/mixins/imageHelper';
 
@@ -100,30 +67,42 @@ export default Vue.extend({
     skeletonLength: {
       type: Number,
       default: 5
+    },
+    title: {
+      type: String,
+      default(): string {
+        return this.$t('youMayAlsoLike').toString();
+      }
     }
   },
   data() {
     return {
-      relatedItems: [] as BaseItemDto[],
-      loading: true,
-      /**
-       * Stores Breakpoints for number of visible slides
-       * on different screen sizes
-       */
-      breakpoints: {
-        600: {
-          visibleSlides: 3
+      swiperOptions: {
+        initialSlide: 0,
+        freeMode: this.$browser.isMobile(),
+        effect: 'slide',
+        navigation: {
+          nextEl: `.related-items .swiper-next`,
+          prevEl: `.related-items .swiper-prev`
         },
-        960: {
-          visibleSlides: 4
-        },
-        1264: {
-          visibleSlides: 6
-        },
-        1904: {
-          visibleSlides: 6
+        slidesPerView: 3,
+        breakpoints: {
+          600: {
+            slidesPerView: 4
+          },
+          960: {
+            slidesPerView: 6
+          },
+          1264: {
+            slidesPerView: 6
+          },
+          1904: {
+            slidesPerView: 8
+          }
         }
-      }
+      } as SwiperOptions,
+      relatedItems: [] as BaseItemDto[],
+      loading: true
     };
   },
   watch: {
@@ -189,42 +168,5 @@ export default Vue.extend({
   bottom: 0.3em;
   left: 0;
   width: 1.25em;
-}
-</style>
-
-<style>
-.related-items .vueperslides__track {
-  position: relative;
-  cursor: default !important;
-}
-
-@media (hover: none) {
-  .related-items .vueperslides__arrows {
-    display: none !important;
-  }
-}
-
-.related-items .vueperslides__arrows {
-  display: flex;
-  position: absolute;
-  top: -2.75em;
-  right: 0;
-  align-items: center;
-}
-
-.related-items .vueperslides__arrow {
-  position: relative;
-  display: inline-flex;
-  transform: none;
-}
-
-.related-items .vueperslides__arrow--prev {
-  margin-right: 0.75em;
-}
-.vueperslides:not(.no-shadow):not(.vueperslides--3d)
-  .vueperslides__parallax-wrapper::after,
-.vueperslides:not(.no-shadow):not(.vueperslides--3d)
-  .vueperslides__parallax-wrapper::before {
-  box-shadow: none;
 }
 </style>

--- a/components/Item/RelatedItems.vue
+++ b/components/Item/RelatedItems.vue
@@ -46,7 +46,6 @@
 <script lang="ts">
 import Vue from 'vue';
 import { mapActions } from 'vuex';
-import { SwiperOptions } from 'swiper';
 import { BaseItemDto, ImageType } from '@jellyfin/client-axios';
 import imageHelper from '~/mixins/imageHelper';
 
@@ -77,30 +76,6 @@ export default Vue.extend({
   },
   data() {
     return {
-      swiperOptions: {
-        initialSlide: 0,
-        freeMode: this.$browser.isMobile(),
-        effect: 'slide',
-        navigation: {
-          nextEl: `.related-items .swiper-next`,
-          prevEl: `.related-items .swiper-prev`
-        },
-        slidesPerView: 3,
-        breakpoints: {
-          600: {
-            slidesPerView: 4
-          },
-          960: {
-            slidesPerView: 6
-          },
-          1264: {
-            slidesPerView: 6
-          },
-          1904: {
-            slidesPerView: 8
-          }
-        }
-      } as SwiperOptions,
       relatedItems: [] as BaseItemDto[],
       loading: true
     };

--- a/components/Layout/Backdrop.vue
+++ b/components/Layout/Backdrop.vue
@@ -23,6 +23,8 @@ export default Vue.extend({
 </script>
 
 <style lang="scss">
+@import '~vuetify/src/styles/styles.sass';
+
 .backdrop {
   & canvas {
     position: fixed;

--- a/components/Layout/HomeSection.vue
+++ b/components/Layout/HomeSection.vue
@@ -1,43 +1,10 @@
 <template>
-  <div style="width: 100%">
-    <skeleton-home-section v-if="loading" :card-shape="section.shape" />
-    <v-col v-show="items && items.length > 0" class="home-section">
-      <h1
-        class="text-h5 font-weight-light header"
-        :class="{ 'header-white-mode': !$vuetify.theme.dark }"
-      >
-        <span>{{ section.name }}</span>
-      </h1>
-
-      <vueper-slides
-        :bullets="false"
-        :bullets-outside="false"
-        :arrows-outside="false"
-        :visible-slides="section.shape === 'thumb-card' ? 4 : 8"
-        :slide-multiple="true"
-        :breakpoints="breakpoints"
-        fixed-height="true"
-      >
-        <vueper-slide v-for="item in items" :key="item.Id">
-          <template #content>
-            <card :shape="section.shape" :item="item" />
-          </template>
-        </vueper-slide>
-
-        <template #arrow-left>
-          <v-btn icon large>
-            <v-icon>mdi-arrow-left</v-icon>
-          </v-btn>
-        </template>
-
-        <template #arrow-right>
-          <v-btn icon large>
-            <v-icon>mdi-arrow-right</v-icon>
-          </v-btn>
-        </template>
-      </vueper-slides>
-    </v-col>
-  </div>
+  <swiper-section
+    :title="section.name"
+    :items="items"
+    :shape="section.shape"
+    :loading="loading"
+  />
 </template>
 
 <script lang="ts">
@@ -51,24 +18,16 @@ export default Vue.extend({
     section: {
       type: Object as () => HomeSection,
       required: true
+    },
+    index: {
+      type: [Number, Boolean],
+      default() {
+        return false;
+      }
     }
   },
   data() {
     return {
-      breakpoints: {
-        600: {
-          visibleSlides: this.section.shape === 'thumb-card' ? 2 : 3
-        },
-        960: {
-          visibleSlides: this.section.shape === 'thumb-card' ? 3 : 4
-        },
-        1264: {
-          visibleSlides: this.section.shape === 'thumb-card' ? 3 : 6
-        },
-        1904: {
-          visibleSlides: this.section.shape === 'thumb-card' ? 4 : 8
-        }
-      },
       loading: true
     };
   },
@@ -121,63 +80,3 @@ export default Vue.extend({
   }
 });
 </script>
-
-<style lang="scss" scoped>
-h1 {
-  margin-left: 0.4em;
-  margin-bottom: 0.25em;
-}
-
-.home-section .header span {
-  padding-left: 0.25em;
-}
-
-@import '~vuetify/src/styles/styles.sass';
-.home-section .header::before {
-  background-color: #{map-get($material-dark, 'text-color')};
-  content: '';
-  position: relative;
-  display: inline-block;
-  height: 1px;
-  bottom: 0.3em;
-  left: 0;
-  width: 1.25em;
-}
-.home-section .header-white-mode::before {
-  background-color: #{map-get($material-light, 'text-color')};
-}
-</style>
-
-<style>
-.home-section .vueperslides__track {
-  position: relative;
-  cursor: default !important;
-}
-
-@media (hover: none) {
-  .home-section .vueperslides__arrows {
-    display: none !important;
-  }
-}
-.home-section .vueperslides__arrows {
-  display: flex;
-  position: absolute;
-  top: -2.75em;
-  right: 0;
-  align-items: center;
-}
-.home-section .vueperslides__arrow {
-  position: relative;
-  display: inline-flex;
-  transform: none;
-}
-.home-section .vueperslides__arrow--prev {
-  margin-right: 0.75em;
-}
-.vueperslides:not(.no-shadow):not(.vueperslides--3d)
-  .vueperslides__parallax-wrapper::after,
-.vueperslides:not(.no-shadow):not(.vueperslides--3d)
-  .vueperslides__parallax-wrapper::before {
-  box-shadow: none;
-}
-</style>

--- a/components/Layout/HomeSection.vue
+++ b/components/Layout/HomeSection.vue
@@ -18,12 +18,6 @@ export default Vue.extend({
     section: {
       type: Object as () => HomeSection,
       required: true
-    },
-    index: {
-      type: [Number, Boolean],
-      default() {
-        return false;
-      }
     }
   },
   data() {

--- a/components/SwiperSection.vue
+++ b/components/SwiperSection.vue
@@ -1,0 +1,108 @@
+<template>
+  <div :class="`swiper-section-${uuid}`" style="width: 100%">
+    <skeleton-home-section v-if="loading" :card-shape="shape" />
+    <v-col v-show="items && items.length > 0" class="swiper-section">
+      <div class="d-flex">
+        <h1
+          class="text-h5 font-weight-light header mt-1 pl-3 pb-2"
+          :class="{ 'header-white-mode': !$vuetify.theme.dark }"
+        >
+          <span class="pl-3">{{ title }}</span>
+        </h1>
+        <v-spacer />
+        <v-btn class="swiper-prev" icon>
+          <v-icon>mdi-arrow-left</v-icon>
+        </v-btn>
+        <v-btn class="swiper-next mr-2" icon>
+          <v-icon>mdi-arrow-right</v-icon>
+        </v-btn>
+      </div>
+
+      <swiper class="swiper" :options="swiperOptions">
+        <swiper-slide v-for="item in items" :key="item.Id">
+          <card :shape="shape" :item="item" />
+        </swiper-slide>
+      </swiper>
+    </v-col>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import { SwiperOptions } from 'swiper';
+import { v4 as uuidv4 } from 'uuid';
+import { BaseItemDto } from '@jellyfin/client-axios';
+
+export default Vue.extend({
+  props: {
+    loading: {
+      type: Boolean,
+      required: true
+    },
+    title: {
+      type: String,
+      required: true
+    },
+    items: {
+      type: Object as () => BaseItemDto[],
+      required: true
+    },
+    shape: {
+      type: String,
+      default() {
+        return undefined;
+      }
+    }
+  },
+  data() {
+    const uuid = uuidv4();
+    return {
+      uuid,
+      swiperOptions: {
+        initialSlide: 0,
+        freeMode: this.$browser.isMobile(),
+        effect: 'slide',
+        navigation: {
+          nextEl: `.swiper-section-${uuid} .swiper-next`,
+          prevEl: `.swiper-section-${uuid} .swiper-prev`
+        },
+        slidesPerView: this.shape === 'thumb-card' ? 2 : 3,
+        slidesPerGroup: this.shape === 'thumb-card' ? 2 : 3,
+        breakpoints: {
+          600: {
+            slidesPerView: this.shape === 'thumb-card' ? 3 : 4,
+            slidesPerGroup: this.shape === 'thumb-card' ? 3 : 4
+          },
+          960: {
+            slidesPerView: this.shape === 'thumb-card' ? 3 : 6,
+            slidesPerGroup: this.shape === 'thumb-card' ? 3 : 6
+          },
+          1904: {
+            slidesPerView: this.shape === 'thumb-card' ? 4 : 8,
+            slidesPerGroup: this.shape === 'thumb-card' ? 4 : 8
+          }
+        }
+      } as SwiperOptions
+    };
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+@import '~vuetify/src/styles/styles.sass';
+
+.swiper-section .header::before {
+  background-color: #{map-get($material-dark, 'text-color')};
+  content: '';
+  position: relative;
+  display: inline-block;
+  height: 1px;
+  bottom: 0.3em;
+  left: 0;
+  width: 1.25em;
+}
+
+.swiper-section .header-white-mode::before {
+  background-color: #{map-get($material-light, 'text-color')};
+}
+</style>

--- a/components/SwiperSection.vue
+++ b/components/SwiperSection.vue
@@ -44,13 +44,15 @@ export default Vue.extend({
       required: true
     },
     items: {
-      type: Object as () => BaseItemDto[],
-      required: true
+      type: Array as () => BaseItemDto[],
+      default(): BaseItemDto[] {
+        return [];
+      }
     },
     shape: {
       type: String,
-      default() {
-        return undefined;
+      default(): string {
+        return '';
       }
     }
   },

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -79,7 +79,6 @@ const config: NuxtConfig = {
     'plugins/nativeWebsocketPlugin.ts',
     // Components
     'plugins/components/swiper.ts',
-    'plugins/components/vueperSlides.ts',
     'plugins/components/vueVirtualScroller.ts',
     'plugins/components/veeValidate.ts',
     // Utility

--- a/package.json
+++ b/package.json
@@ -58,8 +58,7 @@
     "vee-validate": "^3.4.5",
     "vue-awesome-swiper": "^4.1.1",
     "vue-native-websocket": "^2.0.14",
-    "vue-virtual-scroller": "^1.0.10",
-    "vueperslides": "^2.12.1"
+    "vue-virtual-scroller": "^1.0.10"
   },
   "devDependencies": {
     "@commitlint/cli": "^11.0.0",

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -6,7 +6,7 @@
         v-for="(homeSection, index) in homeSections"
         :key="`homeSection-${index}`"
       >
-        <home-section :section="homeSection" />
+        <home-section :section="homeSection" :index="index" />
       </v-row>
     </v-container>
   </div>

--- a/pages/person/_itemId/index.vue
+++ b/pages/person/_itemId/index.vue
@@ -5,6 +5,7 @@
         <v-row>
           <v-col cols="2">
             <v-img
+              v-if="item.Id"
               ref="personImg"
               class="person-image elevation-2 ml-2"
               cover
@@ -52,71 +53,21 @@
         </v-row>
         <v-row v-if="movies.length > 0">
           <v-col>
-            <h1 class="text-h5 mb-2 ml-2 header">
-              <span>{{ $t('movies') }}</span>
-            </h1>
-            <vueper-slides
-              :bullets="false"
-              :bullets-outside="false"
-              :arrows-outside="false"
-              :visible-slides="6"
-              :slide-multiple="true"
-              :breakpoints="breakpoints"
-              fixed-height="true"
-            >
-              <vueper-slide v-for="movie in movies" :key="movie.Id">
-                <template #content>
-                  <card :item="movie" />
-                </template>
-              </vueper-slide>
-
-              <template #arrow-left>
-                <v-btn icon large>
-                  <v-icon>mdi-arrow-left</v-icon>
-                </v-btn>
-              </template>
-
-              <template #arrow-right>
-                <v-btn icon large>
-                  <v-icon>mdi-arrow-right</v-icon>
-                </v-btn>
-              </template>
-            </vueper-slides>
+            <swiper-section
+              :title="$t('movies')"
+              :items="movies"
+              :loading="loading"
+            />
           </v-col>
         </v-row>
 
         <v-row v-if="shows.length > 0">
           <v-col>
-            <h1 class="text-h5 mb-2 ml-2 header">
-              <span>{{ $t('shows') }}</span>
-            </h1>
-            <vueper-slides
-              :bullets="false"
-              :bullets-outside="false"
-              :arrows-outside="false"
-              :visible-slides="6"
-              :slide-multiple="true"
-              :breakpoints="breakpoints"
-              fixed-height="true"
-            >
-              <vueper-slide v-for="show in shows" :key="show.Id">
-                <template #content>
-                  <card :item="show" />
-                </template>
-              </vueper-slide>
-
-              <template #arrow-left>
-                <v-btn icon large>
-                  <v-icon>mdi-arrow-left</v-icon>
-                </v-btn>
-              </template>
-
-              <template #arrow-right>
-                <v-btn icon large>
-                  <v-icon>mdi-arrow-right</v-icon>
-                </v-btn>
-              </template>
-            </vueper-slides>
+            <swiper-section
+              :title="$t('shows')"
+              :items="shows"
+              :loading="loading"
+            />
           </v-col>
         </v-row>
       </v-col>
@@ -127,6 +78,7 @@
 <script lang="ts">
 import Vue from 'vue';
 import { mapActions } from 'vuex';
+import { SwiperOptions } from 'swiper';
 import { BaseItemDto, ImageType } from '@jellyfin/client-axios';
 import imageHelper from '~/mixins/imageHelper';
 import timeUtils from '~/mixins/timeUtils';
@@ -135,23 +87,34 @@ export default Vue.extend({
   mixins: [imageHelper, timeUtils],
   data() {
     return {
+      loading: true,
+      swiperOptions: {
+        initialSlide: 0,
+        freeMode: this.$browser.isMobile(),
+        effect: 'slide',
+        navigation: {
+          nextEl: `.swiper-next`,
+          prevEl: `.swiper-prev`
+        },
+        slidesPerView: 3,
+        breakpoints: {
+          600: {
+            slidesPerView: 4
+          },
+          960: {
+            slidesPerView: 6
+          },
+          1264: {
+            slidesPerView: 6
+          },
+          1904: {
+            slidesPerView: 8
+          }
+        }
+      } as SwiperOptions,
       item: {} as BaseItemDto,
       appearances: [] as BaseItemDto[],
-      backdropImageSource: '',
-      breakpoints: {
-        600: {
-          visibleSlides: 3
-        },
-        960: {
-          visibleSlides: 4
-        },
-        1264: {
-          visibleSlides: 6
-        },
-        1904: {
-          visibleSlides: 6
-        }
-      }
+      backdropImageSource: ''
     };
   },
   computed: {
@@ -200,6 +163,7 @@ export default Vue.extend({
     }
   },
   async beforeMount() {
+    this.loading = true;
     const item = (
       await this.$api.userLibrary.getItem({
         userId: this.$auth.user?.Id,
@@ -224,6 +188,7 @@ export default Vue.extend({
     if (appearances) {
       this.appearances = appearances;
     }
+    this.loading = false;
   },
   destroyed() {
     this.clearBackdrop();
@@ -261,42 +226,5 @@ export default Vue.extend({
   bottom: 0.3em;
   left: 0;
   width: 1.25em;
-}
-</style>
-
-<style>
-.vueperslides__track {
-  position: relative;
-  cursor: default !important;
-}
-
-@media (hover: none) {
-  .vueperslides__arrows {
-    display: none !important;
-  }
-}
-
-.vueperslides__arrows {
-  display: flex;
-  position: absolute;
-  top: -2.75em;
-  right: 0;
-  align-items: center;
-}
-
-.vueperslides__arrow {
-  position: relative;
-  display: inline-flex;
-  transform: none;
-}
-
-.vueperslides__arrow--prev {
-  margin-right: 0.75em;
-}
-.vueperslides:not(.no-shadow):not(.vueperslides--3d)
-  .vueperslides__parallax-wrapper::after,
-.vueperslides:not(.no-shadow):not(.vueperslides--3d)
-  .vueperslides__parallax-wrapper::before {
-  box-shadow: none;
 }
 </style>

--- a/pages/person/_itemId/index.vue
+++ b/pages/person/_itemId/index.vue
@@ -78,7 +78,6 @@
 <script lang="ts">
 import Vue from 'vue';
 import { mapActions } from 'vuex';
-import { SwiperOptions } from 'swiper';
 import { BaseItemDto, ImageType } from '@jellyfin/client-axios';
 import imageHelper from '~/mixins/imageHelper';
 import timeUtils from '~/mixins/timeUtils';
@@ -88,30 +87,6 @@ export default Vue.extend({
   data() {
     return {
       loading: true,
-      swiperOptions: {
-        initialSlide: 0,
-        freeMode: this.$browser.isMobile(),
-        effect: 'slide',
-        navigation: {
-          nextEl: `.swiper-next`,
-          prevEl: `.swiper-prev`
-        },
-        slidesPerView: 3,
-        breakpoints: {
-          600: {
-            slidesPerView: 4
-          },
-          960: {
-            slidesPerView: 6
-          },
-          1264: {
-            slidesPerView: 6
-          },
-          1904: {
-            slidesPerView: 8
-          }
-        }
-      } as SwiperOptions,
       item: {} as BaseItemDto,
       appearances: [] as BaseItemDto[],
       backdropImageSource: ''

--- a/plugins/components/vueperSlides.ts
+++ b/plugins/components/vueperSlides.ts
@@ -1,8 +1,0 @@
-import Vue from 'vue';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- Need to build a Type package for the module
-// @ts-ignore
-import { VueperSlides, VueperSlide } from 'vueperslides';
-import 'vueperslides/dist/vueperslides.css';
-
-Vue.component('VueperSlides', VueperSlides);
-Vue.component('VueperSlide', VueperSlide);

--- a/store/homeSection.ts
+++ b/store/homeSection.ts
@@ -104,8 +104,8 @@ export const actions: ActionTree<HomeSectionState, AppState> = {
   async getAudioResumes({ dispatch }) {
     try {
       const { data } = await this.$api.items.getResumeItems({
-        userId: this.$auth.user?.Id,
-        limit: 12,
+        userId: this.$auth.user.Id,
+        limit: 24,
         fields: [ItemFields.PrimaryImageAspectRatio],
         imageTypeLimit: 1,
         enableImageTypes: [
@@ -142,8 +142,8 @@ export const actions: ActionTree<HomeSectionState, AppState> = {
   async getVideoResumes({ dispatch }) {
     try {
       const { data } = await this.$api.items.getResumeItems({
-        userId: this.$auth.user?.Id,
-        limit: 12,
+        userId: this.$auth.user.Id,
+        limit: 24,
         fields: [ItemFields.PrimaryImageAspectRatio],
         imageTypeLimit: 1,
         enableImageTypes: [
@@ -180,8 +180,8 @@ export const actions: ActionTree<HomeSectionState, AppState> = {
   async getUpNext({ dispatch }, { parentId }: { parentId: string }) {
     try {
       const { data } = await this.$api.tvShows.getNextUp({
-        userId: this.$auth.user?.Id,
-        limit: 12,
+        userId: this.$auth.user.Id,
+        limit: 24,
         fields: [ItemFields.PrimaryImageAspectRatio],
         imageTypeLimit: 1,
         enableImageTypes: [
@@ -217,8 +217,8 @@ export const actions: ActionTree<HomeSectionState, AppState> = {
   async getLatestMedia({ dispatch }, { parentId }: { parentId: string }) {
     try {
       const { data } = await this.$api.userLibrary.getLatestMedia({
-        userId: this.$auth.user?.Id,
-        limit: 12,
+        userId: this.$auth.user.Id,
+        limit: 24,
         fields: [ItemFields.PrimaryImageAspectRatio],
         imageTypeLimit: 1,
         enableImageTypes: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -14126,11 +14126,6 @@ vue@^2.6.10, vue@^2.6.12:
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.12.tgz#f5ebd4fa6bd2869403e29a896aed4904456c9123"
   integrity sha512-uhmLFETqPPNyuLLbsKz6ioJ4q7AZHzD8ZVFNATNyICSZouqP2Sz0rotWQC8UNBF6VGSCs5abnKJoStA6JbCbfg==
 
-vueperslides@^2.12.1:
-  version "2.12.1"
-  resolved "https://registry.yarnpkg.com/vueperslides/-/vueperslides-2.12.1.tgz#5dcb0e7b68ea1a2b997bfcf9beb29744963db5b0"
-  integrity sha512-XStW/eBRnjDEtNHj+47vcQ1gwDAjzKldnmQw1hegJPpeY2rd1OQsE6g2SG+2TsUBV+WfEklOXWJ+fPU8eLTemw==
-
 vuetify-loader@^1.4.3:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/vuetify-loader/-/vuetify-loader-1.6.0.tgz#05df0805b3ab2ff0de198109d34f9da3f69da667"


### PR DESCRIPTION
This removes all instances of Vueper Slides in the code, and replaces all the uses with Swiper. The reasoning is that Swiper is a better library and is officially supported on Vue 3 already.

This also removes some code duplication by creating a `<swiper-section>` component, which is able to take all the options of the various old usages of Vueper and replaces it everywhere. It incorporates the loading skeleton, allows you to override the section title and supports multiple sections on one page (through generating a UUID for each instance, which is then used in the root class of the component in order to differentiate it from other instances of Swiper on the page).

This change also leads to fixing a major issue with the old sliders, which prevented usage on mobile. These new sections use per-page navigation on non-mobile devices, while mobile devices use a more mobile-appropriate "free mode" to allow swiping through items easily.