### PR TITLE
fix(addserverform): add missing async/await

### DIFF
--- a/components/Forms/AddServerForm.vue
+++ b/components/Forms/AddServerForm.vue
@@ -57,9 +57,9 @@ export default Vue.extend({
   },
   methods: {
     ...mapActions('servers', ['connectServer']),
-    connectToServer(): void {
+    async connectToServer(): Promise<void> {
       this.loading = true;
-      this.connectServer(this.serverUrl);
+      await this.connectServer(this.serverUrl);
       this.loading = false;
     }
   }


### PR DESCRIPTION
See https://github.com/jellyfin/jellyfin-vue/pull/466#discussion_r550742849

We should have been using async here as the store function is async