### PR TITLE
fix: this.$nuxt.$loading.finish() is not a function

### DIFF
--- a/pages/library/_viewId.vue
+++ b/pages/library/_viewId.vue
@@ -161,7 +161,9 @@ export default Vue.extend({
           break;
       }
 
-      this.$nuxt.$loading.finish();
+      this.$nextTick(() => {
+        this.$nuxt.$loading.finish();
+      });
     }
   },
   destroyed() {


### PR DESCRIPTION
As proposed [in nuxt's docs](https://nuxtjs.org/docs/2.x/features/loading#programmatically-starting-the-loading-bar)