### PR TITLE
perf(homeheaderitems): switch to fade effect for faster animations when switching between slides apart

### DIFF
--- a/components/Layout/HomeHeader/HomeHeaderItems.vue
+++ b/components/Layout/HomeHeader/HomeHeaderItems.vue
@@ -151,7 +151,10 @@ export default Vue.extend({
           initialSlide: 0,
           loop: true,
           autoplay: false,
-          effect: 'slide'
+          effect: 'fade',
+          fadeEffect: {
+            crossFade: true
+          }
         };
       }
     }


### PR DESCRIPTION
When clicking on a progress bar in swiper, swiper slides all the slides to the destination slide, making the animation look akward.

Switching to fade effect solves this.