### PR TITLE
feat(season tabs): refactor tvShows Vuex store to use itemIds

### DIFF
--- a/components/SeasonTabs.vue
+++ b/components/SeasonTabs.vue
@@ -34,9 +34,9 @@
 </template>
 
 <script lang="ts">
+import { BaseItemDto } from '@jellyfin/client-axios';
 import Vue from 'vue';
-import { mapState, mapActions } from 'vuex';
-import { AppState } from '~/store';
+import { mapActions, mapGetters } from 'vuex';
 
 export default Vue.extend({
   props: {
@@ -64,14 +64,21 @@ export default Vue.extend({
       }
     };
   },
-  computed: mapState<AppState>({
-    seasons: (state: AppState) => state.tvShows.seasons,
-    seasonEpisodes: (state: AppState) => state.tvShows.seasonEpisodes
-  }),
+  computed: {
+    ...mapGetters('tvShows', ['getSeasons', 'getSeasonEpisodes']),
+    seasons(): BaseItemDto[] {
+      return this.getSeasons({
+        itemId: this.item.Id
+      });
+    },
+    seasonEpisodes(): BaseItemDto[][] {
+      return this.getSeasonEpisodes({
+        itemId: this.item.Id
+      });
+    }
+  },
   async beforeMount() {
-    await this.getTvShows({
-      item: this.item
-    });
+    await this.getTvShows({ itemId: this.item.Id });
   },
   methods: {
     ...mapActions('tvShows', {

--- a/store/homeSection.ts
+++ b/store/homeSection.ts
@@ -1,3 +1,4 @@
+import Vue from 'vue';
 import { ActionTree, GetterTree, MutationTree } from 'vuex';
 import {
   BaseItemDto,
@@ -5,7 +6,6 @@ import {
   ImageType,
   ItemFields
 } from '@jellyfin/client-axios';
-import Vue from 'vue';
 import { AppState } from './index';
 
 export interface HomeSection {


### PR DESCRIPTION
**Current Approach**

```
store = {
   seasons: BaseItemDTo[],
   seasonEpisodes: BaseItemDTo[][]
```

**Updated Approach**
The key used is the item Id for the series
```
store = {
   [key: string]: {
      seasons: BaseItemDTo[],
      seasonEpisodes: BaseItemDTo[][]
   }
}
```

This allows for multiple seasons to be stored in the vuex store
