### PR TITLE
Add MediaMetadata support

### DIFF
--- a/components/Players/PlayerManager.vue
+++ b/components/Players/PlayerManager.vue
@@ -146,8 +146,10 @@
 </template>
 
 <script lang="ts">
+import { ImageType } from '@jellyfin/client-axios';
 import Vue from 'vue';
 import { mapActions, mapGetters } from 'vuex';
+import imageHelper from '~/mixins/imageHelper';
 import timeUtils from '~/mixins/timeUtils';
 import { AppState } from '~/store';
 import { PlaybackStatus } from '~/store/playbackManager';
@@ -157,7 +159,7 @@ import {
 } from '~/utils/supportedFeatures';
 
 export default Vue.extend({
-  mixins: [timeUtils],
+  mixins: [timeUtils, imageHelper],
   data() {
     return {
       supportedFeatures: {} as SupportedFeaturesInterface
@@ -234,6 +236,8 @@ export default Vue.extend({
               },
               { progress: false }
             );
+
+            this.updateMetadata();
           }
 
           this.setLastProgressUpdate({ progress: new Date().getTime() });
@@ -280,6 +284,8 @@ export default Vue.extend({
             );
 
             this.setLastProgressUpdate({ progress: 0 });
+
+            this.resetMetadata();
           }
           break;
         case 'playbackManager/PAUSE_PLAYBACK':
@@ -354,6 +360,73 @@ export default Vue.extend({
             this.skipBackward();
             break;
         }
+      }
+    },
+    resetMetadata(): void {
+      if (window.navigator.mediaSession) {
+        window.navigator.mediaSession.metadata = null;
+      }
+    },
+    updateMetadata(): void {
+      if (window.navigator.mediaSession) {
+        // eslint-disable-next-line no-undef
+        window.navigator.mediaSession.metadata = new MediaMetadata({
+          title: this.getCurrentItem.Name,
+          artist: this.getCurrentItem?.AlbumArtist
+            ? this.getCurrentItem.AlbumArtist
+            : '',
+          album: this.getCurrentItem?.Album ? this.getCurrentItem.Album : '',
+          artwork: [
+            {
+              src:
+                this.getImageUrlForElement(ImageType.Primary, {
+                  item: this.getCurrentItem,
+                  maxWidth: 96
+                }) || '',
+              sizes: '96x96'
+            },
+            {
+              src:
+                this.getImageUrlForElement(ImageType.Primary, {
+                  item: this.getCurrentItem,
+                  maxWidth: 128
+                }) || '',
+              sizes: '128x128'
+            },
+            {
+              src:
+                this.getImageUrlForElement(ImageType.Primary, {
+                  item: this.getCurrentItem,
+                  maxWidth: 192
+                }) || '',
+              sizes: '192x192'
+            },
+            {
+              src:
+                this.getImageUrlForElement(ImageType.Primary, {
+                  item: this.getCurrentItem,
+                  maxWidth: 256
+                }) || '',
+              sizes: '256x256'
+            },
+            {
+              src:
+                this.getImageUrlForElement(ImageType.Primary, {
+                  item: this.getCurrentItem,
+                  maxWidth: 384
+                }) || '',
+              sizes: '384x384'
+            },
+            {
+              src:
+                this.getImageUrlForElement(ImageType.Primary, {
+                  item: this.getCurrentItem,
+                  maxWidth: 512
+                }) || '',
+              sizes: '512x512'
+            }
+          ]
+        });
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "@nuxtjs/vuetify": "^1.11.2",
     "@types/nuxtjs__auth": "^4.8.7",
     "@types/qs": "^6.9.5",
+    "@types/wicg-mediasession": "^1.1.0",
     "@vue/test-utils": "^1.1.2",
     "axe-core": "^4.1.1",
     "babel-core": "7.0.0-bridge.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,7 @@
       "@nuxtjs/vuetify",
       "@nuxtjs/date-fns",
       "nuxt-i18n",
+      "@types/wicg-mediasession",
       "jest"
     ]
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2445,6 +2445,11 @@
     "@types/webpack-sources" "*"
     source-map "^0.6.0"
 
+"@types/wicg-mediasession@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@types/wicg-mediasession/-/wicg-mediasession-1.1.0.tgz#368bb113ffc1a5410895cbb1e5ba50ee291f162f"
+  integrity sha512-aA6+ZUHgNpXqWEL8UdS1fx/oCFSrh/Hu9BbM8rXYZLiCQSuZ8+Lzu1//LKwHMNBAXgen7/8LoThDEKS9VEaGxw==
+
 "@types/yargs-parser@*":
   version "15.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-15.0.0.tgz#cb3f9f741869e20cce330ffbeb9271590483882d"
@@ -13686,11 +13691,6 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
-
-typescript@~4.0:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.2.tgz#7ea7c88777c723c681e33bf7988be5d008d05ac2"
-  integrity sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==
 
 typescript@~4.1:
   version "4.1.3"


### PR DESCRIPTION
This adds the necessary MediaMetadata object to get proper metadata for the audio and video players.

![Screenshot from 2021-01-17 06-19-07](https://user-images.githubusercontent.com/19396809/104831840-9e557b00-588c-11eb-90b1-c5a9b26eb2a5.png)

Note: While officially recommended, the typings file for the MediaSession API seems to have a few issues with regards to the MediaMetadata class. Errors have been silenced until we find a fix.