### PR TITLE
refactor(home sections): improve home sections loading speed by caching userviews

### DIFF
--- a/components/Layout/HomeSection.vue
+++ b/components/Layout/HomeSection.vue
@@ -22,7 +22,22 @@ export default Vue.extend({
       required: true
     }
   },
-  async fetch() {
+  data() {
+    return {
+      loading: true
+    };
+  },
+  computed: {
+    ...mapGetters('homeSection', ['getHomeSectionContent']),
+    items(): BaseItemDto[] {
+      return this.getHomeSectionContent(this.section);
+    }
+  },
+  async beforeMount() {
+    if (this.getHomeSectionContent(this.section)) {
+      this.loading = false;
+    }
+
     switch (this.section.type) {
       case 'libraries': {
         await this.getLibraries();
@@ -51,12 +66,8 @@ export default Vue.extend({
       default:
         break;
     }
-  },
-  computed: {
-    ...mapGetters('homeSection', ['getHomeSectionContent']),
-    items(): BaseItemDto[] {
-      return this.getHomeSectionContent(this.section);
-    }
+
+    this.loading = false;
   },
   methods: {
     ...mapActions('homeSection', {

--- a/store/__tests__/userViews.spec.ts
+++ b/store/__tests__/userViews.spec.ts
@@ -85,3 +85,15 @@ test('When getNavigationDrawerItems is called, the nav draw items are returned.'
     { icon: 'mdi-folder', title: 'test-view-c', to: '/library/test-id-3' }
   ]);
 });
+
+test('When getUserViews is called, all userViews are returned.', () => {
+  store.replaceState({
+    views: [DEMO_TEST_ITEM_A, DEMO_TEST_ITEM_B, DEMO_TEST_ITEM_C]
+  });
+
+  expect(store.getters.getUserViews).toMatchObject([
+    DEMO_TEST_ITEM_A,
+    DEMO_TEST_ITEM_B,
+    DEMO_TEST_ITEM_C
+  ]);
+});

--- a/store/userViews.ts
+++ b/store/userViews.ts
@@ -25,6 +25,9 @@ export const getters: GetterTree<UserViewsState, UserViewsState> = {
         to: `/library/${view.Id}`
       };
     });
+  },
+  getUserViews: (state): BaseItemDto[] => {
+    return state.views;
   }
 };
 
@@ -39,13 +42,18 @@ export const mutations: MutationTree<UserViewsState> = {
 
 export const actions: ActionTree<UserViewsState, UserViewsState> = {
   async refreshUserViews({ commit }) {
-    const userViewsResponse = await this.$api.userViews.getUserViews({
-      userId: this.$auth.user?.Id
-    });
+    try {
+      const userViewsResponse = await this.$api.userViews.getUserViews({
+        userId: this.$auth.user?.Id
+      });
 
-    const userViews = userViewsResponse.data.Items;
+      const userViews = userViewsResponse.data.Items;
 
-    commit('SET_USER_VIEWS', { userViews });
+      commit('SET_USER_VIEWS', { userViews });
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error(error);
+    }
   },
   clearUserViews({ commit }) {
     commit('CLEAR_USER_VIEWS');


### PR DESCRIPTION
Currently, when navigating from home -> a different page -> home, the time taken to reload the homepage can be slow.

This is because, in the creation of home sections, we are awaiting for `userView` from the api. By instead using the userViews in store, the speed is greatly impoved.


**To Test**
To test this you must build + run. It cannot be tested in dev mode.

This is because on network failure, it causes the whole page to show an error message.

Navigate from home -> an item -> turn network connectivity to offline -> back to home, the home sections should load immediately, although with some missing images