### PR TITLE
FormsHelper, TimeUtils - Add test

### DIFF
--- a/mixins/__tests__/formsHelper.spec.ts
+++ b/mixins/__tests__/formsHelper.spec.ts
@@ -1,0 +1,28 @@
+import Vue from 'vue';
+import formsHelper from '../formsHelper';
+
+const TestComponent = new Vue({
+  mixins: [formsHelper]
+});
+
+const FORMS_TEST_INPUT = [
+  { name: 'aaa' },
+  { name: 'bbb' },
+  { name: 'ccc' },
+  { name: 'ddd' },
+  { name: 'eee' }
+];
+
+const FORMS_EXPECTED_OUTPUT = [
+  { value: { name: 'aaa' } },
+  { value: { name: 'bbb' } },
+  { value: { name: 'ccc' } },
+  { value: { name: 'ddd' } },
+  { value: { name: 'eee' } }
+];
+
+test('Correctly itemizes the array of items', () => {
+  expect(TestComponent.getItemizedSelect(FORMS_TEST_INPUT)).toMatchObject(
+    FORMS_EXPECTED_OUTPUT
+  );
+});

--- a/mixins/__tests__/timeUtils.spec.ts
+++ b/mixins/__tests__/timeUtils.spec.ts
@@ -8,6 +8,10 @@ const TestComponent = new Vue({
 describe('timeUtils', () => {
   test('converts time from ms to ticks', () => {
     expect(TestComponent.ticksToMs(10000)).toEqual(1);
+
+    expect(TestComponent.ticksToMs(undefined)).toEqual(0);
+
+    expect(TestComponent.ticksToMs(null)).toEqual(0);
   });
 
   test('converts time from ticks to ms', () => {


### PR DESCRIPTION
**TImeUtils**

Covers cases where input is `null` or `undefined`

**FormsHelper**

 - Adds tests for converting from an array of items, to an array of objects to be used in a v-select
