### PR TITLE
Improvments on item v-select

### DIFF
--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -231,6 +231,7 @@
   "unableGetPublicUsers": "Unable to get users",
   "unableGetRelated": "Unable to get related items",
   "unableGetServerConfiguration": "Unable to get server configuration",
+  "undefined": "Undefined",
   "unexpectedError": "Unexpected error",
   "unhandledException": "Unhandled exception",
   "unliked": "Unliked",

--- a/mixins/formsHelper.ts
+++ b/mixins/formsHelper.ts
@@ -1,0 +1,44 @@
+/**
+ * Helper for form related functions
+ *
+ * @mixin
+ */
+import Vue from 'vue';
+
+interface VSelectItem {
+  value: unknown;
+}
+
+declare module '@nuxt/types' {
+  interface Context {
+    getItemizedSelect: (values: unknown[]) => VSelectItem[];
+  }
+
+  interface NuxtAppOptions {
+    getItemizedSelect: (values: unknown[]) => VSelectItem[];
+  }
+}
+
+declare module 'vue/types/vue' {
+  interface Vue {
+    getItemizedSelect: (values: unknown[]) => VSelectItem[];
+  }
+}
+
+const formsHelper = Vue.extend({
+  methods: {
+    /**
+     * Returns a list suitable for use with the 'item' prop for v-select
+     *
+     * @param {any[]} values list of values to use for the v-select
+     * @returns {VSelectItem[]} list ready to be used in the :item property of a v-select
+     */
+    getItemizedSelect(values: unknown[]): VSelectItem[] {
+      return values.map((value) => {
+        return { value };
+      });
+    }
+  }
+});
+
+export default formsHelper;

--- a/pages/item/_itemId/index.vue
+++ b/pages/item/_itemId/index.vue
@@ -298,9 +298,10 @@ import {
   MediaStream
 } from '@jellyfin/client-axios';
 import imageHelper from '~/mixins/imageHelper';
