### PR TITLE
fix(video-player): video container does not scale

### DIFF
--- a/components/Players/VideoPlayer.vue
+++ b/components/Players/VideoPlayer.vue
@@ -1,6 +1,6 @@
 <template>
   <v-container fill-height fluid class="pa-0 justify-center">
-    <div ref="videoContainer">
+    <div ref="videoContainer" style="height: 100%; width: 100%">
       <video
         ref="videoPlayer"
         :poster="poster"

--- a/components/Players/VideoPlayer.vue
+++ b/components/Players/VideoPlayer.vue
@@ -1,16 +1,14 @@
 <template>
   <v-container fill-height fluid class="pa-0 justify-center">
-    <div id="videoContainer" ref="videoContainer">
-      <video
-        ref="videoPlayer"
-        :poster="poster"
-        autoplay
-        @timeupdate="onVideoProgress"
-        @pause="onVideoPause"
-        @play="onVideoProgress"
-        @ended="onVideoStopped"
-      />
-    </div>
+    <video
+      ref="videoPlayer"
+      :poster="poster"
+      autoplay
+      @timeupdate="onVideoProgress"
+      @pause="onVideoPause"
+      @play="onVideoProgress"
+      @ended="onVideoStopped"
+    />
   </v-container>
 </template>
 
@@ -237,10 +235,5 @@ video {
   max-height: 100vh;
   width: 100%;
   height: 100%;
-}
-#videoContainer {
-  height: 100%;
-  width: 100%;
-  overflow: hidden;
 }
 </style>

--- a/components/Players/VideoPlayer.vue
+++ b/components/Players/VideoPlayer.vue
@@ -1,9 +1,6 @@
 <template>
   <v-container fill-height fluid class="pa-0 justify-center">
-    <div
-      ref="videoContainer"
-      style="height: 100%; width: 100%; overflow: hidden"
-    >
+    <div id="videoContainer" ref="videoContainer">
       <video
         ref="videoPlayer"
         :poster="poster"
@@ -240,5 +237,10 @@ video {
   max-height: 100vh;
   width: 100%;
   height: 100%;
+}
+#videoContainer {
+  height: 100%;
+  width: 100%;
+  overflow: hidden;
 }
 </style>

--- a/components/Players/VideoPlayer.vue
+++ b/components/Players/VideoPlayer.vue
@@ -1,6 +1,9 @@
 <template>
   <v-container fill-height fluid class="pa-0 justify-center">
-    <div ref="videoContainer" style="height: 100%; width: 100%">
+    <div
+      ref="videoContainer"
+      style="height: 100%; width: 100%; overflow: hidden"
+    >
       <video
         ref="videoPlayer"
         :poster="poster"


### PR DESCRIPTION
Fixes the issue where SD videos did not scale to fill the screen

Fixes #569 

Tested on chrome and firefox. Verified that HD still works as well (see screenshot)

**SD**
![image](https://user-images.githubusercontent.com/20001253/104817688-0ff8df00-5823-11eb-87d6-c91e2b2ddd1c.png)

**HD**
![2021-01-16_17-55](https://user-images.githubusercontent.com/20001253/104817838-23f11080-5824-11eb-9138-a44f17f90109.png)
