### PR TITLE
More small fixes

### DIFF
--- a/components/Item/Card.vue
+++ b/components/Item/Card.vue
@@ -261,8 +261,13 @@ export default Vue.extend({
       }
     },
     getImageType(): ImageType {
-      if (this.shape === 'thumb-card' && this.item.Type === 'Movie') {
-        return ImageType.Backdrop;
+      if (
+        this.shape === 'thumb-card' &&
+        !['CollectionFolder', 'Folder', 'UserView'].includes(
+          this.item?.Type || ''
+        )
+      ) {
+        return ImageType.Thumb;
       } else {
         return ImageType.Primary;
       }

--- a/components/Layout/HomeHeader/HomeHeader.vue
+++ b/components/Layout/HomeHeader/HomeHeader.vue
@@ -53,12 +53,12 @@ export default Vue.extend({
 
     for (const [key, i] of this.items.entries()) {
       let id: string;
-      if (i.Type === 'Episode' && i.SeriesId) {
-        id = i?.SeriesId as string;
-      } else if (i.Type === 'MusicAlbum') {
-        id = i?.AlbumArtists?.[0].Id as string;
-      } else if (i.ParentLogoItemId) {
-        id = i?.ParentLogoItemId as string;
+      if (i.Type === 'Episode' && i?.SeriesId) {
+        id = i.SeriesId;
+      } else if (i.Type === 'MusicAlbum' && i?.AlbumArtists?.[0]?.Id) {
+        id = i.AlbumArtists[0]?.Id;
+      } else if (i?.ParentLogoItemId) {
+        id = i.ParentLogoItemId;
       } else {
         continue;
       }

--- a/pages/artist/_itemId/index.vue
+++ b/pages/artist/_itemId/index.vue
@@ -147,7 +147,7 @@ export default Vue.extend({
       await this.$api.items.getItems({
         userId: this.$auth.user?.Id,
         parentId: this.$route.params.itemId,
-        sortBy: 'PremiereDate',
+        sortBy: 'PremiereDate,ProductionYear,SortName',
         sortOrder: 'Descending'
       })
     ).data.Items;

--- a/plugins/axe.ts
+++ b/plugins/axe.ts
@@ -3,6 +3,6 @@ import Vue from 'vue';
 if (process.env.NODE_ENV === 'development') {
   // eslint-disable-next-line
   import('vue-axe').then(({ default: VueAxe }) => {
-    Vue.use(VueAxe);
+    Vue.use(VueAxe, { auto: false, clearConsoleOnUpdate: false });
   });
 }


### PR DESCRIPTION
* Prevent Axe from running manually
  This requires you to run it manually in the console, but fixes the console refresh that swallows errors
* Corrects the way parent item IDs are found in the home header, fixing the undefined error in some cases
* Mirror jf-web's sorting for albums on the artist pages
  With jellyfin/jellyfin-web#2265, sorting for the albums is done properly. We were already filtering by PremiereDate, but this adds ProductionYear and SortName as fallbacks, to mimic jf-web.
* Use thumb images for thumb-size cards (Except libraries, folders and user views)
  Ideally, imageUtils would naturally fallback to the Backdrop if there is no thumb, but that's for after ferfega's refactoring effort.