### PR TITLE
Force return types and arrow callbacks on functions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,6 +27,7 @@ module.exports = {
     'promise/prefer-await-to-callbacks': 'error',
     'promise/prefer-await-to-then': 'error',
     '@typescript-eslint/explicit-function-return-type': 'error',
+    'prefer-arrow-callback': 'error',
     // Force some component order stuff, formatting and such, for consistency
     'vue/component-name-in-template-casing': [
       'error',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,6 +26,7 @@ module.exports = {
     'promise/no-return-in-finally': 'error',
     'promise/prefer-await-to-callbacks': 'error',
     'promise/prefer-await-to-then': 'error',
+    '@typescript-eslint/explicit-function-return-type': 'error',
     // Force some component order stuff, formatting and such, for consistency
     'vue/component-name-in-template-casing': [
       'error',

--- a/components/Buttons/FilterButton.vue
+++ b/components/Buttons/FilterButton.vue
@@ -283,13 +283,13 @@ export default Vue.extend({
     };
   },
   watch: {
-    itemsType() {
+    itemsType(): void {
       this.refreshItems();
     }
   },
   methods: {
     ...mapActions('snackbar', ['pushSnackbarMessage']),
-    async refreshItems() {
+    async refreshItems(): Promise<void> {
       try {
         const response = (
           await this.$api.filter.getQueryFiltersLegacy({
@@ -317,7 +317,7 @@ export default Vue.extend({
         });
       }
     },
-    emitFilterChange() {
+    emitFilterChange(): void {
       this.$emit('change', {
         status: this.selectedStatusFilters,
         features: this.selectedFeatureFilters,

--- a/components/Buttons/TypeButton.vue
+++ b/components/Buttons/TypeButton.vue
@@ -49,24 +49,24 @@ export default Vue.extend({
       switch (this.type) {
         case 'movies':
           return [
-            { name: this.$t('movies').toString(), value: 'Movie' },
-            { name: this.$t('collections').toString(), value: 'BoxSet' },
-            { name: this.$t('actors').toString(), value: 'Actor' },
-            { name: this.$t('genres').toString(), value: 'Genre' },
-            { name: this.$t('studios').toString(), value: 'Studio' }
+            { name: this.$t('movies'), value: 'Movie' },
+            { name: this.$t('collections'), value: 'BoxSet' },
+            { name: this.$t('actors'), value: 'Actor' },
+            { name: this.$t('genres'), value: 'Genre' },
+            { name: this.$t('studios'), value: 'Studio' }
           ];
         case 'music':
           return [
-            { name: this.$t('albums').toString(), value: 'MusicAlbum' },
-            { name: this.$t('artists').toString(), value: 'MusicArtist' },
-            { name: this.$t('genres').toString(), value: 'MusicGenre' }
+            { name: this.$t('albums'), value: 'MusicAlbum' },
+            { name: this.$t('artists'), value: 'MusicArtist' },
+            { name: this.$t('genres'), value: 'MusicGenre' }
           ];
         case 'tvshows':
           return [
-            { name: this.$t('series').toString(), value: 'Series' },
-            { name: this.$t('actors').toString(), value: 'Actor' },
-            { name: this.$t('genres').toString(), value: 'Genre' },
-            { name: this.$t('networks').toString(), value: 'Studio' }
+            { name: this.$t('series'), value: 'Series' },
+            { name: this.$t('actors'), value: 'Actor' },
+            { name: this.$t('genres'), value: 'Genre' },
+            { name: this.$t('networks'), value: 'Studio' }
           ];
         default:
           return [];

--- a/components/Buttons/TypeButton.vue
+++ b/components/Buttons/TypeButton.vue
@@ -45,28 +45,28 @@ export default Vue.extend({
     };
   },
   computed: {
-    items() {
+    items(): Array<Record<string, string>> {
       switch (this.type) {
         case 'movies':
           return [
-            { name: this.$t('movies'), value: 'Movie' },
-            { name: this.$t('collections'), value: 'BoxSet' },
-            { name: this.$t('actors'), value: 'Actor' },
-            { name: this.$t('genres'), value: 'Genre' },
-            { name: this.$t('studios'), value: 'Studio' }
+            { name: this.$t('movies').toString(), value: 'Movie' },
+            { name: this.$t('collections').toString(), value: 'BoxSet' },
+            { name: this.$t('actors').toString(), value: 'Actor' },
+            { name: this.$t('genres').toString(), value: 'Genre' },
+            { name: this.$t('studios').toString(), value: 'Studio' }
           ];
         case 'music':
           return [
-            { name: this.$t('albums'), value: 'MusicAlbum' },
-            { name: this.$t('artists'), value: 'MusicArtist' },
-            { name: this.$t('genres'), value: 'MusicGenre' }
+            { name: this.$t('albums').toString(), value: 'MusicAlbum' },
+            { name: this.$t('artists').toString(), value: 'MusicArtist' },
+            { name: this.$t('genres').toString(), value: 'MusicGenre' }
           ];
         case 'tvshows':
           return [
-            { name: this.$t('series'), value: 'Series' },
-            { name: this.$t('actors'), value: 'Actor' },
-            { name: this.$t('genres'), value: 'Genre' },
-            { name: this.$t('networks'), value: 'Studio' }
+            { name: this.$t('series').toString(), value: 'Series' },
+            { name: this.$t('actors').toString(), value: 'Actor' },
+            { name: this.$t('genres').toString(), value: 'Genre' },
+            { name: this.$t('networks').toString(), value: 'Studio' }
           ];
         default:
           return [];

--- a/components/Buttons/UserButton.vue
+++ b/components/Buttons/UserButton.vue
@@ -29,6 +29,11 @@
 import Vue from 'vue';
 import { mapActions } from 'vuex';
 
+interface MenuItem {
+  title: string;
+  action: () => void;
+}
+
 export default Vue.extend({
   data() {
     return {
@@ -36,7 +41,7 @@ export default Vue.extend({
     };
   },
   computed: {
-    menuItems(): Array<Record<never, never>> {
+    menuItems(): MenuItem[] {
       return [
         {
           title: this.$t('logout'),

--- a/components/Buttons/UserButton.vue
+++ b/components/Buttons/UserButton.vue
@@ -36,11 +36,11 @@ export default Vue.extend({
     };
   },
   computed: {
-    menuItems() {
+    menuItems(): Array<Record<never, never>> {
       return [
         {
           title: this.$t('logout'),
-          action: () => {
+          action: (): void => {
             this.logoutUser();
           }
         }
@@ -50,7 +50,7 @@ export default Vue.extend({
   methods: {
     ...mapActions('user', ['clearUser']),
     ...mapActions('deviceProfile', ['clearDeviceProfile']),
-    logoutUser() {
+    logoutUser(): void {
       this.$disconnect();
       this.$auth.logout();
       this.clearDeviceProfile();

--- a/components/Forms/AddServerForm.vue
+++ b/components/Forms/AddServerForm.vue
@@ -57,7 +57,7 @@ export default Vue.extend({
   },
   methods: {
     ...mapActions('servers', ['connectServer']),
-    connectToServer() {
+    connectToServer(): void {
       this.loading = true;
       this.connectServer(this.serverUrl);
       this.loading = false;

--- a/components/Forms/LoginForm.vue
+++ b/components/Forms/LoginForm.vue
@@ -72,7 +72,7 @@ export default Vue.extend({
   props: {
     user: {
       type: Object as () => UserDto,
-      default() {
+      default(): UserDto {
         return {};
       }
     }
@@ -97,7 +97,7 @@ export default Vue.extend({
     ...mapActions('user', ['loginRequest']),
     ...mapActions('deviceProfile', ['setDeviceProfile']),
     ...mapActions('snackbar', ['pushSnackbarMessage']),
-    async userLogin() {
+    async userLogin(): Promise<void> {
       if (!isEmpty(this.user)) {
         // If we have a user from the public user selector, set it as login
         this.login.username = this.user.Name || '';
@@ -108,7 +108,7 @@ export default Vue.extend({
       await this.loginRequest(this.login);
       this.loading = false;
     },
-    isEmpty(value: Record<never, never>) {
+    isEmpty(value: Record<never, never>): boolean {
       return isEmpty(value);
     }
   }

--- a/components/Item/Card.vue
+++ b/components/Item/Card.vue
@@ -93,31 +93,31 @@ export default Vue.extend({
     },
     shape: {
       type: [String, Boolean],
-      default: () => {
+      default: (): string | boolean => {
         return false;
       }
     },
     episode: {
       type: Boolean,
-      default: () => {
+      default: (): boolean => {
         return false;
       }
     },
     overlay: {
       type: Boolean,
-      default: () => {
+      default: (): boolean => {
         return true;
       }
     },
     noText: {
       type: Boolean,
-      default: () => {
+      default: (): boolean => {
         return false;
       }
     },
     noMargin: {
       type: Boolean,
-      default: () => {
+      default: (): boolean => {
         return false;
       }
     }

--- a/components/Item/ItemGrid.vue
+++ b/components/Item/ItemGrid.vue
@@ -49,7 +49,7 @@ export default Vue.extend({
     items: {
       type: Array,
       required: true,
-      default: () => {
+      default: (): Array<never> => {
         return [];
       }
     },

--- a/components/Item/ItemGrid.vue
+++ b/components/Item/ItemGrid.vue
@@ -49,7 +49,7 @@ export default Vue.extend({
     items: {
       type: Array,
       required: true,
-      default: (): Array<never> => {
+      default: (): BaseItemDto[] => {
         return [];
       }
     },

--- a/components/Item/ItemMenu.vue
+++ b/components/Item/ItemMenu.vue
@@ -50,7 +50,7 @@ export default Vue.extend({
         const menuItems = [] as MenuItem[];
         if (this.$auth.$state.user.Policy.IsAdministrator) {
           menuItems.push({
-            title: this.$t('editMetadata') as string,
+            title: this.$t('editMetadata'),
             action: () => {
               this.dialog = true;
             }

--- a/components/Item/MediaInfo.vue
+++ b/components/Item/MediaInfo.vue
@@ -82,7 +82,7 @@ export default Vue.extend({
       // TODO: Use a Date object
       return this.$t('endsAt', {
         time: endTimeShort
-      }).toString();
+      });
     }
   }
 });

--- a/components/Item/MediaInfo.vue
+++ b/components/Item/MediaInfo.vue
@@ -52,7 +52,7 @@ export default Vue.extend({
   },
   computed: {
     runtimeValue: {
-      get() {
+      get(): string {
         const seconds = this.ticksToMs(this.item.RunTimeTicks);
         return this.$dateFns.formatDuration(
           intervalToDuration({ start: 0, end: seconds }),
@@ -63,7 +63,7 @@ export default Vue.extend({
       }
     },
     endsAtValue: {
-      get() {
+      get(): string {
         const seconds = this.ticksToMs(this.item.RunTimeTicks);
         return this.$dateFns.format(Date.now() + seconds, 'p');
       }

--- a/components/Item/Metadata/DateInput.vue
+++ b/components/Item/Metadata/DateInput.vue
@@ -38,7 +38,7 @@ export default Vue.extend({
     };
   },
   methods: {
-    handleChange(value: string) {
+    handleChange(value: string): void {
       this.menu = false;
       this.$emit('update:date', value);
     }

--- a/components/Item/Metadata/ImageEditor.vue
+++ b/components/Item/Metadata/ImageEditor.vue
@@ -84,7 +84,7 @@ export default Vue.extend({
   props: {
     metadata: {
       type: Object,
-      default: () => ({})
+      default: (): Record<never, never> => ({})
     }
   },
   data() {
@@ -94,7 +94,7 @@ export default Vue.extend({
     };
   },
   computed: {
-    generalImages() {
+    generalImages(): boolean {
       return this.$data.images.filter((image: ImageInfo) => {
         const { ImageType } = image;
         return (
@@ -104,7 +104,7 @@ export default Vue.extend({
         );
       });
     },
-    backdropImages() {
+    backdropImages(): Array<never> {
       return this.$data.images.filter((image: ImageInfo) => {
         const { ImageType } = image;
         return ImageType === 'Backdrop';
@@ -112,7 +112,7 @@ export default Vue.extend({
     }
   },
   watch: {
-    metadata() {
+    metadata(): void {
       this.getItemImageInfos();
     }
   },
@@ -120,23 +120,23 @@ export default Vue.extend({
     this.getItemImageInfos();
   },
   methods: {
-    async getItemImageInfos() {
+    async getItemImageInfos(): Promise<void> {
       this.images = (
         await this.$api.image.getItemImageInfos({
           itemId: this.metadata.Id
         })
       ).data;
     },
-    imageFormat(imageInfo: ImageInfo) {
+    imageFormat(imageInfo: ImageInfo): string {
       return this.getImageUrlForElement(imageInfo.ImageType as ImageType, {
         itemId: this.metadata.Id,
         tag: imageInfo.ImageTag as string
       });
     },
-    handleSearch() {
+    handleSearch(): void {
       this.dialog = true;
     },
-    async handleDelete(item: ImageInfo) {
+    async handleDelete(item: ImageInfo): Promise<void> {
       await this.$api.image.deleteItemImage({
         itemId: this.metadata.Id,
         imageType: item.ImageType as ImageType,

--- a/components/Item/Metadata/ImageEditor.vue
+++ b/components/Item/Metadata/ImageEditor.vue
@@ -76,7 +76,7 @@
 
 <script lang="ts">
 import Vue from 'vue';
-import { ImageInfo, ImageType } from '@jellyfin/client-axios';
+import { BaseItemDto, ImageInfo, ImageType } from '@jellyfin/client-axios';
 import imageHelper from '~/mixins/imageHelper';
 
 export default Vue.extend({
@@ -84,7 +84,7 @@ export default Vue.extend({
   props: {
     metadata: {
       type: Object,
-      default: (): Record<never, never> => ({})
+      default: (): BaseItemDto => ({})
     }
   },
   data() {
@@ -104,7 +104,7 @@ export default Vue.extend({
         );
       });
     },
-    backdropImages(): Array<never> {
+    backdropImages(): ImageInfo[] {
       return this.$data.images.filter((image: ImageInfo) => {
         const { ImageType } = image;
         return ImageType === 'Backdrop';

--- a/components/Item/Metadata/ImageSearch.vue
+++ b/components/Item/Metadata/ImageSearch.vue
@@ -100,7 +100,7 @@ import {
 
 export default Vue.extend({
   filters: {
-    fixed(val: number) {
+    fixed(val: number): string | number {
       if (!val) return val;
       return val.toFixed(1);
     }
@@ -108,7 +108,7 @@ export default Vue.extend({
   props: {
     metadata: {
       type: Object,
-      default: () => ({})
+      default: (): Record<never, never> => ({})
     },
     dialog: {
       type: Boolean,
@@ -190,16 +190,16 @@ export default Vue.extend({
     }
   },
   watch: {
-    type() {
+    type(): void {
       this.getImages();
     },
-    source() {
+    source(): void {
       this.getImages();
     },
-    allLanguages() {
+    allLanguages(): void {
       this.getImages();
     },
-    dialog(value) {
+    dialog(value): void {
       if (value) {
         this.getRemoteImageProviders();
         this.getImages();
@@ -209,14 +209,14 @@ export default Vue.extend({
     }
   },
   methods: {
-    async getRemoteImageProviders() {
+    async getRemoteImageProviders(): Promise<void> {
       this.providers = (
         await this.$api.remoteImage.getRemoteImageProviders({
           itemId: this.metadata.Id
         })
       ).data;
     },
-    async getImages() {
+    async getImages(): Promise<void> {
       this.loading = true;
       this.images = (
         await this.$api.remoteImage.getRemoteImages({
@@ -229,12 +229,12 @@ export default Vue.extend({
 
       this.loading = false;
     },
-    imageFormat(url: string) {
+    imageFormat(url: string): string {
       return `${
         this.$axios.defaults.baseURL
       }/Images/Remote?imageUrl=${encodeURIComponent(url)}`;
     },
-    async handleDownload(item: RemoteImageInfo) {
+    async handleDownload(item: RemoteImageInfo): Promise<void> {
       this.loading = true;
       await this.$api.remoteImage.downloadRemoteImage({
         type: item.Type as ImageType,
@@ -245,7 +245,7 @@ export default Vue.extend({
       this.$emit('update:dialog', false);
       this.$emit('download-success', false);
     },
-    reset() {
+    reset(): void {
       this.providers = [];
       this.type = ImageType.Primary;
       this.source = 'All';

--- a/components/Item/Metadata/ImageSearch.vue
+++ b/components/Item/Metadata/ImageSearch.vue
@@ -95,7 +95,8 @@ import Vue from 'vue';
 import {
   ImageProviderInfo,
   RemoteImageInfo,
-  ImageType
+  ImageType,
+  BaseItemDto
 } from '@jellyfin/client-axios';
 
 export default Vue.extend({
@@ -108,7 +109,7 @@ export default Vue.extend({
   props: {
     metadata: {
       type: Object,
-      default: (): Record<never, never> => ({})
+      default: (): BaseItemDto => ({})
     },
     dialog: {
       type: Boolean,

--- a/components/Item/Metadata/MetadataEditor.vue
+++ b/components/Item/Metadata/MetadataEditor.vue
@@ -360,7 +360,7 @@ export default Vue.extend({
         }
 
         this.$store.dispatch('snackbar/display', {
-          message: errorMessage.toString(),
+          message: errorMessage,
           color: 'error'
         });
       }

--- a/components/Item/Metadata/MetadataEditor.vue
+++ b/components/Item/Metadata/MetadataEditor.vue
@@ -261,10 +261,10 @@ export default Vue.extend({
     }
   },
   watch: {
-    itemId() {
+    itemId(): void {
       this.getData();
     },
-    forceRefresh() {
+    forceRefresh(): void {
       this.getData();
       this.$emit('update:forceRefresh', false);
     }
@@ -273,15 +273,17 @@ export default Vue.extend({
     this.getData();
   },
   methods: {
-    async getData() {
+    async getData(): Promise<void> {
       await this.fetchItemInfo();
+      const ancestors = await this.$api.library.getAncestors({
+        itemId: this.metadata.Id as string,
+        userId: this.$auth.user.Id
+      });
       const libraryInfo =
-        (await this.getAncestors()).data.find(
-          (i) => i.Type === 'CollectionFolder'
-        ) || {};
+        ancestors.data.find((i) => i.Type === 'CollectionFolder') || {};
       this.getGenres(libraryInfo.Id);
     },
-    async fetchItemInfo() {
+    async fetchItemInfo(): Promise<void> {
       const userId = this.$auth.user.Id;
       const itemInfo = (
         await this.$api.userLibrary.getItem({
@@ -291,20 +293,14 @@ export default Vue.extend({
       ).data;
       this.$data.metadata = itemInfo;
     },
-    async getGenres(parentId = '') {
+    async getGenres(parentId = ''): Promise<void> {
       this.genders = (
         await this.$api.genres.getGenres({
           parentId
         })
       ).data.Items?.map((i) => i.Name) as BaseItemDto[];
     },
-    async getAncestors() {
-      return await this.$api.library.getAncestors({
-        itemId: this.metadata.Id as string,
-        userId: this.$auth.user.Id
-      });
-    },
-    async saveMetadata() {
+    async saveMetadata(): Promise<void> {
       const item = pick(this.metadata, [
         'Id',
         'Name',
@@ -369,15 +365,15 @@ export default Vue.extend({
         });
       }
     },
-    saveDate(key: string, date: string) {
+    saveDate(key: string, date: string): void {
       this.menu = false;
       set(this.metadata, key, this.$dateFns.formatISO(new Date(date)));
     },
-    handlePersonEdit(item: BaseItemPerson | null = null) {
+    handlePersonEdit(item: BaseItemPerson | null = null): void {
       this.person = item;
       this.dialog = true;
     },
-    handlePersonUpdate(item: BaseItemPerson) {
+    handlePersonUpdate(item: BaseItemPerson): void {
       if (!this.metadata.People) {
         this.metadata.People = [];
       }
@@ -390,10 +386,10 @@ export default Vue.extend({
         this.metadata.People.push(item);
       }
     },
-    handleDialogUpdate(result: boolean) {
+    handleDialogUpdate(result: boolean): void {
       this.dialog = result;
     },
-    handlePersonDel(index: number) {
+    handlePersonDel(index: number): void {
       (this.metadata.People as BaseItemPerson[]).splice(index, 1);
     }
   }

--- a/components/Item/Metadata/MetadataEditorDialog.vue
+++ b/components/Item/Metadata/MetadataEditorDialog.vue
@@ -35,7 +35,7 @@ export default Vue.extend({
     };
   },
   methods: {
-    close() {
+    close(): void {
       this.forceRefresh = true;
       this.$emit('update:dialog', false);
     }

--- a/components/Item/Metadata/PersonEditor.vue
+++ b/components/Item/Metadata/PersonEditor.vue
@@ -65,7 +65,7 @@ export default Vue.extend({
   props: {
     person: {
       type: Object,
-      default: (): Record<string, string> => ({
+      default: (): BaseItemPerson => ({
         Name: '',
         Type: '',
         Role: ''

--- a/components/Item/Metadata/PersonEditor.vue
+++ b/components/Item/Metadata/PersonEditor.vue
@@ -65,7 +65,7 @@ export default Vue.extend({
   props: {
     person: {
       type: Object,
-      default: () => ({
+      default: (): Record<string, string> => ({
         Name: '',
         Type: '',
         Role: ''
@@ -90,22 +90,22 @@ export default Vue.extend({
     };
   },
   watch: {
-    person(value: BaseItemPerson) {
+    person(value: BaseItemPerson): void {
       if (!value) return;
       this.editState = value;
     }
   },
   methods: {
-    handleSubmit() {
+    handleSubmit(): void {
       this.$emit('update:person', this.editState);
       this.$emit('update:dialog', false);
       this.reset();
     },
-    handleCancel() {
+    handleCancel(): void {
       this.$emit('update:dialog', false);
       this.reset();
     },
-    reset() {
+    reset(): void {
       this.editState = { Name: '', Type: '', Role: '' };
     }
   }

--- a/components/Item/PersonList.vue
+++ b/components/Item/PersonList.vue
@@ -45,7 +45,7 @@ export default Vue.extend({
   props: {
     items: {
       type: Array,
-      default: () => {
+      default: (): Array<never> => {
         return [];
       }
     },

--- a/components/Item/PersonList.vue
+++ b/components/Item/PersonList.vue
@@ -37,7 +37,7 @@
 
 <script lang="ts">
 import Vue from 'vue';
-import { ImageType } from '@jellyfin/client-axios';
+import { BaseItemPerson, ImageType } from '@jellyfin/client-axios';
 import imageHelper from '~/mixins/imageHelper';
 
 export default Vue.extend({
@@ -45,7 +45,7 @@ export default Vue.extend({
   props: {
     items: {
       type: Array,
-      default: (): Array<never> => {
+      default: (): BaseItemPerson[] => {
         return [];
       }
     },

--- a/components/Item/RelatedItems.vue
+++ b/components/Item/RelatedItems.vue
@@ -127,7 +127,7 @@ export default Vue.extend({
     };
   },
   watch: {
-    item() {
+    item(): void {
       this.refreshItems();
     }
   },
@@ -143,7 +143,7 @@ export default Vue.extend({
   },
   methods: {
     ...mapActions('snackbar', ['pushSnackbarMessage']),
-    async refreshItems() {
+    async refreshItems(): Promise<void> {
       this.loading = true;
 
       if (this.item.Id) {

--- a/components/Item/ServerCard.vue
+++ b/components/Item/ServerCard.vue
@@ -43,13 +43,13 @@ export default Vue.extend({
   methods: {
     ...mapActions('snackbar', ['pushSnackbarMessage']),
     ...mapActions('servers', ['connectServer', 'removeServer']),
-    async setServer() {
+    async setServer(): Promise<void> {
       // TODO: Merge with the identical method in AddServerForm
       this.loading = true;
       await this.connectServer(this.serverInfo.address);
       this.loading = false;
     },
-    removeServerFromStore() {
+    removeServerFromStore(): void {
       this.removeServer(this.serverInfo);
     }
   }

--- a/components/Layout/Backdrop.vue
+++ b/components/Layout/Backdrop.vue
@@ -11,7 +11,7 @@ import Vue from 'vue';
 
 export default Vue.extend({
   computed: {
-    blurhash() {
+    blurhash(): string | boolean {
       if (this.$store.state.backdrop.blurhash) {
         return this.$store.state.backdrop.blurhash;
       }

--- a/components/Layout/HomeHeader/HomeHeader.vue
+++ b/components/Layout/HomeHeader/HomeHeader.vue
@@ -74,9 +74,9 @@ export default Vue.extend({
     }
 
     if (this.items.length === 0) {
-      this.extraText = this.$t('homeHeader.welcome.noItems').toString();
+      this.extraText = this.$t('homeHeader.welcome.noItems');
     } else {
-      this.extraText = this.$t('homeHeader.welcome.checkNewItems').toString();
+      this.extraText = this.$t('homeHeader.welcome.checkNewItems');
     }
     window.setTimeout(this.hideWelcomeMessage, 1500);
   },

--- a/components/Layout/HomeHeader/HomeHeaderItems.vue
+++ b/components/Layout/HomeHeader/HomeHeaderItems.vue
@@ -149,7 +149,7 @@ export default Vue.extend({
     },
     swiperOptions: {
       type: Object as () => SwiperOptions,
-      default: () => {
+      default: (): SwiperOptions => {
         return {
           initialSlide: 0,
           loop: true,

--- a/components/Layout/HomeHeader/SwiperProgressBar.vue
+++ b/components/Layout/HomeHeader/SwiperProgressBar.vue
@@ -39,17 +39,17 @@ export default Vue.extend({
     };
   },
   watch: {
-    currentIndex() {
+    currentIndex(): void {
       this.$nextTick(() => {
         window.requestAnimationFrame(this.updateBars);
       });
     },
-    paused() {
+    paused(): void {
       this.$nextTick(() => {
         window.requestAnimationFrame(this.togglePause);
       });
     },
-    duration() {
+    duration(): void {
       this.$nextTick(() => {
         window.requestAnimationFrame(this.setAnimationDuration);
       });

--- a/components/Layout/Images/BlurhashCanvas.vue
+++ b/components/Layout/Images/BlurhashCanvas.vue
@@ -31,7 +31,7 @@ export default Vue.extend({
     };
   },
   watch: {
-    hash() {
+    hash(): void {
       this.$nextTick(() => {
         this.draw();
       });
@@ -41,7 +41,7 @@ export default Vue.extend({
     this.draw();
   },
   methods: {
-    async draw() {
+    async draw(): Promise<void> {
       const ctx = (this.$refs.canvas as HTMLCanvasElement).getContext('2d');
       const imageData = ctx?.createImageData(this.width, this.height);
       try {

--- a/components/Players/PlayerDialog.vue
+++ b/components/Players/PlayerDialog.vue
@@ -10,7 +10,7 @@ export default Vue.extend({
   methods: {
     // Copy of https://github.com/vuetifyjs/vuetify/blob/master/packages/vuetify/src/mixins/overlayable/index.ts#L129-L152
     // A block preventing scroll on the overlay has been removed, since we always want to scroll.
-    scrollListener(e: WheelEvent & KeyboardEvent) {
+    scrollListener(e: WheelEvent & KeyboardEvent): void {
       if (e.type === 'keydown') {
         if (
           ['INPUT', 'TEXTAREA', 'SELECT'].includes(

--- a/components/Players/PlayerManager.vue
+++ b/components/Players/PlayerManager.vue
@@ -230,12 +230,12 @@ export default Vue.extend({
           : 'player--fullscreen'
       }`;
     },
-    stopPlayback() {
+    stopPlayback(): void {
       this.setLastItemIndex();
       this.resetCurrentItemIndex();
       this.setNextTrack();
     },
-    togglePause() {
+    togglePause(): void {
       if (this.isPaused) {
         this.unpause();
       } else {

--- a/components/Players/VideoPlayer.vue
+++ b/components/Players/VideoPlayer.vue
@@ -112,7 +112,7 @@ export default Vue.extend({
         });
       } else {
         this.$nuxt.error({
-          message: this.$t('browserNotSupported') as string
+          message: this.$t('browserNotSupported')
         });
       }
     } catch (error) {

--- a/components/Players/VideoPlayer.vue
+++ b/components/Players/VideoPlayer.vue
@@ -62,10 +62,10 @@ export default Vue.extend({
     }
   },
   watch: {
-    getCurrentItem() {
+    getCurrentItem(): void {
       this.getPlaybackUrl();
     },
-    async source(newSource) {
+    async source(newSource): Promise<void> {
       if (this.player) {
         try {
           await this.player.load(newSource);

--- a/components/Skeletons/SkeletonCard.vue
+++ b/components/Skeletons/SkeletonCard.vue
@@ -25,8 +25,8 @@ export default Vue.extend({
     },
     cardShape: {
       type: String,
-      default: () => 'portrait-card',
-      validator: (value) =>
+      default: (): string => 'portrait-card',
+      validator: (value): boolean =>
         ['square-card', 'portrait-card', 'thumb-card'].includes(value)
     }
   }

--- a/components/Skeletons/SkeletonHomeSection.vue
+++ b/components/Skeletons/SkeletonHomeSection.vue
@@ -19,7 +19,7 @@ export default Vue.extend({
   props: {
     cardShape: {
       type: String,
-      validator: (val) =>
+      validator: (val): boolean =>
         ['thumb-card', 'portrait-card', 'square-card'].includes(val),
       default: 'thumb-card'
     }

--- a/components/Skeletons/SkeletonItemGrid.vue
+++ b/components/Skeletons/SkeletonItemGrid.vue
@@ -13,7 +13,7 @@ export default Vue.extend({
   props: {
     viewType: {
       type: String,
-      default: () => 'Movie'
+      default: (): string => 'Movie'
     }
   },
   data() {
@@ -22,7 +22,7 @@ export default Vue.extend({
     };
   },
   watch: {
-    viewType() {
+    viewType(): void {
       this.setCardShape();
     }
   },
@@ -30,7 +30,7 @@ export default Vue.extend({
     this.setCardShape();
   },
   methods: {
-    setCardShape() {
+    setCardShape(): void {
       switch (this.viewType) {
         case 'Audio':
         case 'Folder':

--- a/components/System/DarkModeToggle.vue
+++ b/components/System/DarkModeToggle.vue
@@ -10,10 +10,10 @@ export default Vue.extend({
   computed: {
     ...mapGetters('displayPreferences', ['getBooleanCustomPref']),
     darkMode: {
-      get() {
+      get(): boolean {
         return this.getBooleanCustomPref('darkMode');
       },
-      set(value: boolean) {
+      set(value: boolean): void {
         this.editBooleanCustomPref({ key: 'darkMode', value });
       }
     }

--- a/components/System/Snackbar.vue
+++ b/components/System/Snackbar.vue
@@ -30,7 +30,7 @@ export default Vue.extend({
   },
   methods: {
     ...mapActions('snackbar', ['resetMessage']),
-    displaySnackbar(message: string, color: string) {
+    displaySnackbar(message: string, color: string): void {
       if (message !== '') {
         this.message = message;
         this.color = color;

--- a/components/Users/UserCard.vue
+++ b/components/Users/UserCard.vue
@@ -41,14 +41,14 @@ export default Vue.extend({
     }
   },
   methods: {
-    formatDistance(value: string) {
+    formatDistance(value: string): string {
       if (value) {
         return this.$dateFns.formatDistanceToNow(new Date(value), {
           addSuffix: true,
           locale: this.getDfnsLocale()
         });
       } else {
-        return this.$t('never');
+        return this.$t('never').toString();
       }
     }
   }

--- a/components/Users/UserCard.vue
+++ b/components/Users/UserCard.vue
@@ -48,7 +48,7 @@ export default Vue.extend({
           locale: this.getDfnsLocale()
         });
       } else {
-        return this.$t('never').toString();
+        return this.$t('never');
       }
     }
   }

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -159,7 +159,7 @@ export default Vue.extend({
       return [
         {
           icon: 'mdi-home',
-          title: this.$t('home').toString(),
+          title: this.$t('home'),
           to: '/'
         }
       ];
@@ -168,12 +168,12 @@ export default Vue.extend({
       return [
         {
           icon: 'mdi-pencil-outline',
-          title: this.$t('metadata').toString(),
+          title: this.$t('metadata'),
           to: '/metadata'
         },
         {
           icon: 'mdi-cog',
-          title: this.$t('settings').toString(),
+          title: this.$t('settings'),
           to: '/settings'
         }
       ];

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -155,25 +155,25 @@ export default Vue.extend({
         this.$store.state.playbackManager.status !== PlaybackStatus.stopped
       );
     },
-    items() {
+    items(): Array<Record<string, string>> {
       return [
         {
           icon: 'mdi-home',
-          title: this.$t('home'),
+          title: this.$t('home').toString(),
           to: '/'
         }
       ];
     },
-    configItems() {
+    configItems(): Array<Record<string, string>> {
       return [
         {
           icon: 'mdi-pencil-outline',
-          title: this.$t('metadata'),
+          title: this.$t('metadata').toString(),
           to: '/metadata'
         },
         {
           icon: 'mdi-cog',
-          title: this.$t('settings'),
+          title: this.$t('settings').toString(),
           to: '/settings'
         }
       ];

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -130,6 +130,12 @@ interface WebSocketMessage {
   Data?: Record<string, never>;
 }
 
+interface LayoutButton {
+  icon: string;
+  title: string;
+  to: string;
+}
+
 export default Vue.extend({
   data() {
     return {
@@ -155,7 +161,7 @@ export default Vue.extend({
         this.$store.state.playbackManager.status !== PlaybackStatus.stopped
       );
     },
-    items(): Array<Record<string, string>> {
+    items(): LayoutButton[] {
       return [
         {
           icon: 'mdi-home',
@@ -164,7 +170,7 @@ export default Vue.extend({
         }
       ];
     },
-    configItems(): Array<Record<string, string>> {
+    configItems(): LayoutButton[] {
       return [
         {
           icon: 'mdi-pencil-outline',

--- a/nuxt-i18n.d.ts
+++ b/nuxt-i18n.d.ts
@@ -1,0 +1,23 @@
+import VueI18n, { Path, Values } from 'vue-i18n/types';
+
+/**
+ * Overloads VueI18n interface to avoid needing to cast return value to string.
+ * See https://github.com/kazupon/vue-i18n/issues/410
+ */
+declare module 'vue-i18n/types' {
+  export default class VueI18n {
+    t(key: Path, values?: Values): string;
+  }
+}
+
+declare module 'vue/types/vue' {
+  interface Vue {
+    $t: typeof VueI18n.prototype.t;
+  }
+
+  interface VueConstructor {
+    i18n: typeof VueI18n.prototype;
+  }
+}
+
+export default VueI18n;

--- a/pages/artist/_itemId/index.vue
+++ b/pages/artist/_itemId/index.vue
@@ -122,7 +122,7 @@ export default Vue.extend({
     };
   },
   computed: {
-    overview() {
+    overview(): string {
       if (this.$data.item.Overview) {
         return this.sanitizeHtml(this.$data.item.Overview);
       } else {

--- a/pages/genre/_itemId/index.vue
+++ b/pages/genre/_itemId/index.vue
@@ -101,7 +101,7 @@ export default Vue.extend({
       // Can't get given library ID
       this.$nuxt.error({
         statusCode: 404,
-        message: this.$t('libraryNotFound') as string
+        message: this.$t('libraryNotFound')
       });
     }
   },

--- a/pages/item/_itemId/index.vue
+++ b/pages/item/_itemId/index.vue
@@ -426,7 +426,7 @@ export default Vue.extend({
     ...mapActions('backdrop', ['setBackdrop', 'clearBackdrop']),
     getLanguageName(code?: string): string {
       if (!code) {
-        return this.$t('undefined').toString();
+        return this.$t('undefined');
       }
       return langs.where('2B', code).name;
     },

--- a/pages/item/_itemId/index.vue
+++ b/pages/item/_itemId/index.vue
@@ -325,7 +325,7 @@ export default Vue.extend({
   },
   computed: {
     isPlayable: {
-      get() {
+      get(): boolean {
         // TODO: Move this to a mixin
         if (['PhotoAlbum', 'Photo', 'Book'].includes(this.$data.item.Type)) {
           return false;
@@ -335,7 +335,7 @@ export default Vue.extend({
       }
     },
     crew: {
-      get() {
+      get(): BaseItemPerson[] {
         if (this.$data.item.People) {
           // TODO: Figure out how common it is to have more than one director
           return this.$data.item.People.filter((person: BaseItemPerson) => {
@@ -347,7 +347,7 @@ export default Vue.extend({
       }
     },
     actors: {
-      get() {
+      get(): BaseItemPerson[] {
         if (this.$data.item.People) {
           return this.$data.item.People.filter((person: BaseItemPerson) => {
             return person.Type === 'Actor';
@@ -424,11 +424,13 @@ export default Vue.extend({
   methods: {
     ...mapActions('playbackManager', ['play']),
     ...mapActions('backdrop', ['setBackdrop', 'clearBackdrop']),
-    getLanguageName(code?: string) {
-      if (!code) return this.$t('undefined');
+    getLanguageName(code?: string): string {
+      if (!code) {
+        return this.$t('undefined').toString();
+      }
       return langs.where('2B', code).name;
     },
-    getSurroundIcon(layout: string) {
+    getSurroundIcon(layout: string): string {
       switch (layout) {
         case '2.0':
           return 'mdi-surround-sound-2-0';

--- a/pages/library/_viewId.vue
+++ b/pages/library/_viewId.vue
@@ -166,7 +166,7 @@ export default Vue.extend({
       // Can't get given library ID
       this.$nuxt.error({
         statusCode: 404,
-        message: this.$t('libraryNotFound') as string
+        message: this.$t('libraryNotFound')
       });
     }
   },

--- a/pages/library/_viewId.vue
+++ b/pages/library/_viewId.vue
@@ -104,12 +104,12 @@ export default Vue.extend({
     }
   },
   watch: {
-    async viewType() {
+    async viewType(): Promise<void> {
       this.loading = true;
       await this.refreshItems();
       this.loading = false;
     },
-    async sortBy() {
+    async sortBy(): Promise<void> {
       this.loading = true;
       await this.refreshItems();
       this.loading = false;
@@ -176,16 +176,16 @@ export default Vue.extend({
   methods: {
     ...mapActions('page', ['setPageTitle', 'setAppBarOpacity']),
     ...mapActions('snackbar', ['pushSnackbarMessage']),
-    onChangeType(type: string) {
+    onChangeType(type: string): void {
       const defaultViews = ['Series', 'Movie', 'Book', 'MusicAlbum'];
 
       this.viewType = type;
       this.isDefaultView = defaultViews.includes(this.viewType);
     },
-    onChangeSort(sort: string) {
+    onChangeSort(sort: string): void {
       this.sortBy = sort;
     },
-    onChangeFilter(filter: Record<string, [string]>) {
+    onChangeFilter(filter: Record<string, [string]>): boolean | void {
       this.hasFilters = Object.values(filter).every((value) => {
         return value.length > 0;
       });
@@ -224,7 +224,7 @@ export default Vue.extend({
 
       this.refreshItems();
     },
-    async refreshItems() {
+    async refreshItems(): Promise<void> {
       try {
         let itemsResponse;
         switch (this.viewType) {

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -80,7 +80,7 @@ export default Vue.extend({
     ...mapActions('page', ['setPageTitle']),
     ...mapActions('deviceProfile', ['setDeviceProfile']),
     ...mapActions('snackbar', ['pushSnackbarMessage']),
-    isEmpty(value: Record<never, never>) {
+    isEmpty(value: Record<never, never>): boolean {
       return isEmpty(value);
     },
     setCurrentUser(user: UserDto): void {

--- a/pages/metadata/index.vue
+++ b/pages/metadata/index.vue
@@ -47,7 +47,7 @@ export default Vue.extend({
     });
   },
   methods: {
-    async fetchItems(node: ITreeNode) {
+    async fetchItems(node: ITreeNode): Promise<void> {
       const libItems = (((
         await this.$api.userLibrary.getItem(
           { userId: this.$auth.user.Id, itemId: '' },
@@ -72,7 +72,7 @@ export default Vue.extend({
         })
       );
     },
-    handleAction(ids: string[]) {
+    handleAction(ids: string[]): void {
       this.$data.itemId = ids[0];
     }
   }

--- a/pages/person/_itemId/index.vue
+++ b/pages/person/_itemId/index.vue
@@ -155,7 +155,7 @@ export default Vue.extend({
     };
   },
   computed: {
-    birthDate() {
+    birthDate(): Date | null {
       if (this.$data.item.PremiereDate) {
         return new Date(this.$data.item.PremiereDate);
       } else {
@@ -163,7 +163,7 @@ export default Vue.extend({
       }
     },
     deathDate: {
-      get() {
+      get(): Date | null {
         if (this.$data.item.EndDate) {
           return new Date(this.$data.item.EndDate);
         } else {
@@ -172,7 +172,7 @@ export default Vue.extend({
       }
     },
     birthPlace: {
-      get() {
+      get(): null {
         if (this.$data.item.ProductionLocations) {
           return this.$data.item.ProductionLocations[0];
         } else {
@@ -181,7 +181,7 @@ export default Vue.extend({
       }
     },
     movies: {
-      get() {
+      get(): Array<Record<string, string>> {
         return this.$data.appearances
           .filter((appearance: BaseItemDto) => {
             return appearance.Type === 'Movie';
@@ -190,7 +190,7 @@ export default Vue.extend({
       }
     },
     shows: {
-      get() {
+      get(): Array<Record<string, string>> {
         return this.$data.appearances
           .filter((appearance: BaseItemDto) => {
             return appearance.Type === 'Series';

--- a/pages/person/_itemId/index.vue
+++ b/pages/person/_itemId/index.vue
@@ -172,7 +172,7 @@ export default Vue.extend({
       }
     },
     birthPlace: {
-      get(): null {
+      get(): string | null {
         if (this.$data.item.ProductionLocations) {
           return this.$data.item.ProductionLocations[0];
         } else {
@@ -181,7 +181,7 @@ export default Vue.extend({
       }
     },
     movies: {
-      get(): Array<Record<string, string>> {
+      get(): BaseItemDto[] {
         return this.$data.appearances
           .filter((appearance: BaseItemDto) => {
             return appearance.Type === 'Movie';
@@ -190,7 +190,7 @@ export default Vue.extend({
       }
     },
     shows: {
-      get(): Array<Record<string, string>> {
+      get(): BaseItemDto[] {
         return this.$data.appearances
           .filter((appearance: BaseItemDto) => {
             return appearance.Type === 'Series';

--- a/pages/settings/logsAndActivity.vue
+++ b/pages/settings/logsAndActivity.vue
@@ -126,7 +126,7 @@ export default Vue.extend({
   methods: {
     ...mapActions('page', ['setPageTitle']),
     ...mapActions('snackbar', ['pushSnackbarMessage']),
-    async getActivities() {
+    async getActivities(): Promise<void> {
       this.loadingActivityStatus.status = 'loading';
 
       // Only fetch the activity for the last 7 days
@@ -156,7 +156,7 @@ export default Vue.extend({
         });
       }
     },
-    async getLogs() {
+    async getLogs(): Promise<void> {
       this.loadingLogsStatus.status = 'loading';
       try {
         this.logFiles = (await this.$api.system.getServerLogs()).data;

--- a/plugins/browserDetection.ts
+++ b/plugins/browserDetection.ts
@@ -30,7 +30,7 @@ declare module 'vuex/types/index' {
  * @class BrowserDetector
  */
 class BrowserDetector {
-  supportsMediaSource() {
+  supportsMediaSource(): boolean {
     // Browsers that lack a media source implementation will have no reference
     // to |window.MediaSource|.
     if (!window.MediaSource) {
@@ -49,7 +49,7 @@ class BrowserDetector {
    * @returns {boolean} Determines if user agent of navigator contains a key
    * @memberof BrowserDetector
    */
-  private userAgentContains(key: string) {
+  private userAgentContains(key: string): boolean {
     const userAgent = navigator.userAgent || '';
     return userAgent.includes(key);
   }
@@ -62,7 +62,7 @@ class BrowserDetector {
    * @returns {boolean} Determines if browser is Mozilla Firefox
    * @memberof BrowserDetector
    */
-  isFirefox() {
+  isFirefox(): boolean {
     return this.userAgentContains('Firefox/');
   }
 
@@ -73,7 +73,7 @@ class BrowserDetector {
    * @returns {boolean} Determines if browser is Microsoft Edge
    * @memberof BrowserDetector
    */
-  isEdge() {
+  isEdge(): boolean {
     return this.userAgentContains('Edge/');
   }
 
@@ -83,7 +83,7 @@ class BrowserDetector {
    * @returns {boolean} Determines if browser is Google Chrome
    * @memberof BrowserDetector
    */
-  isChrome() {
+  isChrome(): boolean {
     // The Edge user agent will also contain the "Chrome" keyword, so we need
     // to make sure this is not Edge.
     return this.userAgentContains('Chrome') && !this.isEdge();
@@ -100,10 +100,10 @@ class BrowserDetector {
    * @returns {boolean} Determines if current platform is from Apple
    * @memberof BrowserDetector
    */
-  isApple() {
-    return (
-      navigator.vendor && navigator.vendor.includes('Apple') && !this.isTizen()
-    );
+  isApple(): boolean {
+    return (navigator.vendor &&
+      navigator.vendor.includes('Apple') &&
+      !this.isTizen()) as boolean;
   }
 
   /**
@@ -143,7 +143,7 @@ class BrowserDetector {
    * @returns {boolean} Determines if current platform is Tizen
    * @memberof BrowserDetector
    */
-  isTizen() {
+  isTizen(): boolean {
     return this.userAgentContains('Tizen');
   }
 
@@ -153,7 +153,7 @@ class BrowserDetector {
    * @returns {boolean} Determines if current platform is Tizen 2
    * @memberof BrowserDetector
    */
-  isTizen2() {
+  isTizen2(): boolean {
     return this.userAgentContains('Tizen 2');
   }
 
@@ -163,7 +163,7 @@ class BrowserDetector {
    * @returns {boolean} Determines if current platform is Tizen 3
    * @memberof BrowserDetector
    */
-  isTizen3() {
+  isTizen3(): boolean {
     return this.userAgentContains('Tizen 3');
   }
 
@@ -173,7 +173,7 @@ class BrowserDetector {
    * @returns {boolean} Determines if current platform is Tizen 4
    * @memberof BrowserDetector
    */
-  isTizen4() {
+  isTizen4(): boolean {
     return this.userAgentContains('Tizen 4');
   }
 
@@ -183,7 +183,7 @@ class BrowserDetector {
    * @returns {boolean} Determines if current platform is Tizen 5
    * @memberof BrowserDetector
    */
-  isTizen5() {
+  isTizen5(): boolean {
     return this.userAgentContains('Tizen 5');
   }
 
@@ -193,7 +193,7 @@ class BrowserDetector {
    * @returns {boolean} Determines if current platform is Tizen 5.5
    * @memberof BrowserDetector
    */
-  isTizen55() {
+  isTizen55(): boolean {
     return this.userAgentContains('Tizen 5.5');
   }
 
@@ -203,7 +203,7 @@ class BrowserDetector {
    * @returns {boolean} Determines if current platform is WebOS
    * @memberof BrowserDetector
    */
-  isWebOS() {
+  isWebOS(): boolean {
     return this.userAgentContains('WebOS');
   }
 
@@ -265,7 +265,7 @@ class BrowserDetector {
    * @returns {boolean} Determines if current platform is mobile (Guess)
    * @memberof BrowserDetector
    */
-  isMobile() {
+  isMobile(): boolean {
     if (/(?:iPhone|iPad|iPod|Android)/.test(navigator.userAgent)) {
       // This is Android, iOS, or iPad < 13.
       return true;

--- a/plugins/browserDetection.ts
+++ b/plugins/browserDetection.ts
@@ -101,9 +101,7 @@ class BrowserDetector {
    * @memberof BrowserDetector
    */
   isApple(): boolean {
-    return (navigator.vendor &&
-      navigator.vendor.includes('Apple') &&
-      !this.isTizen()) as boolean;
+    return navigator?.vendor.includes('Apple') && !this.isTizen();
   }
 
   /**

--- a/plugins/playbackProfile.ts
+++ b/plugins/playbackProfile.ts
@@ -160,7 +160,7 @@ function getTranscodingProfiles(): Array<TranscodingProfile> {
 
   ['aac', 'mp3', 'opus', 'wav']
     .filter(getSupportedAudioCodecs)
-    .forEach(function (audioFormat) {
+    .forEach((audioFormat) => {
       TranscodingProfiles.push({
         Container: audioFormat,
         Type: DlnaProfileType.Audio,

--- a/plugins/veeValidate.ts
+++ b/plugins/veeValidate.ts
@@ -13,7 +13,7 @@ const veeValidate: Plugin = ({ app }) => {
   configure({
     defaultMessage: (_field, values) => {
       // values._field_ = app.i18n.t(`fields.${field}`);
-      return app.i18n.t(`validation.${values._rule_}`, values).toString();
+      return app.i18n.t(`validation.${values._rule_}`, values);
     }
   });
 };

--- a/store/displayPreferences.ts
+++ b/store/displayPreferences.ts
@@ -3,8 +3,8 @@ import { DisplayPreferencesDto } from '@jellyfin/client-axios';
 import { MutationTree, ActionTree, GetterTree } from 'vuex';
 import nuxtConfig from '~/nuxt.config';
 
-const stringToBoolean = (value: string) => value === 'True';
-const booleanToString = (value: boolean) => (value ? 'True' : 'False');
+const stringToBoolean = (value: string): boolean => value === 'True';
+const booleanToString = (value: boolean): string => (value ? 'True' : 'False');
 
 export interface DisplayPreferencesState extends DisplayPreferencesDto {
   CustomPrefs: {
@@ -65,8 +65,9 @@ export const getters: GetterTree<
    * @param {DisplayPreferencesState} state Current state
    * @returns {CustomPrefToBoolean} Function to pass the property key to
    */
-  getBooleanCustomPref: (state: DisplayPreferencesState) => (key: string) =>
-    stringToBoolean(state.CustomPrefs[key])
+  getBooleanCustomPref: (state: DisplayPreferencesState) => (
+    key: string
+  ): boolean => stringToBoolean(state.CustomPrefs[key])
 };
 
 export const mutations: MutationTree<DisplayPreferencesState> = {

--- a/store/homeSection.ts
+++ b/store/homeSection.ts
@@ -45,7 +45,9 @@ type MutationPayload = {
 };
 
 export const getters: GetterTree<HomeSectionState, AppState> = {
-  getHomeSectionContent: (state) => (section: HomeSection) => {
+  getHomeSectionContent: (state) => (
+    section: HomeSection
+  ): Array<never> | BaseItemDto | BaseItemDto[] => {
     switch (section.type) {
       case 'libraries':
         return state.libraries;

--- a/store/homeSection.ts
+++ b/store/homeSection.ts
@@ -45,9 +45,7 @@ type MutationPayload = {
 };
 
 export const getters: GetterTree<HomeSectionState, AppState> = {
-  getHomeSectionContent: (state) => (
-    section: HomeSection
-  ): Array<never> | BaseItemDto | BaseItemDto[] => {
+  getHomeSectionContent: (state) => (section: HomeSection): BaseItemDto[] => {
     switch (section.type) {
       case 'libraries':
         return state.libraries;

--- a/store/tvShows.ts
+++ b/store/tvShows.ts
@@ -31,10 +31,14 @@ type MutationPayload = {
 };
 
 export const getters: GetterTree<TvShowsState, AppState> = {
-  getSeasons: (state) => ({ itemId }: { itemId: string }) => {
+  getSeasons: (state) => ({ itemId }: { itemId: string }): BaseItemDto[] => {
     return state[itemId]?.seasons;
   },
-  getSeasonEpisodes: (state) => ({ itemId }: { itemId: string }) => {
+  getSeasonEpisodes: (state) => ({
+    itemId
+  }: {
+    itemId: string;
+  }): Array<BaseItemDto[]> => {
     return state[itemId]?.seasonEpisodes;
   }
 };

--- a/store/tvShows.ts
+++ b/store/tvShows.ts
@@ -38,7 +38,7 @@ export const getters: GetterTree<TvShowsState, AppState> = {
     itemId
   }: {
     itemId: string;
-  }): Array<BaseItemDto[]> => {
+  }): BaseItemDto[][] => {
     return state[itemId]?.seasonEpisodes;
   }
 };

--- a/utils/hlsFormats.ts
+++ b/utils/hlsFormats.ts
@@ -7,7 +7,9 @@ import { browserDetector } from '~/plugins/browserDetection';
  * @param {HTMLVideoElement} videoTestElement A HTML video element for testing codecs
  * @returns {boolean} Determines if the browser has AC3 in HLS support
  */
-function supportsAc3InHls(videoTestElement: HTMLVideoElement) {
+function supportsAc3InHls(
+  videoTestElement: HTMLVideoElement
+): boolean | string {
   if (browserDetector.isTv()) {
     return true;
   }

--- a/utils/mp4AudioFormats.ts
+++ b/utils/mp4AudioFormats.ts
@@ -57,7 +57,7 @@ function hasMp2AudioSupport(): boolean {
  * @param {HTMLVideoElement} videoTestElement A HTML video element for testing codecs
  * @returns {boolean} Determines if browserr has DTS audio support
  */
-function hasDtsSupport(videoTestElement: HTMLVideoElement) {
+function hasDtsSupport(videoTestElement: HTMLVideoElement): boolean | string {
   // DTS audio not supported in 2018 models (Tizen 4.0)
   if (
     browserDetector.isTizen4() ||


### PR DESCRIPTION
Added a rule for enforcing return types on all the functions, which should help us with type checking across all the code

We should also investigate how we can get ``VueI18n`` to return strings instead of ``TranslateResult``, so we don't need to invoke ``toString()`` or do any string casting.