### PR TITLE
Fix logout

### DIFF
--- a/components/Buttons/FilterButton.vue
+++ b/components/Buttons/FilterButton.vue
@@ -293,7 +293,7 @@ export default Vue.extend({
       try {
         const response = (
           await this.$api.filter.getQueryFiltersLegacy({
-            userId: this.$auth.user.Id,
+            userId: this.$auth.user?.Id,
             parentId: this.$route.params.viewId,
             includeItemTypes: [this.itemsType]
           })

--- a/components/Buttons/UserButton.vue
+++ b/components/Buttons/UserButton.vue
@@ -7,7 +7,7 @@
         v-on="on"
       >
         <user-image />
-        <h1 class="font-weight-light pb-1 text-truncate">
+        <h1 v-if="$auth.user" class="font-weight-light pb-1 text-truncate">
           {{ $auth.user.Name }}
         </h1>
         <v-icon>mdi-chevron-down</v-icon>

--- a/components/Item/ItemMenu.vue
+++ b/components/Item/ItemMenu.vue
@@ -48,7 +48,7 @@ export default Vue.extend({
     items: {
       get(): MenuItem[] {
         const menuItems = [] as MenuItem[];
-        if (this.$auth.$state.user.Policy.IsAdministrator) {
+        if (this.$auth.user?.Policy?.IsAdministrator) {
           menuItems.push({
             title: this.$t('editMetadata'),
             action: () => {

--- a/components/Item/Metadata/MetadataEditor.vue
+++ b/components/Item/Metadata/MetadataEditor.vue
@@ -277,14 +277,14 @@ export default Vue.extend({
       await this.fetchItemInfo();
       const ancestors = await this.$api.library.getAncestors({
         itemId: this.metadata.Id as string,
-        userId: this.$auth.user.Id
+        userId: this.$auth.user?.Id
       });
       const libraryInfo =
         ancestors.data.find((i) => i.Type === 'CollectionFolder') || {};
       this.getGenres(libraryInfo.Id);
     },
     async fetchItemInfo(): Promise<void> {
-      const userId = this.$auth.user.Id;
+      const userId = this.$auth.user?.Id;
       const itemInfo = (
         await this.$api.userLibrary.getItem({
           userId,

--- a/components/Item/RelatedItems.vue
+++ b/components/Item/RelatedItems.vue
@@ -149,7 +149,7 @@ export default Vue.extend({
       if (this.item.Id) {
         const response = await this.$api.library.getSimilarItems({
           itemId: this.item.Id,
-          userId: this.$auth.user.Id,
+          userId: this.$auth.user?.Id,
           limit: this.vertical ? 5 : 12
         });
 

--- a/components/Layout/HomeHeader/HomeHeader.vue
+++ b/components/Layout/HomeHeader/HomeHeader.vue
@@ -40,7 +40,7 @@ export default Vue.extend({
   async beforeMount() {
     this.items = (
       await this.$api.userLibrary.getLatestMedia({
-        userId: this.$auth.user.Id,
+        userId: this.$auth.user?.Id,
         limit: this.pages,
         fields: [ItemFields.Overview],
         enableImageTypes: [ImageType.Backdrop, ImageType.Logo],
@@ -65,7 +65,7 @@ export default Vue.extend({
 
       const itemData = (
         await this.$api.userLibrary.getItem({
-          userId: this.$auth.user.Id,
+          userId: this.$auth.user?.Id,
           itemId: id
         })
       ).data;

--- a/components/Layout/HomeHeader/HomeHeaderWelcome.vue
+++ b/components/Layout/HomeHeader/HomeHeaderWelcome.vue
@@ -9,7 +9,10 @@
             class="mx-md-10 mt-md-5 mt-10 py-0 py-md-4 align-start justify-center text-center text-md-left justify-md-start"
           >
             <v-col cols="12" sm="8" md="6" xl="5" class="py-0 py-md-4">
-              <p class="text-h6 text-sm-h4 text-md-h2 text-lg-h2 text-xl-h2">
+              <p
+                v-if="$auth.user"
+                class="text-h6 text-sm-h4 text-md-h2 text-lg-h2 text-xl-h2"
+              >
                 {{
                   $t('homeHeader.welcome.helloUser', {
                     userName: $auth.user.Name

--- a/components/Layout/Images/UserImage.vue
+++ b/components/Layout/Images/UserImage.vue
@@ -32,7 +32,11 @@ export default Vue.extend({
   computed: {
     userImage: {
       get(): string | undefined {
-        if (!this.id && this.$auth.user.Id && this.$auth.user.PrimaryImageTag) {
+        if (
+          !this.id &&
+          this.$auth.user?.Id &&
+          this.$auth.user?.PrimaryImageTag
+        ) {
           return `${this.$axios.defaults.baseURL}/Users/${this.$auth.user.Id}/Images/Primary/?tag=${this.$auth.user.PrimaryImageTag}&quality=${this.quality}`;
         } else if (this.id) {
           return `${this.$axios.defaults.baseURL}/Users/${this.id}/Images/Primary/?tag=${this.$auth.user.PrimaryImageTag}&quality=${this.quality}`;

--- a/components/Players/AudioPlayer.vue
+++ b/components/Players/AudioPlayer.vue
@@ -140,7 +140,7 @@ export default Vue.extend({
         this.playbackInfo = (
           await this.$api.mediaInfo.getPostedPlaybackInfo({
             itemId: this.getCurrentItem?.Id || '',
-            userId: this.$auth.user.Id,
+            userId: this.$auth.user?.Id,
             playbackInfoDto: { DeviceProfile: this.$playbackProfile }
           })
         ).data;

--- a/components/Players/TrackList.vue
+++ b/components/Players/TrackList.vue
@@ -108,7 +108,7 @@ export default Vue.extend({
   async beforeMount() {
     const tracks = (
       await this.$api.items.getItems({
-        userId: this.$auth.user.Id,
+        userId: this.$auth.user?.Id,
         parentId: this.item.Id,
         sortBy: 'SortName',
         sortOrder: 'Ascending'

--- a/components/Players/VideoPlayer.vue
+++ b/components/Players/VideoPlayer.vue
@@ -146,7 +146,7 @@ export default Vue.extend({
         this.playbackInfo = (
           await this.$api.mediaInfo.getPostedPlaybackInfo({
             itemId: this.getCurrentItem?.Id || '',
-            userId: this.$auth.user.Id,
+            userId: this.$auth.user?.Id,
             playbackInfoDto: { DeviceProfile: this.$playbackProfile }
           })
         ).data;

--- a/pages/artist/_itemId/index.vue
+++ b/pages/artist/_itemId/index.vue
@@ -133,7 +133,7 @@ export default Vue.extend({
   async beforeMount() {
     const item = (
       await this.$api.userLibrary.getItem({
-        userId: this.$auth.user.Id,
+        userId: this.$auth.user?.Id,
         itemId: this.$route.params.itemId
       })
     ).data;
@@ -145,7 +145,7 @@ export default Vue.extend({
 
     const appearances = (
       await this.$api.items.getItems({
-        userId: this.$auth.user.Id,
+        userId: this.$auth.user?.Id,
         parentId: this.$route.params.itemId,
         sortBy: 'PremiereDate',
         sortOrder: 'Descending'

--- a/pages/genre/_itemId/index.vue
+++ b/pages/genre/_itemId/index.vue
@@ -75,7 +75,7 @@ export default Vue.extend({
     try {
       this.genre = (
         await this.$api.userLibrary.getItem({
-          userId: this.$auth.user.Id,
+          userId: this.$auth.user?.Id,
           itemId: this.$route.params.itemId
         })
       ).data;
@@ -86,8 +86,8 @@ export default Vue.extend({
 
       this.items = (
         await this.$api.items.getItems({
-          uId: this.$auth.user.Id,
-          userId: this.$auth.user.Id,
+          uId: this.$auth.user?.Id,
+          userId: this.$auth.user?.Id,
           genreIds: this.$route.params.itemId,
           includeItemTypes: type,
           recursive: true,

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -79,7 +79,7 @@ export default Vue.extend({
             const latestMediaSections = [];
 
             const userViewsRequest = await this.$api.userViews.getUserViews({
-              userId: this.$auth.user.Id
+              userId: this.$auth.user?.Id
             });
 
             if (userViewsRequest.data.Items) {

--- a/pages/item/_itemId/index.vue
+++ b/pages/item/_itemId/index.vue
@@ -361,7 +361,7 @@ export default Vue.extend({
   async beforeMount() {
     this.item = (
       await this.$api.userLibrary.getItem({
-        userId: this.$auth.user.Id,
+        userId: this.$auth.user?.Id,
         itemId: this.$route.params.itemId
       })
     ).data;

--- a/pages/library/_viewId.vue
+++ b/pages/library/_viewId.vue
@@ -124,8 +124,8 @@ export default Vue.extend({
       this.loading = true;
       this.collectionInfo = (
         await this.$api.items.getItems({
-          uId: this.$auth.user.Id,
-          userId: this.$auth.user.Id,
+          uId: this.$auth.user?.Id,
+          userId: this.$auth.user?.Id,
           ids: this.$route.params.viewId
         })
       ).data.Items[0];
@@ -232,7 +232,7 @@ export default Vue.extend({
           case 'MusicArtist':
             itemsResponse = (
               await this.$api.artists.getAlbumArtists({
-                userId: this.$auth.user.Id,
+                userId: this.$auth.user?.Id,
                 parentId: this.$route.params.viewId
               })
             ).data;
@@ -240,7 +240,7 @@ export default Vue.extend({
           case 'Actor':
             itemsResponse = (
               await this.$api.persons.getPersons({
-                userId: this.$auth.user.Id,
+                userId: this.$auth.user?.Id,
                 parentId: this.$route.params.viewId,
                 personTypes: 'Actor'
               })
@@ -249,7 +249,7 @@ export default Vue.extend({
           case 'Genre':
             itemsResponse = (
               await this.$api.genres.getGenres({
-                userId: this.$auth.user.Id,
+                userId: this.$auth.user?.Id,
                 parentId: this.$route.params.viewId
               })
             ).data;
@@ -257,7 +257,7 @@ export default Vue.extend({
           case 'MusicGenre':
             itemsResponse = (
               await this.$api.musicGenres.getMusicGenres({
-                userId: this.$auth.user.Id,
+                userId: this.$auth.user?.Id,
                 parentId: this.$route.params.viewId
               })
             ).data;
@@ -265,7 +265,7 @@ export default Vue.extend({
           case 'Studio':
             itemsResponse = (
               await this.$api.studios.getStudios({
-                userId: this.$auth.user.Id,
+                userId: this.$auth.user?.Id,
                 parentId: this.$route.params.viewId
               })
             ).data;
@@ -273,8 +273,8 @@ export default Vue.extend({
           default:
             itemsResponse = (
               await this.$api.items.getItems({
-                uId: this.$auth.user.Id,
-                userId: this.$auth.user.Id,
+                uId: this.$auth.user?.Id,
+                userId: this.$auth.user?.Id,
                 parentId: this.$route.params.viewId,
                 includeItemTypes: this.viewType,
                 sortBy:

--- a/pages/metadata/index.vue
+++ b/pages/metadata/index.vue
@@ -50,7 +50,7 @@ export default Vue.extend({
     async fetchItems(node: ITreeNode): Promise<void> {
       const libItems = (((
         await this.$api.userLibrary.getItem(
-          { userId: this.$auth.user.Id, itemId: '' },
+          { userId: this.$auth.user?.Id, itemId: '' },
           {
             query: {
               ParentId: node.id,

--- a/pages/person/_itemId/index.vue
+++ b/pages/person/_itemId/index.vue
@@ -202,7 +202,7 @@ export default Vue.extend({
   async beforeMount() {
     const item = (
       await this.$api.userLibrary.getItem({
-        userId: this.$auth.user.Id,
+        userId: this.$auth.user?.Id,
         itemId: this.$route.params.itemId
       })
     ).data;
@@ -214,7 +214,7 @@ export default Vue.extend({
 
     const appearances = (
       await this.$api.items.getItems({
-        userId: this.$auth.user.Id,
+        userId: this.$auth.user?.Id,
         personIds: [this.$route.params.itemId],
         recursive: true,
         collapseBoxSetItems: false

--- a/pages/settings/index.vue
+++ b/pages/settings/index.vue
@@ -246,7 +246,7 @@ export default Vue.extend({
     this.setAppBarOpacity({ opaqueAppBar: true });
     this.setPageTitle({ title: this.$t('settings') });
 
-    if (this.$auth.user.Policy.IsAdministrator) {
+    if (this.$auth.user?.Policy?.IsAdministrator) {
       this.systemInfo = (await this.$api.system.getSystemInfo()).data;
     }
   },

--- a/schemes/jellyfinScheme.ts
+++ b/schemes/jellyfinScheme.ts
@@ -15,7 +15,6 @@ export default class JellyfinScheme {
   $auth: NuxtAuth;
   name = 'jellyfin';
   options: Record<string, unknown>;
-  rawToken: '';
 
   constructor(auth: NuxtAuth, options: Record<string, unknown>) {
     this.$auth = auth;
@@ -133,6 +132,10 @@ export default class JellyfinScheme {
   }
 
   async logout(): Promise<never> {
+    // We set the 'loggedIn' variable to false as soon as possible in the logout chain, as nuxt/auth
+    // doesn't set it until 'this.$auth.setUser(undefined)' is called. At that point, component relying
+    // on $auth.user will fail, breaking the logout flow completely.
+    this.$auth.$storage.setState('loggedIn', false);
     await this.$auth.ctx.app.$api.session.reportSessionEnded();
     this.$auth.ctx.app.store.dispatch('displayPreferences/resetState');
 

--- a/store/displayPreferences.ts
+++ b/store/displayPreferences.ts
@@ -121,7 +121,7 @@ export const actions: ActionTree<
       const response = await this.$api.displayPreferences.getDisplayPreferences(
         {
           displayPreferencesId: 'usersettings',
-          userId: this.$auth.user.Id,
+          userId: this.$auth.user?.Id,
           client: 'vue'
         }
       );
@@ -179,7 +179,7 @@ export const actions: ActionTree<
       const response = await this.$api.displayPreferences.updateDisplayPreferences(
         {
           displayPreferencesId: 'usersettings',
-          userId: this.$auth.user.Id,
+          userId: this.$auth.user?.Id,
           client: 'vue',
           displayPreferencesDto: state
         }

--- a/store/homeSection.ts
+++ b/store/homeSection.ts
@@ -104,7 +104,7 @@ export const actions: ActionTree<HomeSectionState, AppState> = {
   async getAudioResumes({ dispatch }) {
     try {
       const { data } = await this.$api.items.getResumeItems({
-        userId: this.$auth.user.Id,
+        userId: this.$auth.user?.Id,
         limit: 12,
         fields: [ItemFields.PrimaryImageAspectRatio],
         imageTypeLimit: 1,
@@ -142,7 +142,7 @@ export const actions: ActionTree<HomeSectionState, AppState> = {
   async getVideoResumes({ dispatch }) {
     try {
       const { data } = await this.$api.items.getResumeItems({
-        userId: this.$auth.user.Id,
+        userId: this.$auth.user?.Id,
         limit: 12,
         fields: [ItemFields.PrimaryImageAspectRatio],
         imageTypeLimit: 1,
@@ -180,7 +180,7 @@ export const actions: ActionTree<HomeSectionState, AppState> = {
   async getUpNext({ dispatch }, { parentId }: { parentId: string }) {
     try {
       const { data } = await this.$api.tvShows.getNextUp({
-        userId: this.$auth.user.Id,
+        userId: this.$auth.user?.Id,
         limit: 12,
         fields: [ItemFields.PrimaryImageAspectRatio],
         imageTypeLimit: 1,
@@ -217,7 +217,7 @@ export const actions: ActionTree<HomeSectionState, AppState> = {
   async getLatestMedia({ dispatch }, { parentId }: { parentId: string }) {
     try {
       const { data } = await this.$api.userLibrary.getLatestMedia({
-        userId: this.$auth.user.Id,
+        userId: this.$auth.user?.Id,
         limit: 12,
         fields: [ItemFields.PrimaryImageAspectRatio],
         imageTypeLimit: 1,

--- a/store/tvShows.ts
+++ b/store/tvShows.ts
@@ -75,7 +75,7 @@ export const actions: ActionTree<TvShowsState, AppState> = {
   async getTvShows({ dispatch }, { itemId }: { itemId: string }) {
     try {
       const { data } = await this.$api.tvShows.getSeasons({
-        userId: this.$auth.user.Id,
+        userId: this.$auth.user?.Id,
         seriesId: itemId
       });
 
@@ -123,7 +123,7 @@ export const actions: ActionTree<TvShowsState, AppState> = {
   async getTvShowsSeasonEpisodes({ dispatch }, { season, itemId }) {
     try {
       const { data } = await this.$api.items.getItems({
-        userId: this.$auth.user.Id,
+        userId: this.$auth.user?.Id,
         parentId: season.Id,
         fields: [ItemFields.Overview]
       });

--- a/store/userViews.ts
+++ b/store/userViews.ts
@@ -35,7 +35,7 @@ export const mutations: MutationTree<UserViewsState> = {
 export const actions: ActionTree<UserViewsState, UserViewsState> = {
   async refreshUserViews({ commit }) {
     const userViewsResponse = await this.$api.userViews.getUserViews({
-      userId: this.$auth.user.Id
+      userId: this.$auth.user?.Id
     });
 
     const userViews = userViewsResponse.data.Items;


### PR DESCRIPTION
Sometimes, components updates triggered before the logout process completed successfully, crashing the whole client with errors.

I added a check in the two troublesome components: **HomeHeaderItemsWelcome** and **UserButton**

The first commit solves the issue completely, but in an additional commit (which I can revert if not everyone agrees with it/have other proposals), I added the chain operator to all the calls to ``this.$auth`` (except the scheme ones), so we can forget about chaining issues (stuff relying on it not being undefined will ofc still be in trouble) which can cause some problems that we're not able to reproduce.

I also tried logging out in the middle of requests being resolved (with first commit only) and I had no issues.