### PR TITLE
fix(library): fix folder navigation and sorting

### DIFF
--- a/components/TypeButton.vue
+++ b/components/TypeButton.vue
@@ -2,7 +2,7 @@
   <v-menu offset-y>
     <template #activator="{ on, attrs }">
       <v-btn
-        v-if="!$vuetify.breakpoint.smAndDown"
+        v-if="!$vuetify.breakpoint.smAndDown && items[model]"
         class="my-2"
         text
         rounded

--- a/pages/library/_viewId.vue
+++ b/pages/library/_viewId.vue
@@ -9,11 +9,16 @@
       </v-chip>
       <v-divider inset vertical class="mx-2 hidden-sm-and-down" />
       <type-button
-        v-if="collectionInfo.CollectionType"
+        v-if="hasViewTypes"
         :type="collectionInfo.CollectionType"
         @change="onChangeType"
       />
-      <v-divider v-if="isSortable" inset vertical class="mx-2" />
+      <v-divider
+        v-if="isSortable && hasViewTypes"
+        inset
+        vertical
+        class="mx-2"
+      />
       <sort-button v-if="isSortable" @change="onChangeSort" />
       <filter-button
         v-if="isSortable"
@@ -69,7 +74,17 @@ export default Vue.extend({
     };
   },
   computed: {
-    isSortable() {
+    hasViewTypes(): boolean {
+      if (
+        ['homevideos'].includes(this.collectionInfo.CollectionType || '') ||
+        this.collectionInfo.CollectionType === undefined
+      ) {
+        return false;
+      } else {
+        return true;
+      }
+    },
+    isSortable(): boolean {
       // Not everything is sortable, so depending on what we're showing, we need to hide the sort menu.
       // Reusing this as "isFilterable" too, since these seem to go hand in hand for now.
       if (
@@ -141,6 +156,7 @@ export default Vue.extend({
             this.viewType = 'MusicAlbum';
             break;
           default:
+            this.refreshItems();
             break;
         }
 
@@ -254,14 +270,17 @@ export default Vue.extend({
             ).data;
             break;
           default:
+            console.warn('loading default items');
+            console.warn(this.collectionInfo.IsFolder);
             itemsResponse = (
               await this.$api.items.getItems({
                 uId: this.$auth.user.Id,
                 userId: this.$auth.user.Id,
                 parentId: this.$route.params.viewId,
                 includeItemTypes: this.viewType,
-                recursive: true,
-                sortBy: this.sortBy,
+                sortBy: this.collectionInfo.IsFolder
+                  ? 'IsFolder,SortName'
+                  : this.sortBy,
                 sortOrder: 'Ascending',
                 filters: this.statusFilter ? this.statusFilter : undefined,
                 genres: this.genresFilter ? this.genresFilter : undefined,

--- a/pages/library/_viewId.vue
+++ b/pages/library/_viewId.vue
@@ -270,8 +270,6 @@ export default Vue.extend({
             ).data;
             break;
           default:
-            console.warn('loading default items');
-            console.warn(this.collectionInfo.IsFolder);
             itemsResponse = (
               await this.$api.items.getItems({
                 uId: this.$auth.user.Id,


### PR DESCRIPTION
With the introduction of the filter button and view modes, folder views such as Photos libraries
were broken. This makes some adjustments in order to restore navigation in these libraries.