### PR TITLE
fix(itemmenu): don't force dark theme

### DIFF
--- a/components/Item/Card/Card.vue
+++ b/components/Item/Card/Card.vue
@@ -79,7 +79,7 @@
             class="card-lower-buttons d-flex justify-center align-center"
           >
             <like-button v-if="canPlay(item)" :item="item" dark />
-            <item-menu :item="item" />
+            <item-menu :item="item" dark />
           </div>
         </div>
       </div>

--- a/components/Item/ItemMenu.vue
+++ b/components/Item/ItemMenu.vue
@@ -66,7 +66,7 @@ export default Vue.extend({
     },
     dark: {
       type: Boolean,
-      default: true
+      default: false
     },
     outlined: {
       type: Boolean,

--- a/components/Layout/AudioControls.vue
+++ b/components/Layout/AudioControls.vue
@@ -143,7 +143,7 @@
                 <span>{{ $t('fullScreen') }}</span>
               </v-tooltip>
             </v-fade-transition>
-            <item-menu :item="getCurrentItem" :dark="false" />
+            <item-menu :item="getCurrentItem" />
           </v-col>
           <v-col
             cols="3"


### PR DESCRIPTION
Don't force dark theme on ItemMenu

## Current
![image](https://user-images.githubusercontent.com/108104/104856466-de464d80-58e0-11eb-870c-f6a2464c8d02.png)

## Fixed
![image](https://user-images.githubusercontent.com/108104/104856443-b2c36300-58e0-11eb-9bc4-c2a2a7d53d7d.png)

## Note
This is my first PR against the new jellyfin-vue repository, so please let me know if there's anything I did wrong or anything I could do better in the future. I found the issue while exploring the new interface. It's looking great!