### PR TITLE
feat(image search): show error message is no images are found

### DIFF
--- a/components/Item/Metadata/ImageSearch.vue
+++ b/components/Item/Metadata/ImageSearch.vue
@@ -38,7 +38,20 @@
       </v-row>
       <v-divider />
       <v-row class="image-results">
-        <v-col class="card-grid-container">
+        <v-progress-circular
+          v-if="loading"
+          :size="70"
+          :width="7"
+          color="primary"
+          indeterminate
+          class="loading-bar"
+        />
+        <v-card v-else-if="!images.length" class="mx-auto">
+          <v-card-title>
+            {{ $t('noImagesFound') }}
+          </v-card-title>
+        </v-card>
+        <v-col v-else class="card-grid-container">
           <v-card
             v-for="(item, i) in images"
             :key="`${item.Type}-${i}`"
@@ -77,14 +90,6 @@
             </v-card-actions>
           </v-card>
         </v-col>
-        <v-progress-circular
-          v-if="loading"
-          :size="70"
-          :width="7"
-          color="primary"
-          indeterminate
-          class="loading-bar"
-        ></v-progress-circular>
       </v-row>
     </v-card>
   </v-dialog>

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -122,6 +122,7 @@
   "noResultsFound": "There is nothing here",
   "noSubtitleAvailable": "No subtitle available",
   "noSubtitleSelected": "No subtitle selected",
+  "noImagesFound": "No images found",
   "numberTracks": "{number} tracks",
   "operatingSystem": "Operating system",
   "originalAspectRatio": "Original aspect ratio",


### PR DESCRIPTION
Previously, if no images were found, nothing would be shown, now it shows an message saying "No images found"