### PR TITLE
refactor(settings layout): create general settings page layout component

### DIFF
--- a/components/Layout/SettingsPage.vue
+++ b/components/Layout/SettingsPage.vue
@@ -1,0 +1,33 @@
+<template>
+  <v-container>
+    <v-row v-if="pageTitle">
+      <v-col>
+        <v-row class="mx-0 justify-space-between">
+          <h2 class="text-h6 mb-2">
+            {{ $t(pageTitle) }}
+          </h2>
+          <div class="ml-a">
+            <slot name="actions" />
+          </div>
+        </v-row>
+      </v-col>
+    </v-row>
+    <v-row>
+      <slot name="content" />
+    </v-row>
+  </v-container>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+
+export default Vue.extend({
+  props: {
+    pageTitle: {
+      type: String || undefined,
+      required: false,
+      default: undefined
+    }
+  }
+});
+</script>

--- a/components/Layout/__tests__/SettingsPage.spec.ts
+++ b/components/Layout/__tests__/SettingsPage.spec.ts
@@ -1,0 +1,39 @@
+import { mount } from '@vue/test-utils';
+import SettingsPage from '~/components/Layout/SettingsPage.vue';
+
+const $t = (str: string): string => str;
+
+const wrapper = mount(SettingsPage, {
+  propsData: {
+    pageTitle: 'test-page-title'
+  },
+  mocks: {
+    $t
+  },
+  slots: {
+    actions: '<p>This is a demo action</p>',
+    content: '<p>This is the demo content</p>'
+  }
+});
+
+describe('Settings Page', () => {
+  test('Title and both slots are displayed', () => {
+    expect(wrapper.text()).toContain('test-page-title');
+    expect(wrapper.text()).toContain('This is a demo action');
+    expect(wrapper.text()).toContain('This is the demo content');
+  });
+
+  test('Only content slot is shown when title is undefined.', async () => {
+    await wrapper.setProps({ pageTitle: undefined });
+
+    expect(wrapper.text()).toEqual(
+      expect.not.stringContaining('test-page-title')
+    );
+
+    expect(wrapper.text()).toEqual(
+      expect.not.stringContaining('This is a demo action')
+    );
+
+    expect(wrapper.text()).toContain('This is the demo content');
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -13,11 +13,12 @@ module.exports = {
   collectCoverageFrom: [
     '<rootDir>/components/**/*.vue',
     '<rootDir>/mixins/**/*.vue',
+    '<rootDir>/mixins/**/*.ts',
     '<rootDir>/pages/**/*.vue',
     '<rootDir>/store/**/*.ts',
     '<rootDir>/utils/**/*.ts'
   ],
   testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$',
-  setupFiles: ['jest-canvas-mock'],
+  setupFiles: ['jest-canvas-mock', './jest.setup.ts'],
   coverageReporters: ['text', 'cobertura']
 };

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,4 @@
+import Vue from 'vue';
+import Vuetify from 'vuetify';
+
+Vue.use(Vuetify);

--- a/pages/settings/logsAndActivity.vue
+++ b/pages/settings/logsAndActivity.vue
@@ -1,7 +1,7 @@
 <template>
-  <v-container>
-    <v-row>
-      <v-col cols="12" :offset-md="1" md="5" class="pt-0 pb-4">
+  <settings-page>
+    <template #content>
+      <v-col md="6" class="pt-0 pb-4">
         <h2 class="text-h6 mb-2">{{ $t('logsAndActivity.logs') }}</h2>
         <v-list v-if="logFiles && logFiles.length > 0" two-line class="mb-2">
           <v-list-item-group>
@@ -22,7 +22,7 @@
                 />
               </v-list-item-content>
               <v-list-item-action>
-                <v-icon>mdi-chevron-right</v-icon>
+                <v-icon>mdi-open-in-new</v-icon>
               </v-list-item-action>
             </v-list-item>
           </v-list-item-group>
@@ -42,7 +42,7 @@
           >
         </v-card>
       </v-col>
-      <v-col cols="12" md="5" class="pt-0 pb-4">
+      <v-col md="6" class="pt-0 pb-4">
         <h2 class="text-h6 mb-2">{{ $t('logsAndActivity.activity') }}</h2>
         <v-list
           v-if="activityList && activityList.length > 0"
@@ -85,8 +85,8 @@
           </v-card-text>
         </v-card>
       </v-col>
-    </v-row>
-  </v-container>
+    </template>
+  </settings-page>
 </template>
 
 <script lang="ts">


### PR DESCRIPTION
Creates a general settings page component discussed in #542 

This component contains two v-slot

 - One containing the action buttons
 - One containing the main page content

This component has one optional prop:

 - page title, if this is left undefined, both the heading, and action buttons will be hidden

See Image

Green Section - Page title

Yellow Section - Action buttons (Docs/help...)

Red Section - Main content

![image](https://user-images.githubusercontent.com/18101008/104385867-ec384f00-552b-11eb-957c-5133a943cf75.png)
