### PR TITLE
feat(localeswitcher): add automatic locale picking

### DIFF
--- a/components/System/LocaleSwitcher.vue
+++ b/components/System/LocaleSwitcher.vue
@@ -19,9 +19,11 @@
     </template>
     <v-list class="overflow-y-auto">
       <v-list-item
-        v-for="(item, index) in $i18n.locales"
-        :key="index"
-        :input-value="item.code === $i18n.locale"
+        v-for="item in locales"
+        :key="item.code"
+        :input-value="
+          item.code === $store.state.displayPreferences.CustomPrefs.locale
+        "
         @click="editCustomPref({ key: 'locale', value: item.code })"
       >
         <v-list-item-title>{{ item.name }}</v-list-item-title>
@@ -30,8 +32,14 @@
   </v-menu>
 </template>
 <script lang="ts">
+import { NuxtVueI18n } from 'nuxt-i18n/types/nuxt-i18n';
 import Vue from 'vue';
 import { mapActions } from 'vuex';
+
+interface LocalesSelect {
+  code: string;
+  name: string;
+}
 
 export default Vue.extend({
   props: {
@@ -40,8 +48,34 @@ export default Vue.extend({
       required: true
     }
   },
+  computed: {
+    locales: {
+      get(): LocalesSelect[] {
+        if (!this.$i18n.locales) return [];
+        const res: LocalesSelect[] = (this.$i18n
+          .locales as NuxtVueI18n.Options.LocaleObject[]).map((el) => {
+          return { code: el.code, name: el.name };
+        });
+        res.unshift({
+          code: 'auto',
+          name: `${this.$t('auto')} (${this.getLocaleCodeName(
+            this.$i18n.getBrowserLocale()
+          )})`
+        });
+        return res;
+      }
+    }
+  },
   methods: {
-    ...mapActions('displayPreferences', ['editCustomPref'])
+    ...mapActions('displayPreferences', ['editCustomPref']),
+    getLocaleCodeName(code: string | undefined): string {
+      if (!this.$i18n.locales || !code) return '';
+      const res = (this.$i18n
+        .locales as NuxtVueI18n.Options.LocaleObject[]).find(
+        (el) => el.code === code
+      );
+      return res ? res.name : '';
+    }
   }
 });
 </script>


### PR DESCRIPTION
As i18n allows us to detect the locale, we could have an item in the picker to pick an `auto` one which would follow the browser setting. This is a draft implementation which has drawbacks:

* The page doesn't change language until it's fully refreshed or we click on the auto language again. Right now `displayPreferences` does the work of setting the locale when it sees the `auto` keyword when updating the preferences, or loading them from the server. So changing the browser's language with the JF client opened wouldn't change the one in the client. Though this is due to how i18n works, as it sets the locale to the cookie and only changes when we call its `setLocale` method.
* In the same vein, the text in the picker doesn't change without refreshing or clicking on `Auto` yet again.

This is how it looks like:
![print_screen_2021-01-17-16-44-21](https://user-images.githubusercontent.com/1619359/104847990-45fd9800-58e3-11eb-93e0-eb0ee6f52136.png)

I'm waiting for when we'll have a better implementation of the display preferences where the store only handles fetching/updating the server and we'll have those client locales react to the store.