### PR TITLE
feat(video osd): Add OSD for video playback

### DIFF
--- a/components/Players/PlayerManager.vue
+++ b/components/Players/PlayerManager.vue
@@ -50,9 +50,9 @@
                     x-large
                     @click="togglePause"
                   >
-                    <v-icon size="48">{{
-                      isPaused ? 'mdi-play' : 'mdi-pause'
-                    }}</v-icon>
+                    <v-icon size="48">
+                      {{ isPaused ? 'mdi-play' : 'mdi-pause' }}
+                    </v-icon>
                   </v-btn>
                   <v-btn
                     class="all-pointer-events"
@@ -62,6 +62,89 @@
                   >
                     <v-icon size="32">mdi-skip-next</v-icon>
                   </v-btn>
+                </div>
+              </div>
+            </v-overlay>
+          </v-fade-transition>
+          <v-fade-transition>
+            <v-overlay v-show="!isMinimized && hover" absolute>
+              <div
+                class="d-flex flex-column justify-space-between align-center player-overlay"
+              >
+                <div class="osd-top">
+                  <div class="d-flex justify-space-between align-center">
+                    <div class="d-flex">
+                      <v-btn icon @click="stopPlayback">
+                        <v-icon>mdi-close</v-icon>
+                      </v-btn>
+                      <v-btn icon @click="toggleMinimized">
+                        <v-icon size="32"> mdi-chevron-down </v-icon>
+                      </v-btn>
+                    </div>
+                    <p class="ma-0">{{ currentItemName }}</p>
+                    <div class="d-flex">
+                      <v-btn icon disabled>
+                        <v-icon> mdi-autorenew </v-icon>
+                      </v-btn>
+                      <v-btn icon disabled>
+                        <v-icon> mdi-apple-airplay </v-icon>
+                      </v-btn>
+                      <v-btn icon disabled>
+                        <v-icon> mdi-cast </v-icon>
+                      </v-btn>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="px-4 osd-bottom">
+                  <div>
+                    <v-slider
+                      :value="currentPosition"
+                      min="0"
+                      :max="runtime"
+                      hide-details
+                      validate-on-blur
+                      :step="0"
+                    >
+                      <template #prepend>
+                        <span class="mt-1">
+                          {{ getRuntime(currentPosition) }}
+                        </span>
+                      </template>
+                      <template #append>
+                        <span class="mt-1">
+                          {{ getRuntime(runtime) }}
+                        </span>
+                      </template>
+                    </v-slider>
+                    <div class="d-flex justify-space-between">
+                      <div>
+                        <v-btn icon @click="setPreviousTrack">
+                          <v-icon> mdi-skip-previous </v-icon>
+                        </v-btn>
+                        <v-btn icon @click="togglePause">
+                          <v-icon>
+                            {{ isPaused ? 'mdi-play' : 'mdi-pause' }}
+                          </v-icon>
+                        </v-btn>
+                        <v-btn icon @click="setNextTrack">
+                          <v-icon icon> mdi-skip-next </v-icon>
+                        </v-btn>
+                      </div>
+                      <div>
+                        <v-btn icon disabled>
+                          <v-icon> mdi-closed-caption </v-icon>
+                        </v-btn>
+                        <v-btn icon disabled>
+                          <v-icon> mdi-cog </v-icon>
+                        </v-btn>
+
+                        <v-btn icon disabled>
+                          <v-icon> mdi-fullscreen </v-icon>
+                        </v-btn>
+                      </div>
+                    </div>
+                  </div>
                 </div>
               </div>
             </v-overlay>
