### PR TITLE
fix(library): trigger items refresh for user views

### DIFF
--- a/pages/library/_viewId.vue
+++ b/pages/library/_viewId.vue
@@ -132,8 +132,9 @@ export default Vue.extend({
 
       if (
         this.collectionInfo &&
-        (this.collectionInfo.Type === 'CollectionFolder' ||
-          this.collectionInfo.Type === 'Folder')
+        ['CollectionFolder', 'Folder', 'UserView'].includes(
+          this.collectionInfo.Type || ''
+        )
       ) {
         if (this.collectionInfo.Name) {
           this.setPageTitle({


### PR DESCRIPTION
For merged libraries, the CollectionType is different. This adds it to the list of valid types for refreshing items.