### PR TITLE
feat: disable buttons on load or no items and show progress circular in chip while loading

### DIFF
--- a/components/Buttons/FilterButton.vue
+++ b/components/Buttons/FilterButton.vue
@@ -232,7 +232,8 @@ export default Vue.extend({
     },
     disabled: {
       type: Boolean,
-      required: true
+      required: false,
+      default: false
     }
   },
   data() {

--- a/components/Buttons/FilterButton.vue
+++ b/components/Buttons/FilterButton.vue
@@ -3,6 +3,7 @@
     <template #activator="{ on, attrs }">
       <v-btn
         v-if="!$vuetify.breakpoint.smAndDown"
+        :disabled="disabled"
         class="ma-2"
         text
         rounded
@@ -12,7 +13,14 @@
         {{ $t('filter') }}
         <v-icon right>mdi-menu-down</v-icon>
       </v-btn>
-      <v-btn v-else class="my-2" icon v-bind="attrs" v-on="on">
+      <v-btn
+        v-else
+        :disabled="disabled"
+        class="my-2"
+        icon
+        v-bind="attrs"
+        v-on="on"
+      >
         <v-icon>mdi-filter-variant</v-icon>
       </v-btn>
     </template>
@@ -220,6 +228,10 @@ export default Vue.extend({
     },
     itemsType: {
       type: String,
+      required: true
+    },
+    disabled: {
+      type: Boolean,
       required: true
     }
   },

--- a/components/Buttons/SortButton.vue
+++ b/components/Buttons/SortButton.vue
@@ -6,13 +6,21 @@
         class="my-2"
         text
         rounded
+        :disabled="disabled"
         v-bind="attrs"
         v-on="on"
       >
         {{ $t('sortByType', { type: items[model].name }) }}
         <v-icon right>mdi-menu-down</v-icon>
       </v-btn>
-      <v-btn v-else class="my-2" icon v-bind="attrs" v-on="on">
+      <v-btn
+        v-else
+        :disabled="disabled"
+        class="my-2"
+        icon
+        v-bind="attrs"
+        v-on="on"
+      >
         <v-icon>mdi-sort-alphabetical-ascending</v-icon>
       </v-btn>
     </template>
@@ -33,6 +41,12 @@
 import Vue from 'vue';
 
 export default Vue.extend({
+  props: {
+    disabled: {
+      type: Boolean,
+      required: true
+    }
+  },
   data() {
     return {
       items: [

--- a/components/Buttons/SortButton.vue
+++ b/components/Buttons/SortButton.vue
@@ -44,7 +44,8 @@ export default Vue.extend({
   props: {
     disabled: {
       type: Boolean,
-      required: true
+      required: false,
+      default: false
     }
   },
   data() {

--- a/components/Buttons/TypeButton.vue
+++ b/components/Buttons/TypeButton.vue
@@ -6,13 +6,21 @@
         class="my-2"
         text
         rounded
+        :disabled="disabled"
         v-bind="attrs"
         v-on="on"
       >
         {{ items[model].name }}
         <v-icon right>mdi-menu-down</v-icon>
       </v-btn>
-      <v-btn v-else class="my-2" icon v-bind="attrs" v-on="on">
+      <v-btn
+        v-else
+        :disabled="disabled"
+        class="my-2"
+        icon
+        v-bind="attrs"
+        v-on="on"
+      >
         <v-icon>mdi-eye</v-icon>
       </v-btn>
     </template>
@@ -36,6 +44,10 @@ export default Vue.extend({
   props: {
     type: {
       type: String,
+      required: true
+    },
+    disabled: {
+      type: Boolean,
       required: true
     }
   },

--- a/components/Buttons/TypeButton.vue
+++ b/components/Buttons/TypeButton.vue
@@ -48,7 +48,8 @@ export default Vue.extend({
     },
     disabled: {
       type: Boolean,
-      required: true
+      required: false,
+      default: false
     }
   },
   data() {

--- a/pages/library/_viewId.vue
+++ b/pages/library/_viewId.vue
@@ -4,11 +4,9 @@
       <span class="text-h6 hidden-sm-and-down">
         {{ collectionInfo.Name }}
       </span>
-      <v-chip v-if="!loading" small class="ma-2 hidden-sm-and-down">
-        {{ itemsCount }}
-      </v-chip>
-      <v-chip v-else class="ma-2 hidden-sm-and-down">
-        <v-progress-circular width="2" indeterminate size="15" />
+      <v-chip :small="!loading" class="ma-2 hidden-sm-and-down">
+        <template v-if="!loading">{{ itemsCount }}</template>
+        <v-progress-circular v-else width="2" indeterminate size="16" />
       </v-chip>
       <v-divider inset vertical class="mx-2 hidden-sm-and-down" />
       <type-button

--- a/pages/library/_viewId.vue
+++ b/pages/library/_viewId.vue
@@ -7,10 +7,14 @@
       <v-chip v-if="!loading" small class="ma-2 hidden-sm-and-down">
         {{ itemsCount }}
       </v-chip>
+      <v-chip v-else class="ma-2 hidden-sm-and-down">
+        <v-progress-circular width="2" indeterminate size="15" />
+      </v-chip>
       <v-divider inset vertical class="mx-2 hidden-sm-and-down" />
       <type-button
         v-if="hasViewTypes"
         :type="collectionInfo.CollectionType"
+        :disabled="loading || !items.length"
         @change="onChangeType"
       />
       <v-divider
@@ -19,10 +23,15 @@
         vertical
         class="mx-2"
       />
-      <sort-button v-if="isSortable" @change="onChangeSort" />
+      <sort-button
+        v-if="isSortable"
+        :disabled="loading || !items.length"
+        @change="onChangeSort"
+      />
       <filter-button
         v-if="isSortable"
         :collection-info="collectionInfo"
+        :disabled="loading || !items.length"
         :items-type="viewType"
         @change="onChangeFilter"
       />


### PR DESCRIPTION
That way we avoid popping or bad inputs while content is not loaded.


https://user-images.githubusercontent.com/10274099/105354474-e6f49780-5bf0-11eb-9010-aa4546093b84.mp4