@@ -98,6 +181,21 @@ export default Vue.extend({
     },
     isMinimized(): boolean {
       return this.$store.state.playbackManager.isMinimized;
+    },
+    currentPosition(): number {
+      return this.$store.state.playbackManager.currentTime;
+    },
+    runtime(): number {
+      return this.ticksToMs(this.getCurrentItem.RunTimeTicks) / 1000;
+    },
+    currentItemName(): string {
+      switch (this.getCurrentItem.Type) {
+        case 'Episode':
+          return `${this.getCurrentItem.SeriesName} - S${this.getCurrentItem.ParentIndexNumber}E${this.getCurrentItem.IndexNumber} -  ${this.getCurrentItem.Name}`;
+        case 'Movie':
+        default:
+          return this.getCurrentItem.Name;
+      }
     }
   },
   created() {
@@ -241,6 +339,26 @@ export default Vue.extend({
       } else {
         this.pause();
       }
+    },
+    getRuntime(seconds: number): string {
+      let minutes = Math.floor(seconds / 60);
+      const hours = Math.floor(minutes / 60);
+      minutes = minutes - hours * 60;
+      seconds = Math.floor(seconds - (minutes * 60 + hours * 60 * 60));
+      /**
+       * Formats the second number
+       * E.g. 7 -> 07
+       *
+       * @param {string} seconds Number to format
+       * @returns {string} Formatted seconds number
+       */
+      function formatSeconds(seconds: string): string {
+        return ('0' + seconds).slice(-2);
+      }
+
+      if (hours)
+        return `${hours}:${minutes}:${formatSeconds(seconds.toString())}`;
+      return `${minutes}:${formatSeconds(seconds.toString())}`;
     }
   }
 });
