### PR TITLE
refactor(login flor): improve responsiveness of selectserver and login pages

### DIFF
--- a/pages/SelectServer.vue
+++ b/pages/SelectServer.vue
@@ -1,7 +1,7 @@
 <template>
   <v-container fill-height>
     <v-row align="center" justify="center">
-      <v-col md="4">
+      <v-col sm="6" md="6" lg="5">
         <h1 class="text-h4 mb-6 text-center">{{ $t('selectServer') }}</h1>
         <div v-if="$store.state.servers.serverList">
           <server-card

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -3,7 +3,9 @@
     <v-row align="center" justify="center">
       <v-col
         v-if="isEmpty(currentUser) && !loginAsOther && publicUsers.length > 0"
-        xl="8"
+        sm="7"
+        md="6"
+        lg="5"
       >
         <h1 class="text-h4 mb-6 text-center">{{ $t('selectUser') }}</h1>
         <v-row align="center" justify="center">
@@ -11,8 +13,8 @@
             v-for="publicUser in publicUsers"
             :key="publicUser.Id"
             xl="2"
-            lg="2"
-            md="3"
+            lg="4"
+            md="4"
             sm="4"
             xs="4"
             cols="6"
@@ -21,7 +23,7 @@
           </v-col>
         </v-row>
         <v-row align="center" justify="center" no-gutters>
-          <v-col md="4" class="d-flex flex-row mt-7">
+          <v-col class="d-flex flex-row mt-7">
             <v-btn class="flex-grow-1 mr-2" large @click="loginAsOther = true">
               {{ $t('manualLogin') }}
             </v-btn>
@@ -34,7 +36,9 @@
       </v-col>
       <v-col
         v-else-if="!isEmpty(currentUser) || loginAsOther || !publicUsers.length"
-        md="4"
+        sm="6"
+        md="6"
+        lg="5"
       >
         <h1 v-if="!isEmpty(currentUser)" class="text-h4 mb-6 text-center">
           {{ $t('loginAs', { name: currentUser.Name }) }}


### PR DESCRIPTION
Increases width of selectserver and login forms to prevent locale switcher wrapping onto next line.

https://user-images.githubusercontent.com/18101008/104755345-3438bb00-5752-11eb-8428-54e27ccb9217.mp4



https://user-images.githubusercontent.com/18101008/104755255-1f5c2780-5752-11eb-8a6a-f4f7d09c9695.mp4

Previously this could occur in some situations
![image](https://user-images.githubusercontent.com/18101008/104755457-5b8f8800-5752-11eb-84e7-33c0c6c2739a.png)

