### PR TITLE
fix(login): fix some responsive problems

### DIFF
--- a/components/System/LocaleSwitcher.vue
+++ b/components/System/LocaleSwitcher.vue
@@ -6,7 +6,8 @@
           <v-btn
             :icon="!fab"
             :fab="fab"
-            :small="fab"
+            :small="!large & fab"
+            :large="large"
             :class="{ 'mr-n1': !fab, 'ml-1': fab }"
             v-bind="{ ...attrsMenu, ...attrsTooltip }"
             v-on="{ ...onMenu, ...onTooltip }"
@@ -37,7 +38,11 @@ export default Vue.extend({
   props: {
     fab: {
       type: Boolean,
-      required: true
+      required: false
+    },
+    large: {
+      type: Boolean,
+      required: false
     }
   },
   methods: {

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -3,8 +3,8 @@
     <v-row align="center" justify="center">
       <v-col
         v-if="isEmpty(currentUser) && !loginAsOther && publicUsers.length > 0"
-        sm="7"
-        md="6"
+        sm="10"
+        md="7"
         lg="5"
       >
         <h1 class="text-h4 mb-6 text-center">{{ $t('selectUser') }}</h1>
@@ -12,27 +12,26 @@
           <v-col
             v-for="publicUser in publicUsers"
             :key="publicUser.Id"
-            xl="2"
-            lg="4"
-            md="4"
-            sm="4"
-            xs="4"
-            cols="6"
+            cols="auto"
           >
             <user-card :user="publicUser" @connect="setCurrentUser" />
           </v-col>
         </v-row>
-        <v-row align="center" justify="center" no-gutters>
-          <v-col class="d-flex flex-row mt-7">
-            <v-btn class="flex-grow-1 mr-2" large @click="loginAsOther = true">
+        <v-row align="center" justify="center" dense class="mt-7">
+          <v-col cols="11" sm="6" class="d-flex justify-center">
+            <v-btn block large @click="loginAsOther = true">
               {{ $t('manualLogin') }}
             </v-btn>
-            <v-btn class="flex-grow-1 mr-2" to="/selectServer" nuxt large>
+          </v-col>
+          <v-col cols="11" sm="6" class="d-flex justify-center">
+            <v-btn block to="/selectServer" nuxt large>
               {{ $t('changeServer') }}
             </v-btn>
-            <locale-switcher />
           </v-col>
         </v-row>
+        <div class="d-flex justify-center mt-6">
+          <locale-switcher large />
+        </div>
       </v-col>
       <v-col
         v-else-if="!isEmpty(currentUser) || loginAsOther || !publicUsers.length"


### PR DESCRIPTION
On lower ends of some breakpoints, user cards were too narrow. Also, on really narrow (<500px) screens the buttons and locale picker disappeared on the right.

# Current
![print_screen_2021-01-17-17-35-42](https://user-images.githubusercontent.com/1619359/104850109-6cc0cc00-58ed-11eb-808d-6212479038fd.png)
![print_screen_2021-01-17-17-35-28](https://user-images.githubusercontent.com/1619359/104850110-6d596280-58ed-11eb-9492-96578f443017.png)
![print_screen_2021-01-17-17-35-19](https://user-images.githubusercontent.com/1619359/104850111-6df1f900-58ed-11eb-9b77-a6a3ea0ede18.png)

# PR
![Screenshot_2021-01-25 Jellyfin(1)](https://user-images.githubusercontent.com/1619359/105692694-03e5df00-5eff-11eb-80d1-2e9b2d2ba6bc.png)
![Screenshot_2021-01-25 Jellyfin](https://user-images.githubusercontent.com/1619359/105692696-047e7580-5eff-11eb-8896-9a94404c9646.png)