@@ -269,7 +387,6 @@ export default Vue.extend({
 .v-overlay .v-overlay__content {
   width: 100%;
   height: 100%;
-  padding: 8px;
   box-sizing: border-box;
 }
 
@@ -298,5 +415,35 @@ export default Vue.extend({
   left: auto;
   bottom: 2em;
   right: 2em;
+}
+
+.osd-top,
+.osd-bottom {
+  width: 100%;
+  padding: 8px;
+}
+
+.osd-bottom > div,
+.osd-top > div {
+  max-width: calc(100vh * 1.77 - 2vh);
+  margin: auto;
+}
+
+.osd-top {
+  padding-bottom: 10em;
+  background: linear-gradient(
+    180deg,
+    rgba(16, 16, 16, 0.75) 0%,
+    rgba(16, 16, 16, 0) 100%
+  );
+}
+
+.osd-bottom {
+  padding-top: 10em;
+  background: linear-gradient(
+    0deg,
+    rgba(16, 16, 16, 0.75) 0%,
+    rgba(16, 16, 16, 0) 100%
+  );
 }
 </style>

--- a/components/Players/PlayerManager.vue
+++ b/components/Players/PlayerManager.vue
@@ -66,6 +66,7 @@
               </div>
             </v-overlay>
           </v-fade-transition>
+          <!-- Full Screen OSD -->
           <v-fade-transition>
             <v-overlay v-show="!isMinimized && hover" absolute>
               <div
@@ -78,10 +79,17 @@
                         <v-icon>mdi-close</v-icon>
                       </v-btn>
                       <v-btn icon @click="toggleMinimized">
-                        <v-icon size="32"> mdi-chevron-down </v-icon>
+                        <v-icon> mdi-chevron-down </v-icon>
+                      </v-btn>
+                      <v-btn
+                        v-if="supportedFeatures.pictureInPicture"
+                        icon
+                        disabled
+                      >
+                        <v-icon> mdi-picture-in-picture-bottom-right </v-icon>
                       </v-btn>
                     </div>
-                    <p class="ma-0">{{ currentItemName }}</p>
+                    <p class="ma-0 text-center">{{ currentItemName }}</p>
                     <div class="d-flex">
                       <v-btn icon disabled>
                         <v-icon> mdi-autorenew </v-icon>

--- a/components/Players/PlayerManager.vue
+++ b/components/Players/PlayerManager.vue
@@ -5,6 +5,7 @@
       class="d-none"
     />
     <player-dialog
+      v-if="isPlaying && getCurrentlyPlayingMediaType === 'Video'"
       dark
       persistent
       hide-overlay
@@ -18,9 +19,8 @@
     >
       <v-hover v-slot="{ hover }">
         <v-card class="player-card" width="100%">
-          <video-player
-            v-if="isPlaying && getCurrentlyPlayingMediaType === 'Video'"
-          />
+          <video-player />
+          <!-- Mini Player Overlay -->
           <v-fade-transition>
             <v-overlay v-show="hover && isMinimized" absolute>
               <div class="d-flex flex-column player-overlay">
@@ -86,7 +86,7 @@
                       <v-btn icon disabled>
                         <v-icon> mdi-autorenew </v-icon>
                       </v-btn>
-                      <v-btn icon disabled>
+                      <v-btn v-if="supportedFeatures.airplay" icon disabled>
                         <v-icon> mdi-apple-airplay </v-icon>
                       </v-btn>
                       <v-btn icon disabled>
@@ -161,9 +161,16 @@ import { mapActions, mapGetters } from 'vuex';
 import timeUtils from '~/mixins/timeUtils';
 import { AppState } from '~/store';
 import { PlaybackStatus } from '~/store/playbackManager';
+import {
+  getSupportedFeatures,
+  SupportedFeaturesInterface
+} from '~/utils/supportedFeatures';
 
 export default Vue.extend({
   mixins: [timeUtils],
+  data() {
+    return { supportedFeatures: {} as SupportedFeaturesInterface };
+  },
   computed: {
     ...mapGetters('playbackManager', [
       'getCurrentItem',
@@ -199,6 +206,8 @@ export default Vue.extend({
     }
   },
   created() {
+    this.supportedFeatures = getSupportedFeatures();
+
     this.$store.subscribe((mutation, state: AppState) => {
       switch (mutation.type) {
         case 'playbackManager/START_PLAYBACK':

--- a/components/Players/PlayerManager.vue
+++ b/components/Players/PlayerManager.vue
@@ -107,17 +107,26 @@
                 <div class="px-4 osd-bottom">
                   <div>
                     <v-slider
-                      :value="currentPosition"
                       min="0"
                       :max="runtime"
-                      hide-details
                       validate-on-blur
                       :step="0"
+                      :value="sliderValue"
+                      hide-details
+                      thumb-label
+                      @end="onPositionChange"
+                      @change="onPositionChange"
+                      @mousedown="onClick"
+                      @mouseup="onClick"
+                      @input="onInputChange"
                     >
                       <template #prepend>
                         <span class="mt-1">
-                          {{ getRuntime(currentPosition) }}
+                          {{ getRuntime(realPosition) }}
                         </span>
+                      </template>
+                      <template #thumb-label>
+                        {{ getRuntime(sliderValue) }}
                       </template>
                       <template #append>
                         <span class="mt-1">
@@ -177,7 +186,11 @@ import {
 export default Vue.extend({
   mixins: [timeUtils],
   data() {
-    return { supportedFeatures: {} as SupportedFeaturesInterface };
+    return {
+      supportedFeatures: {} as SupportedFeaturesInterface,
+      clicked: false,
+      currentInput: 0
+    };
   },
   computed: {
     ...mapGetters('playbackManager', [
@@ -210,6 +223,19 @@ export default Vue.extend({
         case 'Movie':
         default:
           return this.getCurrentItem.Name;
+      }
+    },
+    sliderValue: {
+      get(): number {
+        if (!this.clicked) {
+          return this.$store.state.playbackManager.currentTime;
+        }
+        return this.currentInput;
+      }
+    },
+    realPosition: {
+      get(): number {
+        return this.$store.state.playbackManager.currentTime;
       }
     }
   },
@@ -336,7 +362,8 @@ export default Vue.extend({
       'setLastItemIndex',
       'resetLastItemIndex',
       'pause',
-      'unpause'
+      'unpause',
+      'changeCurrentTime'
     ]),
     getContentClass(): string {
       return `player ${
@@ -376,6 +403,18 @@ export default Vue.extend({
       if (hours)
         return `${hours}:${minutes}:${formatSeconds(seconds.toString())}`;
       return `${minutes}:${formatSeconds(seconds.toString())}`;
+    },
+    onPositionChange(value: number): void {
+      if (!this.clicked) {
+        this.changeCurrentTime({ time: value });
+      }
+    },
+    onInputChange(value: number): void {
+      this.currentInput = value;
+    },
+    onClick(): void {
+      this.currentInput = this.realPosition;
+      this.clicked = !this.clicked;
     }
   }
 });

--- a/components/Players/VideoPlayer.vue
+++ b/components/Players/VideoPlayer.vue
@@ -9,7 +9,7 @@
         @pause="onVideoPause"
         @play="onVideoProgress"
         @ended="onVideoStopped"
-      ></video>
+      />
     </div>
   </v-container>
 </template>
@@ -19,12 +19,11 @@ import Vue from 'vue';
 import { stringify } from 'qs';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
-import shaka from 'shaka-player/dist/shaka-player.ui';
+import shaka from 'shaka-player/dist/shaka-player.compiled';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import muxjs from 'mux.js';
 import { mapActions, mapGetters, mapState } from 'vuex';
-import 'shaka-player/dist/controls.css';
 import { ImageType, PlaybackInfoResponse } from '@jellyfin/client-axios';
 import { AppState } from '~/store';
 import timeUtils from '~/mixins/timeUtils';
@@ -83,12 +82,7 @@ export default Vue.extend({
       shaka.polyfill.installAll();
       if (shaka.Player.isBrowserSupported()) {
         this.player = new shaka.Player(this.$refs.videoPlayer);
-        // TODO: Remove Shaka's OSD and use our own
-        this.ui = new shaka.ui.Overlay(
-          this.player,
-          this.$refs.videoContainer,
-          this.$refs.videoPlayer
-        );
+
         // Register player events
         this.player.addEventListener('error', this.onPlayerError);
         // Subscribe to Vuex actions
@@ -225,6 +219,8 @@ export default Vue.extend({
 <style scoped>
 .shaka-video-container,
 video {
+  max-width: 100vw;
+  max-height: 100vh;
   width: 100%;
   height: 100%;
 }

--- a/components/Players/VideoPlayer.vue
+++ b/components/Players/VideoPlayer.vue
@@ -102,6 +102,12 @@ export default Vue.extend({
               if (this.$refs.videoPlayer) {
                 (this.$refs.videoPlayer as HTMLVideoElement).currentTime = 0;
               }
+              break;
+            case 'playbackManager/CHANGE_CURRENT_TIME':
+              if (this.$refs.videoPlayer && mutation?.payload?.time) {
+                (this.$refs.videoPlayer as HTMLVideoElement).currentTime =
+                  mutation?.payload?.time;
+              }
           }
         });
       } else {

--- a/utils/supportedFeatures.ts
+++ b/utils/supportedFeatures.ts
@@ -1,0 +1,46 @@
+import { browserDetector } from '~/plugins/browserDetection';
+
+export interface SupportedFeaturesInterface {
+  pictureInPicture: boolean;
+  airPlay: boolean;
+  playbackRate: boolean;
+}
+
+export const getSupportedFeatures = (): SupportedFeaturesInterface => {
+  const supportedFeatures = {
+    pictureInPicture: false,
+    airPlay: false,
+    playbackRate: false
+  };
+
+  const video = document.createElement('video');
+
+  if (
+    // Check non-standard Safari PiP support
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    (typeof video.webkitSupportsPresentationMode === 'function' &&
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      video.webkitSupportsPresentationMode('picture-in-picture') &&
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      typeof video.webkitSetPresentationMode === 'function') ||
+    // Check standard PiP support
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    document.pictureInPictureEnabled
+  ) {
+    supportedFeatures.pictureInPicture = true;
+  }
+
+  if (browserDetector.isApple()) {
+    supportedFeatures.airPlay = true;
+  }
+
+  if (typeof video.playbackRate === 'number') {
+    supportedFeatures.playbackRate = true;
+  }
+
+  return supportedFeatures;
+};


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/18101008/103443822-9c6ba500-4c5a-11eb-9807-a6d2fd868b1f.png)

All Icons, excluding:

 - Play/Pause
 - Prev/Next track
 - Minimize / Exit

are not currently hooked up to anything

AirPlay and PiP icons are hidden if it is not supported.


Top Left Buttons: Close Player, mini player, PiP mode
Top Right Buttons: SyncPlay, AirPlay, ChromeCast
Bottom Left: Prev Track, Play/Pause, Next Track
Bottom Right: Captions, Settings, Full Screen