### PR TITLE
feat(playback): add functions to handle mediasession inputs

### DIFF
--- a/components/Players/PlayerManager.vue
+++ b/components/Players/PlayerManager.vue
@@ -287,6 +287,8 @@ export default Vue.extend({
             this.setLastProgressUpdate({ progress: 0 });
 
             this.resetMetadata();
+
+            this.removeMediaHandlers();
           }
           break;
         case 'playbackManager/PAUSE_PLAYBACK':
@@ -346,7 +348,7 @@ export default Vue.extend({
       'setLastItemIndex',
       'playPause',
       'pause',
-      'play',
+      'unpause',
       'skipForward',
       'skipBackward',
       'changeCurrentTime'
@@ -400,8 +402,8 @@ export default Vue.extend({
         const actionHandlers = [
           [
             'play',
-            async (): Promise<void> => {
-              await this.play();
+            (): void => {
+              this.unpause();
               if (navigator.mediaSession) {
                 navigator.mediaSession.playbackState = 'playing';
               }
@@ -430,8 +432,8 @@ export default Vue.extend({
           ],
           [
             'stop',
-            async (): Promise<void> => {
-              await this.stopPlayback();
+            (): void => {
+              this.stopPlayback();
               if (navigator.mediaSession) {
                 navigator.mediaSession.playbackState = 'none';
               }
@@ -467,6 +469,31 @@ export default Vue.extend({
             console.log(
               `The media session action "${action}" is not supported.`
             );
+          }
+        }
+      }
+    },
+    removeMediaHandlers(): void {
+      if (navigator.mediaSession) {
+        const actionHandlers = [
+          ['play', null],
+          ['pause', null],
+          ['previoustrack', null],
+          ['nexttrack', null],
+          ['stop', null],
+          ['seekbackward', null],
+          ['seekforward', null],
+          ['seekto', null]
+        ];
+
+        for (const [action, handler] of actionHandlers) {
+          try {
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            navigator.mediaSession.setActionHandler(action, handler);
+          } catch (error) {
+            // eslint-disable-next-line no-console
+            console.log(`Error removing mediaSession action: "${action}".`);
           }
         }
       }

--- a/components/Players/PlayerManager.vue
+++ b/components/Players/PlayerManager.vue
@@ -171,6 +171,7 @@ export default Vue.extend({
     ...mapGetters('playbackManager', [
       'getCurrentItem',
       'getPreviousItem',
+      'getNextItem',
       'getCurrentlyPlayingMediaType'
     ]),
     isPlaying(): boolean {
@@ -198,6 +199,7 @@ export default Vue.extend({
     this.$store.subscribe((mutation, state: AppState) => {
       switch (mutation.type) {
         case 'playbackManager/INCREASE_QUEUE_INDEX':
+        case 'playbackManager/DECREASE_QUEUE_INDEX':
         case 'playbackManager/SET_CURRENT_ITEM_INDEX':
           // Report playback stop for the previous item
           if (


### PR DESCRIPTION
**Before**
![image](https://user-images.githubusercontent.com/18101008/104902139-3c714000-5976-11eb-9b35-34851614233d.png)

**After**
![image](https://user-images.githubusercontent.com/18101008/104902164-48f59880-5976-11eb-8e6b-0424f499a62b.png)

Unfortunately chrome desktop cannot seek through media tracks however it should not be too difficult to add:

```
navigator.mediaSession.setActionHandler('seekto', (time: number) => { 
  this.changeCurrentTime(time)
});
