### PR TITLE
fix(library): handle folders properly

### DIFF
--- a/pages/library/_viewId.vue
+++ b/pages/library/_viewId.vue
@@ -276,9 +276,16 @@ export default Vue.extend({
                 userId: this.$auth.user.Id,
                 parentId: this.$route.params.viewId,
                 includeItemTypes: this.viewType,
-                sortBy: this.collectionInfo.IsFolder
-                  ? 'IsFolder,SortName'
-                  : this.sortBy,
+                sortBy:
+                  this.collectionInfo.CollectionType === 'homevideos' ||
+                  this.collectionInfo.Type === 'Folder'
+                    ? 'IsFolder,SortName'
+                    : this.sortBy,
+                recursive:
+                  this.collectionInfo.CollectionType === 'homevideos' ||
+                  this.collectionInfo.Type === 'Folder'
+                    ? undefined
+                    : true,
                 sortOrder: 'Ascending',
                 filters: this.statusFilter ? this.statusFilter : undefined,
                 genres: this.genresFilter ? this.genresFilter : undefined,


### PR DESCRIPTION
84add64 introduced an issue where Music libraries were treated as folders, thereby returning no items (Because our API is weird like that).

This changes the conditions a bit to properly handle Photos libraries and actual folders, without breaking other libraries.