### PR TITLE
refactor(swiper-progress): fix z-index issue, responsive placement and adds padding

### DIFF
--- a/assets/global.scss
+++ b/assets/global.scss
@@ -44,3 +44,10 @@
 .layout-leave-to {
   opacity: 0;
 }
+
+/* Vuetify overrides
+   We can't set these through variables, so override them here */
+
+.v-app-bar.v-app-bar--fixed {
+  z-index: 100 !important;
+}

--- a/components/HomeHeader.vue
+++ b/components/HomeHeader.vue
@@ -19,7 +19,7 @@
         <div class="slide-content">
           <v-container
             fill-height
-            class="mx-md-10 mt-md-5 py-0 py-md-4 align-end align-md-start"
+            class="mx-md-10 mt-md-5 py-0 py-md-4 align-end align-sm-center align-md-start"
           >
             <v-row>
               <v-col cols="12" sm="8" md="6" xl="5" class="py-0 py-md-4">
@@ -109,7 +109,7 @@
       :current-index="currentIndex"
       :duration="slideDuration"
       :paused="isPaused"
-      class="progressbar"
+      class="px-2 px-sm-4 progress-bar"
       @on-animation-end="onAnimationEnd"
       @on-progress-clicked="onProgressClicked"
     />
@@ -234,6 +234,8 @@ export default Vue.extend({
 </script>
 
 <style lang="scss" scoped>
+@import '~vuetify/src/styles/styles.sass';
+
 .text-h2,
 .text-h4 {
   line-height: normal;
@@ -246,12 +248,11 @@ export default Vue.extend({
   user-select: none;
 }
 
-@import '~vuetify/src/styles/styles.sass';
-.progressbar {
+.progress-bar {
   position: absolute;
   z-index: 5;
   top: 0;
-  margin-top: -15px;
+  margin-top: 0;
 }
 
 .slide-backdrop {
@@ -299,16 +300,16 @@ export default Vue.extend({
   .slide-content {
     top: 56px;
   }
+
+  .progress-bar {
+    top: initial;
+    margin-top: initial;
+  }
 }
 
 @media #{map-get($display-breakpoints, 'md-and-up')} {
   .swiper {
     margin-bottom: -128px !important;
-  }
-
-  .progressbar {
-    top: initial;
-    margin-top: initial;
   }
 }
 </style>

--- a/components/SwiperProgressBar.vue
+++ b/components/SwiperProgressBar.vue
@@ -109,6 +109,7 @@ export default Vue.extend({
 
 <style lang="scss" scoped>
 .progress-container {
+  box-sizing: border-box;
   display: flex;
   flex-direction: row;
   width: 100%;


### PR DESCRIPTION
* Fix a z-index issue where the progress bars were going over the top bar
* Fix the positioning of the bar in the xs and sm breakpoints
* Add padding to the bar to fit better with the other padding around the page

![Screenshot_2020-12-26 Jellyfin](https://user-images.githubusercontent.com/19396809/103156664-39d25f00-47ab-11eb-88a9-8f096889f580.png)

![Screenshot_2020-12-26 Jellyfin](https://user-images.githubusercontent.com/19396809/103156667-4060d680-47ab-11eb-971b-917b7c226e62.jpg)
