### PR TITLE
feat(player-manager): add mini player OSD

### DIFF
--- a/components/PlayerManager.vue
+++ b/components/PlayerManager.vue
@@ -26,15 +26,30 @@
                 </v-btn>
               </div>
               <div class="absolute d-flex flex-row justify-center align-center">
-                <v-btn icon large @click="setPreviousTrack">
+                <v-btn
+                  class="all-pointer-events"
+                  icon
+                  large
+                  @click="setPreviousTrack"
+                >
                   <v-icon size="32">mdi-skip-previous</v-icon>
                 </v-btn>
-                <v-btn icon x-large @click="togglePause">
+                <v-btn
+                  class="all-pointer-events"
+                  icon
+                  x-large
+                  @click="togglePause"
+                >
                   <v-icon size="48">{{
                     isPaused ? 'mdi-play' : 'mdi-pause'
                   }}</v-icon>
                 </v-btn>
-                <v-btn icon large @click="setNextTrack">
+                <v-btn
+                  class="all-pointer-events"
+                  icon
+                  large
+                  @click="setNextTrack"
+                >
                   <v-icon size="32">mdi-skip-next</v-icon>
                 </v-btn>
               </div>
@@ -222,6 +237,7 @@ export default Vue.extend({
 
 <style lang="scss">
 .absolute {
+  pointer-events: none;
   height: 100%;
   width: 100%;
   position: absolute;
@@ -229,6 +245,10 @@ export default Vue.extend({
   left: 0;
   right: 0;
   bottom: 0;
+}
+
+.all-pointer-events {
+  pointer-events: all;
 }
 
 .v-card.player-card {

--- a/components/PlayerManager.vue
+++ b/components/PlayerManager.vue
@@ -15,9 +15,30 @@
         <video-player v-if="isPlaying" />
         <v-fade-transition>
           <v-overlay v-show="hover && isMinimized" absolute>
-            <v-btn icon @click="toggleMinimized">
-              <v-icon>mdi-arrow-expand-all</v-icon>
-            </v-btn>
+            <div class="d-flex flex-column player-overlay">
+              <div class="d-flex flex-row">
+                <v-btn icon @click="toggleMinimized">
+                  <v-icon>mdi-arrow-expand-all</v-icon>
+                </v-btn>
+                <v-spacer />
+                <v-btn icon @click="stopPlayback">
+                  <v-icon>mdi-close</v-icon>
+                </v-btn>
+              </div>
+              <div class="absolute d-flex flex-row justify-center align-center">
+                <v-btn icon large @click="setPreviousTrack">
+                  <v-icon size="32">mdi-skip-previous</v-icon>
+                </v-btn>
+                <v-btn icon x-large @click="togglePause">
+                  <v-icon size="48">{{
+                    isPaused ? 'mdi-play' : 'mdi-pause'
+                  }}</v-icon>
+                </v-btn>
+                <v-btn icon large @click="setNextTrack">
+                  <v-icon size="32">mdi-skip-next</v-icon>
+                </v-btn>
+              </div>
+            </div>
           </v-overlay>
         </v-fade-transition>
       </v-card>
@@ -45,6 +66,9 @@ export default Vue.extend({
       return (
         this.$store.state.playbackManager.status !== PlaybackStatus.stopped
       );
+    },
+    isPaused(): boolean {
+      return this.$store.state.playbackManager.status === PlaybackStatus.paused;
     },
     isMinimized(): boolean {
       return this.$store.state.playbackManager.isMinimized;
@@ -99,6 +123,7 @@ export default Vue.extend({
           const now = new Date().getTime();
 
           if (
+            this.getCurrentItem !== null &&
             now - state.playbackManager.lastProgressUpdate > 1000 &&
             state.playbackManager.currentTime !== null
           ) {
@@ -163,7 +188,14 @@ export default Vue.extend({
   methods: {
     ...mapActions('playbackManager', [
       'toggleMinimized',
-      'setLastProgressUpdate'
+      'setLastProgressUpdate',
+      'resetCurrentItemIndex',
+      'setNextTrack',
+      'setPreviousTrack',
+      'setLastItemIndex',
+      'resetLastItemIndex',
+      'pause',
+      'unpause'
     ]),
     getContentClass(): string {
       return `player ${
@@ -171,14 +203,47 @@ export default Vue.extend({
           ? 'player--minimized align-self-end'
           : 'player--fullscreen'
       }`;
+    },
+    stopPlayback() {
+      this.setLastItemIndex();
+      this.resetCurrentItemIndex();
+      this.setNextTrack();
+    },
+    togglePause() {
+      if (this.isPaused) {
+        this.unpause();
+      } else {
+        this.pause();
+      }
     }
   }
 });
 </script>
 
 <style lang="scss">
+.absolute {
+  height: 100%;
+  width: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+}
+
 .v-card.player-card {
   background-color: black !important;
+}
+
+.v-overlay .v-overlay__content {
+  width: 100%;
+  height: 100%;
+  padding: 8px;
+  box-sizing: border-box;
+}
+
+.player-overlay {
+  height: 100%;
 }
 
 .player--fullscreen {

--- a/components/VideoPlayer.vue
+++ b/components/VideoPlayer.vue
@@ -95,13 +95,19 @@ export default Vue.extend({
         this.$store.subscribe((mutation, _state: AppState) => {
           switch (mutation.type) {
             case 'playbackManager/PAUSE_PLAYBACK':
-              (this.$refs.videoPlayer as HTMLVideoElement).pause();
+              if (this.$refs.videoPlayer) {
+                (this.$refs.videoPlayer as HTMLVideoElement).pause();
+              }
               break;
             case 'playbackManager/UNPAUSE_PLAYBACK':
-              (this.$refs.videoPlayer as HTMLVideoElement).play();
+              if (this.$refs.videoPlayer) {
+                (this.$refs.videoPlayer as HTMLVideoElement).play();
+              }
               break;
             case 'playbackManager/RESET_CURRENT_TIME':
-              (this.$refs.videoPlayer as HTMLVideoElement).currentTime = 0;
+              if (this.$refs.videoPlayer) {
+                (this.$refs.videoPlayer as HTMLVideoElement).currentTime = 0;
+              }
           }
         });
       } else {

--- a/components/VideoPlayer.vue
+++ b/components/VideoPlayer.vue
@@ -26,6 +26,7 @@ import muxjs from 'mux.js';
 import { mapActions, mapGetters, mapState } from 'vuex';
 import 'shaka-player/dist/controls.css';
 import { ImageType, PlaybackInfoResponse } from '@jellyfin/client-axios';
+import { AppState } from '~/store';
 import timeUtils from '~/mixins/timeUtils';
 import imageHelper from '~/mixins/imageHelper';
 
@@ -54,9 +55,9 @@ export default Vue.extend({
     poster(): string {
       return this.getImageUrlForElement(ImageType.Backdrop, {
         itemId:
-          this.getCurrentItem.ParentBackdropItemId ||
-          this.getCurrentItem.SeriesId ||
-          this.getCurrentItem.Id
+          this.getCurrentItem?.ParentBackdropItemId ||
+          this.getCurrentItem?.SeriesId ||
+          this.getCurrentItem?.Id
       });
     }
   },
@@ -90,6 +91,19 @@ export default Vue.extend({
         );
         // Register player events
         this.player.addEventListener('error', this.onPlayerError);
+        // Subscribe to Vuex actions
+        this.$store.subscribe((mutation, _state: AppState) => {
+          switch (mutation.type) {
+            case 'playbackManager/PAUSE_PLAYBACK':
+              (this.$refs.videoPlayer as HTMLVideoElement).pause();
+              break;
+            case 'playbackManager/UNPAUSE_PLAYBACK':
+              (this.$refs.videoPlayer as HTMLVideoElement).play();
+              break;
+            case 'playbackManager/RESET_CURRENT_TIME':
+              (this.$refs.videoPlayer as HTMLVideoElement).currentTime = 0;
+          }
+        });
       } else {
         this.$nuxt.error({
           message: this.$t('browserNotSupported') as string
@@ -122,69 +136,78 @@ export default Vue.extend({
       'setLastProgressUpdate'
     ]),
     async getPlaybackUrl(): Promise<void> {
-      this.playbackInfo = (
-        await this.$api.mediaInfo.getPostedPlaybackInfo({
-          itemId: this.getCurrentItem.Id || '',
-          userId: this.$auth.user.Id,
-          playbackInfoDto: { DeviceProfile: this.$playbackProfile }
-        })
-      ).data;
+      if (this.getCurrentItem) {
+        this.playbackInfo = (
+          await this.$api.mediaInfo.getPostedPlaybackInfo({
+            itemId: this.getCurrentItem?.Id || '',
+            userId: this.$auth.user.Id,
+            playbackInfoDto: { DeviceProfile: this.$playbackProfile }
+          })
+        ).data;
 
-      this.setPlaySessionId({ id: this.playbackInfo.PlaySessionId });
+        this.setPlaySessionId({ id: this.playbackInfo.PlaySessionId });
 
-      let mediaSource;
-      if (this.playbackInfo?.MediaSources) {
-        mediaSource = this.playbackInfo.MediaSources[0];
-        this.setMediaSource({ mediaSource });
-      } else {
-        throw new Error("This item can't be played.");
-      }
-
-      if (mediaSource.SupportsDirectStream) {
-        const directOptions: Record<
-          string,
-          string | boolean | undefined | null
-        > = {
-          Static: true,
-          mediaSourceId: mediaSource.Id,
-          deviceId: this.$store.state.deviceProfile.deviceId,
-          api_key: this.$store.state.user.accessToken
-        };
-
-        if (mediaSource.ETag) {
-          directOptions.Tag = mediaSource.ETag;
+        let mediaSource;
+        if (this.playbackInfo?.MediaSources) {
+          mediaSource = this.playbackInfo.MediaSources[0];
+          this.setMediaSource({ mediaSource });
+        } else {
+          throw new Error("This item can't be played.");
         }
 
-        if (mediaSource.LiveStreamId) {
-          directOptions.LiveStreamId = mediaSource.LiveStreamId;
-        }
+        if (mediaSource.SupportsDirectStream) {
+          const directOptions: Record<
+            string,
+            string | boolean | undefined | null
+          > = {
+            Static: true,
+            mediaSourceId: mediaSource.Id,
+            deviceId: this.$store.state.deviceProfile.deviceId,
+            api_key: this.$store.state.user.accessToken
+          };
 
-        const params = stringify(directOptions);
-        this.source = `${this.$axios.defaults.baseURL}/Videos/${mediaSource.Id}/stream.${mediaSource.Container}?${params}`;
-      } else if (
-        mediaSource.SupportsTranscoding &&
-        mediaSource.TranscodingUrl
-      ) {
-        this.source = this.$axios.defaults.baseURL + mediaSource.TranscodingUrl;
+          if (mediaSource.ETag) {
+            directOptions.Tag = mediaSource.ETag;
+          }
+
+          if (mediaSource.LiveStreamId) {
+            directOptions.LiveStreamId = mediaSource.LiveStreamId;
+          }
+
+          const params = stringify(directOptions);
+          this.source = `${this.$axios.defaults.baseURL}/Videos/${mediaSource.Id}/stream.${mediaSource.Container}?${params}`;
+        } else if (
+          mediaSource.SupportsTranscoding &&
+          mediaSource.TranscodingUrl
+        ) {
+          this.source =
+            this.$axios.defaults.baseURL + mediaSource.TranscodingUrl;
+        }
       }
     },
     onVideoProgress(_event?: Event): void {
-      const currentTime = (this.$refs.videoPlayer as HTMLVideoElement)
-        .currentTime;
+      if (this.$refs.videoPlayer) {
+        const currentTime = (this.$refs.videoPlayer as HTMLVideoElement)
+          .currentTime;
 
-      this.setCurrentTime({ time: currentTime });
+        this.setCurrentTime({ time: currentTime });
+      }
     },
     onVideoPause(_event?: Event): void {
-      const currentTime = (this.$refs.videoPlayer as HTMLVideoElement)
-        .currentTime;
-      this.setCurrentTime({ time: currentTime });
-      this.pause();
+      if (this.$refs.videoPlayer) {
+        const currentTime = (this.$refs.videoPlayer as HTMLVideoElement)
+          .currentTime;
+        this.setCurrentTime({ time: currentTime });
+        this.pause();
+      }
     },
     onVideoStopped(_event?: Event): void {
-      const currentTime = (this.$refs.videoPlayer as HTMLVideoElement)
-        .currentTime;
-      this.setCurrentTime({ time: currentTime });
-      this.setNextTrack();
+      if (this.$refs.videoPlayer) {
+        const currentTime = (this.$refs.videoPlayer as HTMLVideoElement)
+          .currentTime;
+        this.setCurrentTime({ time: currentTime });
+        this.setNextTrack();
+      }
     },
     onPlayerError(event: ErrorEvent): void {
       this.$emit('error', event);

--- a/store/playbackManager.ts
+++ b/store/playbackManager.ts
@@ -145,13 +145,37 @@ export const mutations: MutationTree<PlaybackManagerState> = {
   START_PLAYBACK(state: PlaybackManagerState) {
     state.status = PlaybackStatus.playing;
   },
+  UNPAUSE_PLAYBACK(state: PlaybackManagerState) {
+    state.status = PlaybackStatus.playing;
+  },
   PAUSE_PLAYBACK(state: PlaybackManagerState) {
     state.status = PlaybackStatus.paused;
   },
   STOP_PLAYBACK(state: PlaybackManagerState) {
-    state.lastItemIndex = state.currentItemIndex;
-    state.currentItemIndex = null;
     state.status = PlaybackStatus.stopped;
+    state.lastItemIndex = null;
+    state.currentItemIndex = null;
+    state.currentMediaSource = null;
+    state.currentVideoStreamIndex = 0;
+    state.currentAudioStreamIndex = 0;
+    state.currentSubtitleStreamIndex = 0;
+    state.currentItemChapters = null;
+    state.currentTime = null;
+    state.lastProgressUpdate = 0;
+    state.currentVolume = 100;
+    state.isFullscreen = false;
+    state.isMuted = false;
+    state.isShuffling = false;
+    state.isMinimized = true;
+    state.repeatMode = null;
+    state.queue = [];
+    state.playSessionId = null;
+  },
+  RESET_LAST_ITEM_INDEX(state: PlaybackManagerState) {
+    state.lastItemIndex = null;
+  },
+  SET_LAST_ITEM_INDEX(state: PlaybackManagerState) {
+    state.lastItemIndex = state.currentItemIndex;
   },
   SET_LAST_PROGRESS_UPDATE(state: PlaybackManagerState, { progress }) {
     state.lastProgressUpdate = progress;
@@ -170,6 +194,9 @@ export const mutations: MutationTree<PlaybackManagerState> = {
     { time }: { time: number | null }
   ) {
     state.currentTime = time;
+  },
+  RESET_CURRENT_TIME(state: PlaybackManagerState) {
+    state.currentTime = 0;
   },
   TOGGLE_MINIMIZE(state: PlaybackManagerState) {
     state.isMinimized = !state.isMinimized;
@@ -202,6 +229,9 @@ export const actions: ActionTree<PlaybackManagerState, PlaybackManagerState> = {
   pause({ commit }) {
     commit('PAUSE_PLAYBACK');
   },
+  unpause({ commit }) {
+    commit('UNPAUSE_PLAYBACK');
+  },
   clearQueue({ commit }) {
     commit('SET_QUEUE', { queue: [] });
   },
@@ -217,6 +247,24 @@ export const actions: ActionTree<PlaybackManagerState, PlaybackManagerState> = {
     } else {
       commit('STOP_PLAYBACK');
     }
+  },
+  setPreviousTrack({ commit, state }) {
+    if (state.currentTime !== null && state.currentTime > 2) {
+      commit('RESET_CURRENT_TIME');
+    } else if (state.currentItemIndex !== null && state.currentItemIndex > 0) {
+      commit('DECREASE_QUEUE_INDEX');
+    } else {
+      commit('RESET_CURRENT_TIME');
+    }
+  },
+  resetCurrentItemIndex({ commit }) {
+    commit('SET_CURRENT_ITEM_INDEX', { currentItemIndex: null });
+  },
+  setLastItemIndex({ commit }) {
+    commit('SET_LAST_ITEM_INDEX');
+  },
+  resetLastItemIndex({ commit }) {
+    commit('RESET_LAST_ITEM_INDEX');
   },
   setLastProgressUpdate({ commit }, { progress }: { progress: number }) {
     commit('SET_LAST_PROGRESS_UPDATE', { progress });


### PR DESCRIPTION
Adds a snazzy OSD to the mini player, allowing you to stop playback, move to the big player, pause/unpause and skip tracks.

Also fixes a bunch of bugs in the playback manager in order to get this working.

![image](https://user-images.githubusercontent.com/19396809/103143718-7dca5300-471c-11eb-98c2-f0841c193271.png)
