### PR TITLE
fix(item details): add missing translations

### DIFF
--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -11,6 +11,7 @@
   "art": "Art",
   "artist": "Artist",
   "artists": "Artists",
+  "audio": "Audio",
   "backdrop": "Backdrop",
   "badRequest": "Bad request. Try again",
   "banner": "Banner",
@@ -241,6 +242,7 @@
     "mustBeUrl": "This field must be a valid URL",
     "required": "This field is required"
   },
+  "video": "Video",
   "videoTypes": "Video Types",
   "viewDetails": "View details",
   "vueClientVersion": "Vue client version",

--- a/pages/item/_itemId/index.vue
+++ b/pages/item/_itemId/index.vue
@@ -110,7 +110,7 @@
               >
                 <v-row v-if="item.MediaSources.length > 1">
                   <v-col cols="2" class="d-flex align-center pa-0">
-                    <label class="text--secondary">Video</label>
+                    <label class="text--secondary">{{ $t('video') }}</label>
                   </v-col>
                   <v-col cols="7">
                     <v-select
@@ -131,7 +131,7 @@
                 </v-row>
                 <v-row v-if="videoTracks.length > 0">
                   <v-col cols="2" class="d-flex align-center pa-0">
-                    <label class="text--secondary">Video</label>
+                    <label class="text--secondary">{{ $t('video') }}</label>
                   </v-col>
                   <v-col cols="7">
                     <v-select
@@ -153,7 +153,7 @@
                 </v-row>
                 <v-row v-if="audioTracks.length > 0">
                   <v-col cols="2" class="d-flex align-center pa-0">
-                    <label class="text--secondary">Audio</label>
+                    <label class="text--secondary">{{ $t('audio') }}</label>
                   </v-col>
                   <v-col cols="7">
                     <v-select
@@ -191,7 +191,7 @@
                 </v-row>
                 <v-row v-if="subtitleTracks.length > 0">
                   <v-col cols="2" class="d-flex align-center pa-0">
-                    <label class="text--secondary">Subtitles</label>
+                    <label class="text--secondary">{{ $t('subtitles') }}</label>
                   </v-col>
                   <v-col cols="7">
                     <v-select


### PR DESCRIPTION
Adds missing translations for:
`subtitles`
`video`
`audio`
 on item details page