### PR TITLE
fix: sometimes Id is undefined when stopping playback

### DIFF
--- a/components/Players/PlayerManager.vue
+++ b/components/Players/PlayerManager.vue
@@ -218,7 +218,7 @@ export default Vue.extend({
           }
 
           // Then report the start of the next one
-          if (this.getCurrentItem.Id !== null) {
+          if (this.getCurrentItem?.Id) {
             this.$api.playState.reportPlaybackStart(
               {
                 playbackStartInfo: {


### PR DESCRIPTION
Missed in #575. Sometimes, if timing is precise after the mutation notification, Id could be undefined (not only null).