### PR TITLE
refactor: use asyncData for populating page data

### DIFF
--- a/components/Item/ItemMenu.vue
+++ b/components/Item/ItemMenu.vue
@@ -17,11 +17,11 @@
       </template>
       <v-list>
         <v-list-item
-          v-for="(it, index) in items"
+          v-for="(menuItem, index) in items"
           :key="index"
-          @click="it.action"
+          @click="menuItem.action"
         >
-          <v-list-item-title>{{ it.title }}</v-list-item-title>
+          <v-list-item-title>{{ menuItem.title }}</v-list-item-title>
         </v-list-item>
       </v-list>
     </v-menu>

--- a/components/Item/ItemMenu.vue
+++ b/components/Item/ItemMenu.vue
@@ -18,7 +18,7 @@
       <v-list>
         <v-list-item
           v-for="(menuItem, index) in items"
-          :key="index"
+          :key="`item-${item.Id}-menu-${index}`"
           @click="menuItem.action"
         >
           <v-list-item-title>{{ menuItem.title }}</v-list-item-title>

--- a/components/Item/PersonList.vue
+++ b/components/Item/PersonList.vue
@@ -51,7 +51,7 @@ export default Vue.extend({
     },
     skeletonLength: {
       type: Number,
-      default: 3
+      default: 0
     }
   },
   methods: {

--- a/components/Layout/SwiperSection.vue
+++ b/components/Layout/SwiperSection.vue
@@ -37,7 +37,9 @@ export default Vue.extend({
   props: {
     loading: {
       type: Boolean,
-      required: true
+      default(): boolean {
+        return false;
+      }
     },
     title: {
       type: String,

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -133,6 +133,7 @@
   "parentalRatings": "Parental Ratings",
   "password": "Password",
   "people": "People",
+  "person": "Person",
   "play": "Play",
   "played": "Played",
   "present": "Present",

--- a/pages/artist/_itemId/index.vue
+++ b/pages/artist/_itemId/index.vue
@@ -113,6 +113,25 @@ import timeUtils from '~/mixins/timeUtils';
 
 export default Vue.extend({
   mixins: [htmlHelper, imageHelper, timeUtils],
+  async asyncData({ params, $api, $auth }) {
+    const item = (
+      await $api.userLibrary.getItem({
+        userId: $auth.user?.Id,
+        itemId: params.itemId
+      })
+    ).data;
+
+    const appearances = (
+      await $api.items.getItems({
+        userId: $auth.user?.Id,
+        parentId: params.itemId,
+        sortBy: 'PremiereDate,ProductionYear,SortName',
+        sortOrder: 'Descending'
+      })
+    ).data.Items;
+
+    return { item, appearances };
+  },
   data() {
     return {
       activeTab: 0,
@@ -135,34 +154,11 @@ export default Vue.extend({
       }
     }
   },
-  async beforeMount() {
-    const item = (
-      await this.$api.userLibrary.getItem({
-        userId: this.$auth.user?.Id,
-        itemId: this.$route.params.itemId
-      })
-    ).data;
-
-    if (item) {
-      this.setPageTitle({ title: item.Name });
-      this.setAppBarOpacity({ opaqueAppBar: false });
-      const hash = this.getBlurhash(item, ImageType.Backdrop);
-      this.setBackdrop({ hash });
-      this.item = item;
-    }
-
-    const appearances = (
-      await this.$api.items.getItems({
-        userId: this.$auth.user?.Id,
-        parentId: this.$route.params.itemId,
-        sortBy: 'PremiereDate,ProductionYear,SortName',
-        sortOrder: 'Descending'
-      })
-    ).data.Items;
-
-    if (appearances) {
-      this.appearances = appearances;
-    }
+  beforeMount() {
+    this.setPageTitle({ title: this.item.Name });
+    this.setAppBarOpacity({ opaqueAppBar: false });
+    const hash = this.getBlurhash(this.item, ImageType.Backdrop);
+    this.setBackdrop({ hash });
   },
   destroyed() {
     this.setAppBarOpacity({ opaqueAppBar: true });

--- a/pages/genre/_itemId/index.vue
+++ b/pages/genre/_itemId/index.vue
@@ -98,6 +98,7 @@ export default Vue.extend({
 
       this.loaded = true;
     } catch (error) {
+      /* eslint-disable-next-line no-console */
       console.error(error);
       // Can't get given library ID
       this.$nuxt.error({

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -20,25 +20,12 @@ import { getShapeFromCollectionType } from '~/utils/items';
 import { HomeSection } from '~/store/homeSection';
 
 export default Vue.extend({
-  data() {
-    return {
-      homeSections: [] as HomeSection[]
-    };
-  },
-  head() {
-    return {
-      title: this.$store.state.page.title
-    };
-  },
-  async created() {
-    this.setPageTitle({ title: this.$t('home') });
-    this.setAppBarOpacity({ opaqueAppBar: false });
-
+  async asyncData({ store, app, $api, $auth }) {
     const validSections = ['resume', 'resumeaudio', 'upnext', 'latestmedia'];
 
     // Filter for valid sections in Jellyfin Vue
     let homeSectionsArray = pickBy(
-      this.$store.state.displayPreferences.CustomPrefs,
+      store.state.displayPreferences.CustomPrefs,
       (value: string, key: string) => {
         return (
           value &&
@@ -58,90 +45,102 @@ export default Vue.extend({
       };
     }
 
-    if (homeSectionsArray) {
-      // Convert to an array
-      homeSectionsArray = Object.values(homeSectionsArray);
+    // Convert to an array
+    homeSectionsArray = Object.values(homeSectionsArray);
 
-      const homeSections = [];
+    const homeSections = [];
 
-      for (const homeSection of homeSectionsArray as Array<string>) {
-        switch (homeSection) {
-          case 'librarytiles': {
-            homeSections.push({
-              name: this.$t('libraries'),
-              libraryId: '',
-              shape: 'thumb-card',
-              type: 'libraries'
-            });
-            break;
-          }
-          case 'latestmedia': {
-            const latestMediaSections = [];
+    for (const homeSection of homeSectionsArray as Array<string>) {
+      switch (homeSection) {
+        case 'librarytiles': {
+          homeSections.push({
+            name: app.i18n.t('libraries'),
+            libraryId: '',
+            shape: 'thumb-card',
+            type: 'libraries'
+          });
+          break;
+        }
+        case 'latestmedia': {
+          const latestMediaSections = [];
 
-            const userViewsRequest = await this.$api.userViews.getUserViews({
-              userId: this.$auth.user?.Id
-            });
+          const userViewsRequest = await $api.userViews.getUserViews({
+            userId: $auth.user?.Id
+          });
 
-            if (userViewsRequest.data.Items) {
-              const excludeViewTypes = [
-                'playlists',
-                'livetv',
-                'boxsets',
-                'channels'
-              ];
+          if (userViewsRequest.data.Items) {
+            const excludeViewTypes = [
+              'playlists',
+              'livetv',
+              'boxsets',
+              'channels'
+            ];
 
-              for (const userView of userViewsRequest.data.Items) {
-                if (
-                  excludeViewTypes.includes(userView.CollectionType as string)
-                ) {
-                  continue;
-                }
-
-                latestMediaSections.push({
-                  name: this.$t('latestLibrary', {
-                    libraryName: userView.Name
-                  }),
-                  libraryId: userView.Id || '',
-                  shape: getShapeFromCollectionType(userView.CollectionType),
-                  type: 'latestmedia'
-                });
+            for (const userView of userViewsRequest.data.Items) {
+              if (
+                excludeViewTypes.includes(userView.CollectionType as string)
+              ) {
+                continue;
               }
 
-              homeSections.push(...latestMediaSections);
+              latestMediaSections.push({
+                name: app.i18n.t('latestLibrary', {
+                  libraryName: userView.Name
+                }),
+                libraryId: userView.Id || '',
+                shape: getShapeFromCollectionType(userView.CollectionType),
+                type: 'latestmedia'
+              });
             }
-            break;
-          }
-          case 'resume':
-            homeSections.push({
-              name: this.$t('continueWatching'),
-              libraryId: '',
-              shape: 'thumb-card',
-              type: 'resume'
-            });
-            break;
-          case 'resumeaudio':
-            homeSections.push({
-              name: this.$t('continueListening'),
-              libraryId: '',
-              shape: 'square-card',
-              type: 'resumeaudio'
-            });
-            break;
-          case 'upnext':
-            homeSections.push({
-              name: this.$t('nextUp'),
-              libraryId: '',
-              shape: 'thumb-card',
-              type: 'upnext'
-            });
-            break;
-          default:
-            break;
-        }
-      }
 
-      this.homeSections = homeSections;
+            homeSections.push(...latestMediaSections);
+          }
+          break;
+        }
+        case 'resume':
+          homeSections.push({
+            name: app.i18n.t('continueWatching'),
+            libraryId: '',
+            shape: 'thumb-card',
+            type: 'resume'
+          });
+          break;
+        case 'resumeaudio':
+          homeSections.push({
+            name: app.i18n.t('continueListening'),
+            libraryId: '',
+            shape: 'square-card',
+            type: 'resumeaudio'
+          });
+          break;
+        case 'upnext':
+          homeSections.push({
+            name: app.i18n.t('nextUp'),
+            libraryId: '',
+            shape: 'thumb-card',
+            type: 'upnext'
+          });
+          break;
+        default:
+          break;
+      }
     }
+
+    return { homeSections };
+  },
+  data() {
+    return {
+      homeSections: [] as HomeSection[]
+    };
+  },
+  head() {
+    return {
+      title: this.$store.state.page.title
+    };
+  },
+  created() {
+    this.setPageTitle({ title: this.$t('home') });
+    this.setAppBarOpacity({ opaqueAppBar: false });
   },
   destroyed() {
     this.setAppBarOpacity({ opaqueAppBar: true });

--- a/pages/item/_itemId/index.vue
+++ b/pages/item/_itemId/index.vue
@@ -361,11 +361,11 @@
       <v-col cols="12" sm="4" md="3">
         <div v-if="crew.length > 0">
           <h2>Crew</h2>
-          <person-list :items="crew" :skeleton-length="3" />
+          <person-list :items="crew" />
         </div>
         <div v-if="actors.length > 0">
           <h2>Cast</h2>
-          <person-list :items="actors" :skeleton-length="5" />
+          <person-list :items="actors" />
         </div>
         <related-items
           v-if="['Series', 'MusicAlbum'].includes(item.Type)"

--- a/pages/item/_itemId/index.vue
+++ b/pages/item/_itemId/index.vue
@@ -4,32 +4,24 @@
       <v-col cols="12" sm="8" md="9">
         <v-row justify="center" justify-md="start">
           <v-col cols="7" md="3">
-            <card v-if="loaded" :item="item" no-text no-margin />
-            <skeleton-card v-else no-text />
+            <card :item="item" no-text no-margin />
           </v-col>
           <v-col cols="12" md="9">
             <h1
-              v-if="loaded"
               class="text-h4 font-weight-light"
               :class="{ 'text-center': !$vuetify.breakpoint.mdAndUp }"
             >
               {{ item.Name }}
             </h1>
-            <v-skeleton-loader
-              v-else
-              class="mt-3 mb-2"
-              type="heading"
-              width="50em"
-            />
             <h2
-              v-if="loaded && item.OriginalTitle"
+              v-if="item.OriginalTitle"
               class="text-subtitle-1"
               :class="{ 'text-center': !$vuetify.breakpoint.mdAndUp }"
             >
               {{ item.OriginalTitle }}
             </h2>
             <h2
-              v-if="loaded && item.AlbumArtist"
+              v-if="item.AlbumArtist"
               class="text-subtitle-1 text-truncate mt-2"
               :class="{ 'text-center': !$vuetify.breakpoint.mdAndUp }"
             >
@@ -42,31 +34,18 @@
                 {{ item.AlbumArtist }}
               </nuxt-link>
             </h2>
-            <v-skeleton-loader
-              v-else-if="!loaded"
-              type="heading"
-              width="25em"
-            />
             <div
               class="text-caption text-h4 font-weight-medium mt-2"
               :class="{ 'text-center': !$vuetify.breakpoint.mdAndUp }"
             >
-              <media-info
-                v-if="loaded"
-                :item="item"
-                year
-                runtime
-                rating
-                ends-at
-              />
-              <v-skeleton-loader v-else type="text" width="50em" class="mt-2" />
+              <media-info :item="item" year runtime rating ends-at />
             </div>
             <v-row
               class="mt-4 align-center"
               :class="{ 'text-center': !$vuetify.breakpoint.mdAndUp }"
             >
               <v-btn
-                v-if="loaded && canPlay(item)"
+                v-if="canPlay(item)"
                 class="play-button mr-2"
                 color="primary"
                 min-width="8em"
@@ -77,17 +56,11 @@
               >
                 {{ $t('play') }}
               </v-btn>
-              <v-skeleton-loader v-else type="button" />
               <item-menu :item="item" outlined :absolute="false" />
             </v-row>
             <v-col cols="12" md="10">
               <v-row
-                v-if="
-                  loaded &&
-                  item &&
-                  item.GenreItems &&
-                  item.GenreItems.length > 0
-                "
+                v-if="item && item.GenreItems && item.GenreItems.length > 0"
                 align="center"
               >
                 <v-col
@@ -122,10 +95,7 @@
               </v-row>
               <v-row
                 v-if="
-                  loaded &&
-                  item &&
-                  directors.length > 0 &&
-                  !$vuetify.breakpoint.smAndUp
+                  item && directors.length > 0 && !$vuetify.breakpoint.smAndUp
                 "
                 align="center"
               >
@@ -156,10 +126,7 @@
               </v-row>
               <v-row
                 v-if="
-                  loaded &&
-                  item &&
-                  writers.length > 0 &&
-                  !$vuetify.breakpoint.smAndUp
+                  item && writers.length > 0 && !$vuetify.breakpoint.smAndUp
                 "
                 align="center"
               >
@@ -190,7 +157,6 @@
               </v-row>
               <div
                 v-if="
-                  loaded &&
                   item &&
                   ((item.MediaSources && item.MediaSources.length > 1) ||
                     videoTracks.length > 0 ||
@@ -367,21 +333,10 @@
               </div>
             </v-col>
             <div>
-              <p
-                v-if="loaded && item.Taglines"
-                class="text-subtitle-1 text-truncate"
-              >
+              <p v-if="item.Taglines" class="text-subtitle-1 text-truncate">
                 {{ item.Taglines[0] }}
               </p>
-              <v-skeleton-loader v-else type="text" width="25em" class="mb-4" />
-              <p v-if="loaded" class="item-overview">{{ item.Overview }}</p>
-              <div v-else>
-                <v-skeleton-loader
-                  v-for="index in 2"
-                  :key="index"
-                  type="sentences"
-                />
-              </div>
+              <p class="item-overview">{{ item.Overview }}</p>
             </div>
           </v-col>
         </v-row>
@@ -405,13 +360,11 @@
       </v-col>
       <v-col cols="12" sm="4" md="3">
         <div v-if="crew.length > 0">
-          <h2 v-if="loaded">Crew</h2>
-          <v-skeleton-loader v-else type="heading" />
+          <h2>Crew</h2>
           <person-list :items="crew" :skeleton-length="3" />
         </div>
         <div v-if="actors.length > 0">
-          <h2 v-if="loaded">Cast</h2>
-          <v-skeleton-loader v-else type="heading" />
+          <h2>Cast</h2>
           <person-list :items="actors" :skeleton-length="5" />
         </div>
         <related-items
@@ -443,9 +396,83 @@ import itemHelper from '~/mixins/itemHelper';
 
 export default Vue.extend({
   mixins: [imageHelper, formsHelper, itemHelper],
+  async asyncData({ params, $api, $auth }) {
+    const item = (
+      await $api.userLibrary.getItem({
+        userId: $auth.user?.Id,
+        itemId: params.itemId
+      })
+    ).data;
+
+    let crew: BaseItemPerson[] = [];
+    if (item.People) {
+      crew = item.People.filter((person: BaseItemPerson) => {
+        return ['Director', 'Writer'].includes(person.Type || '');
+      });
+    }
+
+    let currentSource: MediaSourceInfo = {};
+    let videoTracks: MediaStream[] = [];
+    let currentVideoTrack: MediaStream = {};
+    let audioTracks: MediaStream[] = [];
+    let currentAudioTrack: MediaStream = {};
+    let subtitleTracks: MediaStream[] = [];
+    let currentSubtitleTrack: MediaStream = {};
+    if (item.MediaSources && item.MediaSources.length > 0) {
+      currentSource = item.MediaSources[0];
+
+      // Filter the streams to get each type of track
+      if (currentSource.MediaStreams) {
+        videoTracks = currentSource.MediaStreams.filter(
+          (stream: MediaStream) => {
+            return stream.Type === 'Video';
+          }
+        );
+        audioTracks = currentSource.MediaStreams.filter(
+          (stream: MediaStream) => {
+            return stream.Type === 'Audio';
+          }
+        );
+        subtitleTracks = currentSource.MediaStreams.filter(
+          (stream: MediaStream) => {
+            return stream.Type === 'Subtitle';
+          }
+        );
+
+        // Set default tracks
+        if (videoTracks.length > 0) {
+          currentVideoTrack = videoTracks[0];
+        }
+        if (audioTracks.length > 0 && currentSource.DefaultAudioStreamIndex) {
+          currentAudioTrack =
+            audioTracks[currentSource.DefaultAudioStreamIndex - 1];
+        } else if (audioTracks.length > 0) {
+          currentAudioTrack = audioTracks[0];
+        }
+        if (
+          subtitleTracks.length > 0 &&
+          currentSource.DefaultSubtitleStreamIndex
+        ) {
+          currentSubtitleTrack =
+            subtitleTracks[currentSource.DefaultSubtitleStreamIndex - 1];
+        }
+      }
+    }
+
+    return {
+      item,
+      crew,
+      currentSource,
+      videoTracks,
+      currentVideoTrack,
+      audioTracks,
+      currentAudioTrack,
+      subtitleTracks,
+      currentSubtitleTrack
+    };
+  },
   data() {
     return {
-      loaded: false,
       item: {} as BaseItemDto,
       crew: [] as BaseItemPerson[],
       parentItem: {} as BaseItemDto,
@@ -503,73 +530,12 @@ export default Vue.extend({
       }
     }
   },
-  async beforeMount() {
-    this.item = (
-      await this.$api.userLibrary.getItem({
-        userId: this.$auth.user?.Id,
-        itemId: this.$route.params.itemId
-      })
-    ).data;
-
+  beforeMount() {
     if (this.item) {
       this.setPageTitle({ title: this.item.Name });
       this.setAppBarOpacity({ opaqueAppBar: false });
       const hash = this.getBlurhash(this.item, ImageType.Backdrop);
       this.setBackdrop({ hash });
-
-      if (this.item.MediaSources) {
-        this.currentSource = this.item.MediaSources[0];
-
-        // Filter the streams to get each type of track
-        if (this.currentSource.MediaStreams) {
-          this.videoTracks = this.currentSource.MediaStreams.filter(
-            (stream: MediaStream) => {
-              return stream.Type === 'Video';
-            }
-          );
-          this.audioTracks = this.currentSource.MediaStreams.filter(
-            (stream: MediaStream) => {
-              return stream.Type === 'Audio';
-            }
-          );
-          this.subtitleTracks = this.currentSource.MediaStreams.filter(
-            (stream: MediaStream) => {
-              return stream.Type === 'Subtitle';
-            }
-          );
-
-          // Set default tracks
-          if (this.videoTracks.length > 0) {
-            this.currentVideoTrack = this.videoTracks[0];
-          }
-          if (
-            this.audioTracks.length > 0 &&
-            this.currentSource.DefaultAudioStreamIndex
-          ) {
-            this.currentAudioTrack = this.audioTracks[
-              this.currentSource.DefaultAudioStreamIndex - 1
-            ];
-          } else if (this.audioTracks.length > 0) {
-            this.currentAudioTrack = this.audioTracks[0];
-          }
-          if (
-            this.subtitleTracks.length > 0 &&
-            this.currentSource.DefaultSubtitleStreamIndex
-          ) {
-            this.currentSubtitleTrack = this.subtitleTracks[
-              this.currentSource.DefaultSubtitleStreamIndex - 1
-            ];
-          }
-        }
-      }
-
-      if (this.item.People) {
-        this.crew = this.item.People.filter((person: BaseItemPerson) => {
-          return ['Director', 'Writer'].includes(person.Type || '');
-        });
-      }
-
-      this.loaded = true;
     }
   },
   destroyed() {

--- a/pages/library/_viewId.vue
+++ b/pages/library/_viewId.vue
@@ -45,6 +45,16 @@ import { BaseItemDto } from '@jellyfin/client-axios';
 import { validLibraryTypes } from '~/utils/items';
 
 export default Vue.extend({
+  async asyncData({ params, $api, $auth }) {
+    const collectionInfo = (
+      await $api.items.getItems({
+        userId: $auth.user?.Id,
+        ids: [params.viewId]
+      })
+    ).data?.Items?.[0];
+
+    return { collectionInfo };
+  },
   data() {
     return {
       items: [] as BaseItemDto[],
@@ -116,20 +126,13 @@ export default Vue.extend({
       this.loading = false;
     }
   },
-  async beforeMount() {
+  beforeMount() {
     this.setAppBarOpacity({ opaqueAppBar: true });
     this.$nextTick(() => {
       this.$nuxt.$loading.start();
     });
     try {
       this.loading = true;
-      this.collectionInfo = (
-        await this.$api.items.getItems({
-          uId: this.$auth.user?.Id,
-          userId: this.$auth.user?.Id,
-          ids: this.$route.params.viewId
-        })
-      ).data.Items[0];
 
       if (
         this.collectionInfo &&

--- a/pages/library/_viewId.vue
+++ b/pages/library/_viewId.vue
@@ -131,46 +131,37 @@ export default Vue.extend({
     this.$nextTick(() => {
       this.$nuxt.$loading.start();
     });
-    try {
-      this.loading = true;
 
-      if (
-        this.collectionInfo &&
-        validLibraryTypes.includes(this.collectionInfo.Type || '')
-      ) {
-        if (this.collectionInfo.Name) {
-          this.setPageTitle({
-            title: this.collectionInfo.Name
-          });
-        }
-
-        // Set default view type - This will trigger an items refresh
-        switch (this.collectionInfo.CollectionType) {
-          case 'tvshows':
-            this.viewType = 'Series';
-            break;
-          case 'movies':
-            this.viewType = 'Movie';
-            break;
-          case 'books':
-            this.viewType = 'Book';
-            break;
-          case 'music':
-            this.viewType = 'MusicAlbum';
-            break;
-          default:
-            this.refreshItems();
-            break;
-        }
-
-        this.$nuxt.$loading.finish();
+    if (
+      this.collectionInfo?.Type &&
+      validLibraryTypes.includes(this.collectionInfo.Type)
+    ) {
+      if (this.collectionInfo.Name) {
+        this.setPageTitle({
+          title: this.collectionInfo.Name
+        });
       }
-    } catch (error) {
-      // Can't get given library ID
-      this.$nuxt.error({
-        statusCode: 404,
-        message: this.$t('libraryNotFound')
-      });
+
+      // Set default view type - This will trigger an items refresh
+      switch (this.collectionInfo.CollectionType) {
+        case 'tvshows':
+          this.viewType = 'Series';
+          break;
+        case 'movies':
+          this.viewType = 'Movie';
+          break;
+        case 'books':
+          this.viewType = 'Book';
+          break;
+        case 'music':
+          this.viewType = 'MusicAlbum';
+          break;
+        default:
+          this.refreshItems();
+          break;
+      }
+
+      this.$nuxt.$loading.finish();
     }
   },
   destroyed() {

--- a/pages/library/_viewId.vue
+++ b/pages/library/_viewId.vue
@@ -126,7 +126,7 @@ export default Vue.extend({
       this.loading = false;
     }
   },
-  beforeMount() {
+  async beforeMount() {
     this.setAppBarOpacity({ opaqueAppBar: true });
     this.$nextTick(() => {
       this.$nuxt.$loading.start();
@@ -157,7 +157,7 @@ export default Vue.extend({
           this.viewType = 'MusicAlbum';
           break;
         default:
-          this.refreshItems();
+          await this.refreshItems();
           break;
       }
 

--- a/pages/person/_itemId/index.vue
+++ b/pages/person/_itemId/index.vue
@@ -98,8 +98,7 @@ export default Vue.extend({
   data() {
     return {
       item: {} as BaseItemDto,
-      appearances: [] as BaseItemDto[],
-      backdropImageSource: ''
+      appearances: [] as BaseItemDto[]
     };
   },
   computed: {
@@ -174,18 +173,5 @@ export default Vue.extend({
 <style lang="scss" scoped>
 .person-image {
   border-radius: 50%;
-}
-.header span {
-  padding-left: 0.25em;
-}
-.header::before {
-  background-color: white;
-  content: '';
-  position: relative;
-  display: inline-block;
-  height: 1px;
-  bottom: 0.3em;
-  left: 0;
-  width: 1.25em;
 }
 </style>


### PR DESCRIPTION
Switches most of the pages' data fetching to use `asyncData`, which will load data before rendering the page.

Some notable exceptions are the items in libraries and genres pages, since currently the server can be quite slow returning them.

https://user-images.githubusercontent.com/19396809/104120888-9b153900-533a-11eb-8475-f4ecfb62d611.mp4

