### PR TITLE
fix(player-manager): fix scroll when a player is open

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,5 +85,3 @@ jobs:
         run: yarn test
       - name: Upload coverage
         uses: codecov/codecov-action@v1
-        with:
-          fail_ci_if_error: true

--- a/components/PlayerDialog.vue
+++ b/components/PlayerDialog.vue
@@ -1,0 +1,36 @@
+<script lang="ts">
+import Vue from 'vue';
+import { VDialog } from 'vuetify/lib';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import { keyCodes } from 'vuetify/lib/util/helpers';
+
+export default Vue.extend({
+  extends: VDialog,
+  methods: {
+    // Copy of https://github.com/vuetifyjs/vuetify/blob/master/packages/vuetify/src/mixins/overlayable/index.ts#L129-L152
+    // A block preventing scroll on the overlay has been removed, since we always want to scroll.
+    scrollListener(e: WheelEvent & KeyboardEvent) {
+      if (e.type === 'keydown') {
+        if (
+          ['INPUT', 'TEXTAREA', 'SELECT'].includes(
+            (e.target as Element).tagName
+          ) ||
+          // https://github.com/vuetifyjs/vuetify/issues/4715
+          (e.target as HTMLElement).isContentEditable
+        )
+          return;
+
+        const up = [keyCodes.up, keyCodes.pageup];
+        const down = [keyCodes.down, keyCodes.pagedown];
+
+        if (up.includes(e.keyCode)) {
+          (e as any).deltaY = -1;
+        } else if (down.includes(e.keyCode)) {
+          (e as any).deltaY = 1;
+        }
+      }
+    }
+  }
+});
+</script>

--- a/components/PlayerManager.vue
+++ b/components/PlayerManager.vue
@@ -1,10 +1,11 @@
 <template>
-  <v-dialog
+  <player-dialog
     dark
     persistent
     hide-overlay
     no-click-animation
     scrollable
+    :fullscreen="!isMinimized"
     :retain-focus="!isMinimized"
     :content-class="getContentClass()"
     :width="$vuetify.breakpoint.mobile ? '60vw' : '25vw'"
@@ -22,7 +23,7 @@
         </v-fade-transition>
       </v-card>
     </v-hover>
-  </v-dialog>
+  </player-dialog>
 </template>
 
 <script lang="ts">


### PR DESCRIPTION
This attempts to fix the scroll issue with the player dialog, by extending `v-dialog` and removing a block of code from the `scrollListener`, which was seemingly preventing scroll events on the overlay from doing anything.

I'm not fully sure this works as intended, so **please test this when reviewing**.