### PR TITLE
refactor(settings): group settings into sections

### DIFF
--- a/pages/settings/index.vue
+++ b/pages/settings/index.vue
@@ -87,27 +87,34 @@
           </v-list-item-group>
         </v-list>
         <!-- Administrator settings -->
-        <v-list v-if="$auth.user.Policy.IsAdministrator" two-line class="mb-4">
-          <v-list-item-group>
-            <v-list-item
-              v-for="adminItem in adminItems"
-              :key="adminItem.name"
-              nuxt
-              :to="adminItem.link"
-            >
-              <v-list-item-avatar>
-                <v-icon v-text="adminItem.icon" />
-              </v-list-item-avatar>
-              <v-list-item-content>
-                <v-list-item-title v-text="adminItem.name" />
-                <v-list-item-subtitle v-text="adminItem.description" />
-              </v-list-item-content>
-              <v-list-item-action>
-                <v-icon>mdi-chevron-right</v-icon>
-              </v-list-item-action>
-            </v-list-item>
-          </v-list-item-group>
-        </v-list>
+        <div v-if="$auth.user.Policy.IsAdministrator">
+          <v-list
+            v-for="(adminSection, index) in adminSections"
+            :key="`admin-section-${index}`"
+            two-line
+            class="mb-4"
+          >
+            <v-list-item-group>
+              <v-list-item
+                v-for="adminItem in adminSection"
+                :key="adminItem.name"
+                nuxt
+                :to="adminItem.link"
+              >
+                <v-list-item-avatar>
+                  <v-icon v-text="adminItem.icon" />
+                </v-list-item-avatar>
+                <v-list-item-content>
+                  <v-list-item-title v-text="adminItem.name" />
+                  <v-list-item-subtitle v-text="adminItem.description" />
+                </v-list-item-content>
+                <v-list-item-action>
+                  <v-icon>mdi-chevron-right</v-icon>
+                </v-list-item-action>
+              </v-list-item>
+            </v-list-item-group>
+          </v-list>
+        </div>
         <about-links v-if="$vuetify.breakpoint.mobile" />
       </v-col>
     </v-row>
@@ -155,75 +162,83 @@ export default Vue.extend({
           description: this.$t('settingsSections.subtitles.description')
         }
       ],
-      adminItems: [
-        {
-          icon: 'mdi-server',
-          name: this.$t('settingsSections.server.name'),
-          description: this.$t('settingsSections.server.description')
-        },
-        {
-          icon: 'mdi-devices',
-          name: this.$t('settingsSections.devices.name'),
-          description: this.$t('settingsSections.devices.description')
-        },
-        {
-          icon: 'mdi-account-multiple',
-          name: this.$t('settingsSections.users.name'),
-          description: this.$t('settingsSections.users.description')
-        },
-        {
-          icon: 'mdi-library-shelves',
-          name: this.$t('settingsSections.libraries.name'),
-          description: this.$t('settingsSections.libraries.description')
-        },
-        {
-          icon: 'mdi-play-network',
-          name: this.$t('settingsSections.transcodingAndStreaming.name'),
-          description: this.$t(
-            'settingsSections.transcodingAndStreaming.description'
-          )
-        },
-        {
-          icon: 'mdi-dlna',
-          name: this.$t('settingsSections.dlna.name'),
-          description: this.$t('settingsSections.dlna.description')
-        },
-        {
-          icon: 'mdi-television-classic',
-          name: this.$t('settingsSections.liveTvAndDvr.name'),
-          description: this.$t('settingsSections.liveTvAndDvr.description')
-        },
-        {
-          icon: 'mdi-network',
-          name: this.$t('settingsSections.networking.name'),
-          description: this.$t('settingsSections.networking.description')
-        },
-        {
-          icon: 'mdi-puzzle',
-          name: this.$t('settingsSections.plugins.name'),
-          description: this.$t('settingsSections.plugins.description')
-        },
-        {
-          icon: 'mdi-key-chain',
-          name: this.$t('settingsSections.apiKeys.name'),
-          description: this.$t('settingsSections.apiKeys.description')
-        },
-        {
-          icon: 'mdi-calendar-clock',
-          name: this.$t('settingsSections.scheduledTasks.name'),
-          description: this.$t('settingsSections.scheduledTasks.description')
-        },
-        {
-          icon: 'mdi-bell',
-          name: this.$t('settingsSections.notifications.name'),
-          description: this.$t('settingsSections.notifications.description')
-        },
-        {
-          icon: 'mdi-text-box',
-          name: this.$t('settingsSections.logs.name'),
-          description: this.$t('settingsSections.logs.description'),
-          link: 'settings/logsAndActivity'
-        }
+      adminSections: [
+        [
+          {
+            icon: 'mdi-server',
+            name: this.$t('settingsSections.server.name'),
+            description: this.$t('settingsSections.server.description')
+          },
+          {
+            icon: 'mdi-devices',
+            name: this.$t('settingsSections.devices.name'),
+            description: this.$t('settingsSections.devices.description')
+          },
+          {
+            icon: 'mdi-library-shelves',
+            name: this.$t('settingsSections.libraries.name'),
+            description: this.$t('settingsSections.libraries.description')
+          }
+        ],
+        [
+          {
+            icon: 'mdi-account-multiple',
+            name: this.$t('settingsSections.users.name'),
+            description: this.$t('settingsSections.users.description')
+          },
+          {
+            icon: 'mdi-key-chain',
+            name: this.$t('settingsSections.apiKeys.name'),
+            description: this.$t('settingsSections.apiKeys.description')
+          }
+        ],
+        [
+          {
+            icon: 'mdi-play-network',
+            name: this.$t('settingsSections.transcodingAndStreaming.name'),
+            description: this.$t(
+              'settingsSections.transcodingAndStreaming.description'
+            )
+          },
+          {
+            icon: 'mdi-dlna',
+            name: this.$t('settingsSections.dlna.name'),
+            description: this.$t('settingsSections.dlna.description')
+          },
+          {
+            icon: 'mdi-television-classic',
+            name: this.$t('settingsSections.liveTvAndDvr.name'),
+            description: this.$t('settingsSections.liveTvAndDvr.description')
+          },
+          {
+            icon: 'mdi-network',
+            name: this.$t('settingsSections.networking.name'),
+            description: this.$t('settingsSections.networking.description')
+          }
+        ],
+        [
+          {
+            icon: 'mdi-puzzle',
+            name: this.$t('settingsSections.plugins.name'),
+            description: this.$t('settingsSections.plugins.description')
+          },
+          {
+            icon: 'mdi-calendar-clock',
+            name: this.$t('settingsSections.scheduledTasks.name'),
+            description: this.$t('settingsSections.scheduledTasks.description')
+          },
+          {
+            icon: 'mdi-bell',
+            name: this.$t('settingsSections.notifications.name'),
+            description: this.$t('settingsSections.notifications.description')
+          },
+          {
+            icon: 'mdi-text-box',
+            name: this.$t('settingsSections.logs.name'),
+            description: this.$t('settingsSections.logs.description'),
+            link: 'settings/logsAndActivity'
+          }
+        ]
       ]
     };
   },


### PR DESCRIPTION
To help with the readability of the page, this groups admin settings into logical groups, in order
to break up the flow of that long list of entries.

![image](https://user-images.githubusercontent.com/19396809/102594476-8c11e100-4116-11eb-9efd-ddf80522e568.png)