+import formsHelper from '~/mixins/formsHelper';
 
 export default Vue.extend({
-  mixins: [imageHelper],
+  mixins: [imageHelper, formsHelper],
   data() {
     return {
       loaded: false,
@@ -416,11 +417,6 @@ export default Vue.extend({
   },
   methods: {
     ...mapActions('backdrop', ['setBackdrop', 'clearBackdrop']),
-    getItemizedSelect(objects: any[]) {
-      return objects.map((item: any) => {
-        return { value: item };
-      });
-    },
     getLanguageName(code?: string) {
       if (!code) return this.$t('undefined');
       return langs.where('2B', code).name;

--- a/pages/item/_itemId/index.vue
+++ b/pages/item/_itemId/index.vue
@@ -115,7 +115,7 @@
                   <v-col cols="7">
                     <v-select
                       v-model="currentSource"
-                      :items="item.MediaSources"
+                      :items="getItemizedSelect(item.MediaSources)"
                       outlined
                       filled
                       flat
@@ -124,7 +124,7 @@
                       hide-details
                     >
                       <template slot="selection" slot-scope="{ item: i }">
-                        {{ i.DisplayTitle }}
+                        {{ i.value.DisplayTitle }}
                       </template>
                     </v-select>
                   </v-col>
@@ -136,7 +136,7 @@
                   <v-col cols="7">
                     <v-select
                       v-model="currentVideoTrack"
-                      :items="videoTracks"
+                      :items="getItemizedSelect(videoTracks)"
                       :disabled="videoTracks.length <= 1"
                       outlined
                       filled
@@ -146,7 +146,7 @@
                       hide-details
                     >
                       <template slot="selection" slot-scope="{ item: i }">
-                        {{ i.DisplayTitle }}
+                        {{ i.value.DisplayTitle }}
                       </template>
                     </v-select>
                   </v-col>
@@ -159,7 +159,7 @@
                     <v-select
                       v-if="audioTracks.length > 1"
                       v-model="currentAudioTrack"
-                      :items="audioTracks"
+                      :items="getItemizedSelect(audioTracks)"
                       :disabled="audioTracks.length <= 1"
                       outlined
                       filled
@@ -169,21 +169,21 @@
                       hide-details
                     >
                       <template slot="selection" slot-scope="{ item: i }">
-                        {{ i.DisplayTitle }}
+                        {{ i.value.DisplayTitle }}
                       </template>
                       <template slot="item" slot-scope="{ item: i, on, attrs }">
                         <v-list-item v-bind="attrs" two-line v-on="on">
                           <v-list-item-avatar>
                             <v-icon
-                              v-text="getSurroundIcon(i.ChannelLayout)"
+                              v-text="getSurroundIcon(i.value.ChannelLayout)"
                             ></v-icon>
                           </v-list-item-avatar>
                           <v-list-item-content>
                             <v-list-item-title>{{
-                              i.DisplayTitle
+                              i.value.DisplayTitle
                             }}</v-list-item-title>
                             <v-list-item-subtitle>
-                              {{ getLanguageName(i.Language) }}
+                              {{ getLanguageName(i.value.Language) }}
                             </v-list-item-subtitle>
                           </v-list-item-content>
                         </v-list-item>
@@ -199,7 +199,7 @@
                     <v-select
                       v-if="subtitleTracks.length > 0"
                       v-model="currentSubtitleTrack"
-                      :items="subtitleTracks"
+                      :items="getItemizedSelect(subtitleTracks)"
                       outlined
                       filled
                       flat
@@ -208,16 +208,16 @@
                       hide-details
                     >
                       <template slot="selection" slot-scope="{ item: i }">
-                        {{ i.DisplayTitle }}
+                        {{ i.value.DisplayTitle }}
                       </template>
                       <template slot="item" slot-scope="{ item: i, on, attrs }">
                         <v-list-item v-bind="attrs" two-line v-on="on">
                           <v-list-item-content>
                             <v-list-item-title>{{
-                              i.DisplayTitle
+                              i.value.DisplayTitle
                             }}</v-list-item-title>
                             <v-list-item-subtitle>
-                              {{ getLanguageName(i.Language) }}
+                              {{ getLanguageName(i.value.Language) }}
                             </v-list-item-subtitle>
                           </v-list-item-content>
                         </v-list-item>
@@ -414,6 +414,11 @@ export default Vue.extend({
   },
   methods: {
     ...mapActions('backdrop', ['setBackdrop', 'clearBackdrop']),
+    getItemizedSelect(objects: any[]) {
+      return objects.map((item: any) => {
+        return { value: item };
+      });
+    },
     getLanguageName(code?: string) {
       if (!code) return this.$t('undefined');
       return langs.where('2B', code).name;

--- a/pages/item/_itemId/index.vue
+++ b/pages/item/_itemId/index.vue
@@ -157,7 +157,7 @@
                   </v-col>
                   <v-col cols="7">
                     <v-select
-                      v-if="audioTracks.length > 1"
+                      v-if="audioTracks.length > 0"
                       v-model="currentAudioTrack"
                       :items="getItemizedSelect(audioTracks)"
                       :disabled="audioTracks.length <= 1"
@@ -392,15 +392,17 @@ export default Vue.extend({
             this.currentSource.DefaultAudioStreamIndex
           ) {
             this.currentAudioTrack = this.audioTracks[
-              this.currentSource.DefaultAudioStreamIndex
+              this.currentSource.DefaultAudioStreamIndex - 1
             ];
+          } else if (this.audioTracks.length > 0) {
+            this.currentAudioTrack = this.audioTracks[0];
           }
           if (
             this.subtitleTracks.length > 0 &&
             this.currentSource.DefaultSubtitleStreamIndex
           ) {
             this.currentSubtitleTrack = this.subtitleTracks[
-              this.currentSource.DefaultSubtitleStreamIndex
+              this.currentSource.DefaultSubtitleStreamIndex - 1
             ];
           }
         }

--- a/pages/item/_itemId/index.vue
+++ b/pages/item/_itemId/index.vue
@@ -179,7 +179,9 @@
                             ></v-icon>
                           </v-list-item-avatar>
                           <v-list-item-content>
-                            <v-list-item-title>{{ i.Title }}</v-list-item-title>
+                            <v-list-item-title>{{
+                              i.DisplayTitle
+                            }}</v-list-item-title>
                             <v-list-item-subtitle>
                               {{ getLanguageName(i.Language) }}
                             </v-list-item-subtitle>
@@ -211,7 +213,9 @@
                       <template slot="item" slot-scope="{ item: i, on, attrs }">
                         <v-list-item v-bind="attrs" two-line v-on="on">
                           <v-list-item-content>
-                            <v-list-item-title>{{ i.Title }}</v-list-item-title>
+                            <v-list-item-title>{{
+                              i.DisplayTitle
+                            }}</v-list-item-title>
                             <v-list-item-subtitle>
                               {{ getLanguageName(i.Language) }}
                             </v-list-item-subtitle>
@@ -411,7 +415,7 @@ export default Vue.extend({
   methods: {
     ...mapActions('backdrop', ['setBackdrop', 'clearBackdrop']),
     getLanguageName(code?: string) {
-      if (!code) return '';
+      if (!code) return this.$t('undefined');
       return langs.where('2B', code).name;
     },
     getSurroundIcon(layout: string) {


### PR DESCRIPTION
* Replace empty string by `undefined` string when language is unknown for audio & subs
* Fix audio & subs titles being called by a misnamed property
* Fix `v-select` being directly fed the array of values when it's supposed to get an array of objects as { value } (see the Vuetify API, this object can provide a few more options which we don't  use now). It resulted in the select thinking 'activating' every input once one was selected
* Fix logic error for default audio & sub selection (index by the server starts at 1 it seems, we directly used this number to get from the local array which starts at 0)
* Fix audio `v-select` not appearing when a single track was available due to bad boolean logic