### PR TITLE
chore(a11y): add vue-axe when in dev mode

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -71,6 +71,8 @@ const config: NuxtConfig = {
    ** https://nuxtjs.org/guide/plugins
    */
   plugins: [
+    // Development
+    'plugins/axe.ts',
     // General
     'plugins/appInitPlugin.ts',
     'plugins/veeValidate.ts',

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@types/nuxtjs__auth": "^4.8.6",
     "@types/qs": "^6.9.5",
     "@vue/test-utils": "^1.1.2",
+    "axe-core": "^4.1.1",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "^10.1.0",
     "babel-jest": "^26.6.3",
@@ -100,6 +101,7 @@
     "stylelint-config-standard": "^20.0.0",
     "ts-jest": "^26.4.4",
     "ts-loader": "^8.0.10",
+    "vue-axe": "^2.4.4",
     "vue-jest": "^3.0.7"
   },
   "config": {

--- a/plugins/axe.ts
+++ b/plugins/axe.ts
@@ -1,0 +1,8 @@
+import Vue from 'vue';
+
+if (process.env.NODE_ENV === 'development') {
+  // eslint-disable-next-line
+  import('vue-axe').then(({ default: VueAxe }) => {
+    Vue.use(VueAxe);
+  });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3095,6 +3095,11 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.10.1.tgz#e1e82e4f3e999e2cfd61b161280d16a111f86428"
   integrity sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==
 
+axe-core@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.1.1.tgz#70a7855888e287f7add66002211a423937063eaf"
+  integrity sha512-5Kgy8Cz6LPC9DJcNb3yjAXTu3XihQgEdnIg50c//zOC/MyLP0Clg+Y8Sh9ZjjnvBrDZU4DgXS9C3T9r4/scGZQ==
+
 axios-retry@^3.1.9:
   version "3.1.9"
   resolved "https://registry.yarnpkg.com/axios-retry/-/axios-retry-3.1.9.tgz#6c30fc9aeb4519aebaec758b90ef56fa03fe72e8"
@@ -12817,6 +12822,11 @@ vue-awesome-swiper@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/vue-awesome-swiper/-/vue-awesome-swiper-4.1.1.tgz#8f7ab221ad003021d756b86aa618f429924900fe"
   integrity sha512-50um10t6N+lJaORkpwSi1wWuMmBI1sgFc9Znsi5oUykw2cO5DzLaBHcO2JNX21R+Ue4TGoIJDhhxjBHtkFrTEQ==
+
+vue-axe@^2.4.4:
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/vue-axe/-/vue-axe-2.4.4.tgz#fbe7ee93bc7e4cacf9dac0a1b0cfaa9e91f66dda"
+  integrity sha512-zIhIenmvSzzDYLSGMRCZWHPXGryW5qAWNSKGzuzgn1/tK9zwYpWXagIihD91egyHKz9yWkPjcTO25bnxq9/OPg==
 
 vue-client-only@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
In an effort to push us towards taking accessibility more seriously, this adds [vue-axe](https://github.com/vue-a11y/vue-axe) when in development mode.

It will run checks on the current page while it runs and point out areas where we can improve accessibility.

Here is an example of the output:
![image](https://user-images.githubusercontent.com/19396809/103392971-9c678a00-4b20-11eb-84e3-e4e814515043.png)
