### PR TITLE
refactor: rework details page and make responsive

### DIFF
--- a/assets/global.scss
+++ b/assets/global.scss
@@ -81,10 +81,16 @@ body {
 
 .link {
   cursor: pointer;
+  color: inherit !important;
+  text-decoration: none;
 }
 
 .link:hover {
   text-decoration: underline;
+}
+
+.flex-0 {
+  flex: 0;
 }
 
 /* Customized Vuetify components */

--- a/components/Item/Card/Card.vue
+++ b/components/Item/Card/Card.vue
@@ -1,7 +1,7 @@
 <template>
   <nuxt-link
     :event="link ? 'click' : null"
-    :to="itemLink"
+    :to="getItemDetailsLink(item)"
     :class="link ? null : 'link-disabled'"
     class="nuxt-link"
   >
@@ -99,7 +99,7 @@ import { mapActions } from 'vuex';
 import { BaseItemDto, ImageType } from '@jellyfin/client-axios';
 import imageHelper from '~/mixins/imageHelper';
 import itemHelper from '~/mixins/itemHelper';
-import { getShapeFromItemType, validLibraryTypes } from '~/utils/items';
+import { getShapeFromItemType } from '~/utils/items';
 
 export default Vue.extend({
   mixins: [imageHelper, itemHelper],
@@ -152,21 +152,6 @@ export default Vue.extend({
     };
   },
   computed: {
-    itemLink: {
-      get(): string {
-        if (this.item.Type && validLibraryTypes.includes(this.item.Type)) {
-          return `/library/${this.item.Id}`;
-        } else if (this.item.Type === 'Person') {
-          return `/person/${this.item.Id}`;
-        } else if (this.item.Type === 'MusicArtist') {
-          return `/artist/${this.item.Id}`;
-        } else if (this.item.Type === 'Genre') {
-          return `/genre/${this.item.Id}`;
-        } else {
-          return `/item/${this.item.Id}`;
-        }
-      }
-    },
     cardType: {
       get(): string {
         // Otherwise, figure out the shape based on the type of the item

--- a/components/Item/Card/Card.vue
+++ b/components/Item/Card/Card.vue
@@ -70,7 +70,7 @@
           />
         </div>
         <div
-          v-if="overlay"
+          v-if="overlay && !$browser.isMobile()"
           class="card-overlay d-flex justify-center align-center"
         >
           <play-button fab :item="item" />

--- a/components/Item/PersonList.vue
+++ b/components/Item/PersonList.vue
@@ -5,7 +5,7 @@
         v-for="(item, index) in items"
         :key="`${item.Id}-${index}`"
         nuxt
-        :to="getItemDetailsLink(item)"
+        :to="getItemDetailsLink(item, 'Person')"
       >
         <v-list-item-avatar>
           <v-img

--- a/components/Item/PersonList.vue
+++ b/components/Item/PersonList.vue
@@ -5,7 +5,7 @@
         v-for="(item, index) in items"
         :key="`${item.Id}-${index}`"
         nuxt
-        :to="`/person/${item.Id}`"
+        :to="getItemDetailsLink(item)"
       >
         <v-list-item-avatar>
           <v-img
@@ -39,9 +39,10 @@
 import Vue from 'vue';
 import { BaseItemPerson, ImageType } from '@jellyfin/client-axios';
 import imageHelper from '~/mixins/imageHelper';
+import itemHelper from '~/mixins/itemHelper';
 
 export default Vue.extend({
-  mixins: [imageHelper],
+  mixins: [imageHelper, itemHelper],
   props: {
     items: {
       type: Array,

--- a/components/Item/RelatedItems.vue
+++ b/components/Item/RelatedItems.vue
@@ -22,7 +22,7 @@
             v-for="relatedItem in relatedItems"
             :key="relatedItem.Id"
             nuxt
-            :to="getItemLink(relatedItem)"
+            :to="getItemDetailsLink(relatedItem)"
           >
             <v-list-item-avatar>
               <v-img ref="avatarImg" :src="getImageUrl(relatedItem.Id)" />
@@ -54,9 +54,10 @@ import Vue from 'vue';
 import { mapActions } from 'vuex';
 import { BaseItemDto, ImageType } from '@jellyfin/client-axios';
 import imageHelper from '~/mixins/imageHelper';
+import itemHelper from '~/mixins/itemHelper';
 
 export default Vue.extend({
-  mixins: [imageHelper],
+  mixins: [imageHelper, itemHelper],
   props: {
     /**
      * item.Id To be used to get related items
@@ -121,16 +122,6 @@ export default Vue.extend({
     getImageUrl(itemId: string): string | undefined {
       const element = this.$refs.avatarImg as HTMLElement;
       return this.getImageUrlForElement(ImageType.Primary, { itemId, element });
-    },
-    getItemLink(item: BaseItemDto): string {
-      switch (item.Type) {
-        case 'MusicArtist':
-          return `/artist/${item.Id}`;
-        case 'Person':
-          return `/person/${item.Id}`;
-        default:
-          return `/item/${item.Id}`;
-      }
     }
   }
 });

--- a/components/Item/RelatedItems.vue
+++ b/components/Item/RelatedItems.vue
@@ -10,7 +10,7 @@
       </client-only>
     </div>
     <div v-else-if="vertical">
-      <h2 v-if="!loading && relatedItems.length > 0">
+      <h2 v-if="!loading && relatedItems.length > 0" class="text-h6 text-sm-h5">
         <slot>
           {{ $t('youMayAlsoLike') }}
         </slot>

--- a/components/Item/SeasonTabs.vue
+++ b/components/Item/SeasonTabs.vue
@@ -12,7 +12,7 @@
             v-for="episode in seasonEpisodes[season.Id]"
             :key="episode.Id"
             nuxt
-            :to="`/item/${episode.Id}`"
+            :to="getItemDetailsLink(episode)"
           >
             <v-list-item-avatar tile width="20em" height="12em">
               <blurhash-image
@@ -39,8 +39,10 @@ import { BaseItemDto } from '@jellyfin/client-axios';
 import Vue from 'vue';
 import { mapActions, mapGetters } from 'vuex';
 import { TvShowItem } from '~/store/tvShows';
+import itemHelper from '~/mixins/itemHelper';
 
 export default Vue.extend({
+  mixins: [itemHelper],
   props: {
     item: {
       type: Object,

--- a/components/Layout/AudioControls.vue
+++ b/components/Layout/AudioControls.vue
@@ -34,7 +34,7 @@
                 <nuxt-link
                   tag="span"
                   class="text-truncate link mt-2 height-fit-content"
-                  :to="`/item/${getCurrentItem.Id}`"
+                  :to="getItemDetailsLink(getCurrentItem)"
                 >
                   {{ getCurrentItem.Name }}
                 </nuxt-link>
@@ -43,14 +43,14 @@
                 <span
                   v-for="(artist, index) in getCurrentItem.ArtistItems"
                   :key="`artist-${artist.Id}`"
-                  :to="`/artist/${artist.Id}`"
+                  :to="getItemDetailsLink(artist)"
                   class="ma-0"
                 >
                   <p class="mb-0">
                     <nuxt-link
                       tag="span"
                       class="text--secondary text-caption text-truncate link"
-                      :to="`/artist/${artist.Id}`"
+                      :to="getItemDetailsLink(artist)"
                       >{{ artist.Name }}</nuxt-link
                     >
                     <!-- Handles whitespaces -->
@@ -218,9 +218,10 @@ import { mapActions, mapGetters } from 'vuex';
 import timeUtils from '~/mixins/timeUtils';
 import imageHelper from '~/mixins/imageHelper';
 import { PlaybackStatus } from '~/store/playbackManager';
+import itemHelper from '~/mixins/itemHelper';
 
 export default Vue.extend({
-  mixins: [timeUtils, imageHelper],
+  mixins: [timeUtils, imageHelper, itemHelper],
   computed: {
     ...mapGetters('playbackManager', [
       'getCurrentItem',

--- a/components/Layout/AudioControls.vue
+++ b/components/Layout/AudioControls.vue
@@ -43,14 +43,14 @@
                 <span
                   v-for="(artist, index) in getCurrentItem.ArtistItems"
                   :key="`artist-${artist.Id}`"
-                  :to="getItemDetailsLink(artist)"
+                  :to="getItemDetailsLink(artist, 'MusicArtist')"
                   class="ma-0"
                 >
                   <p class="mb-0">
                     <nuxt-link
                       tag="span"
                       class="text--secondary text-caption text-truncate link"
-                      :to="getItemDetailsLink(artist)"
+                      :to="getItemDetailsLink(artist, 'MusicArtist')"
                       >{{ artist.Name }}</nuxt-link
                     >
                     <!-- Handles whitespaces -->

--- a/components/Layout/HomeHeader/HomeHeaderItems.vue
+++ b/components/Layout/HomeHeader/HomeHeaderItems.vue
@@ -70,7 +70,7 @@
                   rounded
                   nuxt
                   data-swiper-parallax="-100"
-                  :to="`item/${item.Id}`"
+                  :to="getItemDetailsLink(item)"
                 >
                   {{ $t('viewDetails') }}
                 </v-btn>

--- a/components/Layout/ItemCols.vue
+++ b/components/Layout/ItemCols.vue
@@ -1,0 +1,12 @@
+<template>
+  <v-container class="px-6">
+    <v-row>
+      <v-col cols="12" sm="8" md="9">
+        <slot name="left" />
+      </v-col>
+      <v-col cols="12" sm="4" md="3">
+        <slot name="right" />
+      </v-col>
+    </v-row>
+  </v-container>
+</template>

--- a/components/Layout/SwiperSection.vue
+++ b/components/Layout/SwiperSection.vue
@@ -4,7 +4,7 @@
     <v-col v-show="items && items.length > 0" class="swiper-section">
       <div class="d-flex">
         <h1
-          class="text-h5 font-weight-light header mt-1 pl-3 pb-2"
+          class="text-h6 text-sm-h5 font-weight-light header mt-1 pl-3 pb-2"
           :class="{ 'header-white-mode': !$vuetify.theme.dark }"
         >
           <span class="pl-3">{{ title }}</span>

--- a/components/Players/TrackList.vue
+++ b/components/Players/TrackList.vue
@@ -54,7 +54,7 @@
                     :key="artist.Id"
                     tag="span"
                     class="link text--secondary"
-                    :to="getItemDetailsLink(artist)"
+                    :to="getItemDetailsLink(artist, 'MusicArtist')"
                   >
                     {{ artist.Name }}
                   </nuxt-link>

--- a/components/Players/TrackList.vue
+++ b/components/Players/TrackList.vue
@@ -2,7 +2,7 @@
   <v-simple-table dense class="track-table no-select">
     <thead>
       <tr>
-        <th style="width: 6em" class="pr-0 text-center" scope="col">#</th>
+        <th style="width: 4em" class="pr-0 text-center" scope="col">#</th>
         <th style="width: 3em" class="pr-0 pl-0" scope="col" />
         <th scope="col">{{ $t('item.tracklist.title') }}</th>
         <th style="width: 6.5em" class="text-center" scope="col">
@@ -31,9 +31,9 @@
             :class="{ 'primary--text': isPlaying(track) }"
             @dblclick="playTracks(track)"
           >
-            <td style="width: 6em" class="pr-0 text-center">
+            <td style="width: 4em" class="pr-0 text-center">
               <span v-if="hover">
-                <v-btn icon @click="playTracks(track)">
+                <v-btn small icon @click="playTracks(track)">
                   <v-icon>mdi-play-circle-outline</v-icon>
                 </v-btn>
               </span>
@@ -59,6 +59,7 @@
                     {{ artist.Name }}
                   </nuxt-link>
                 </div>
+                <v-spacer />
                 <item-menu v-show="hover" :item="item" />
               </div>
             </td>

--- a/components/Players/TrackList.vue
+++ b/components/Players/TrackList.vue
@@ -54,7 +54,7 @@
                     :key="artist.Id"
                     tag="span"
                     class="link text--secondary"
-                    :to="`/artist/${artist.Id}`"
+                    :to="getItemDetailsLink(artist)"
                   >
                     {{ artist.Name }}
                   </nuxt-link>
@@ -77,9 +77,10 @@ import { mapActions, mapGetters } from 'vuex';
 import { Dictionary, groupBy } from 'lodash';
 import { BaseItemDto, BaseItemDtoQueryResult } from '@jellyfin/client-axios';
 import timeUtils from '~/mixins/timeUtils';
+import itemHelper from '~/mixins/itemHelper';
 
 export default Vue.extend({
-  mixins: [timeUtils],
+  mixins: [timeUtils, itemHelper],
   props: {
     item: {
       type: Object as () => BaseItemDto,

--- a/components/Players/TrackList.vue
+++ b/components/Players/TrackList.vue
@@ -148,12 +148,6 @@ export default Vue.extend({
 </script>
 
 <style lang="scss" scoped>
-.link {
-  cursor: pointer;
-}
-.link:hover {
-  text-decoration: underline;
-}
 .v-data-table.track-table {
   background-color: transparent;
 }

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -1,5 +1,6 @@
 {
   "3DFormat": "3D format",
+  "about": "About",
   "actor": "Actor",
   "actors": "Actors",
   "addNewPerson": "Add a new person",

--- a/mixins/itemHelper.ts
+++ b/mixins/itemHelper.ts
@@ -1,9 +1,9 @@
-import { BaseItemDto } from '@jellyfin/client-axios';
 /**
  * Item and playback helpers
  *
  * @mixin
  */
+import { BaseItemDto } from '@jellyfin/client-axios';
 import Vue from 'vue';
 
 declare module '@nuxt/types' {

--- a/mixins/itemHelper.ts
+++ b/mixins/itemHelper.ts
@@ -5,16 +5,19 @@
  */
 import { BaseItemDto } from '@jellyfin/client-axios';
 import Vue from 'vue';
+import { validLibraryTypes } from '~/utils/items';
 
 declare module '@nuxt/types' {
   interface Context {
     canPlay: (item: BaseItemDto) => boolean;
     canResume: (item: BaseItemDto) => boolean;
+    getItemDetailsLink: (item: BaseItemDto) => string;
   }
 
   interface NuxtAppOptions {
     canPlay: (item: BaseItemDto) => boolean;
     canResume: (item: BaseItemDto) => boolean;
+    getItemDetailsLink: (item: BaseItemDto) => string;
   }
 }
 
@@ -22,6 +25,7 @@ declare module 'vue/types/vue' {
   interface Vue {
     canPlay: (item: BaseItemDto) => boolean;
     canResume: (item: BaseItemDto) => boolean;
+    getItemDetailsLink: (item: BaseItemDto) => string;
   }
 }
 
@@ -63,6 +67,53 @@ const itemHelper = Vue.extend({
       } else {
         return false;
       }
+    },
+    /**
+     * Generate a link to the item's details page route
+     *
+     * @param {BaseItemDto} item - The item used to generate the route
+     * @returns {string} A valid route to the item's details page
+     */
+    getItemDetailsLink(item: BaseItemDto): string {
+      let routeName: string;
+      let routeParams: Record<never, never>;
+
+      if (item.Type && validLibraryTypes.includes(item.Type)) {
+        routeName = 'library-viewId';
+        routeParams = { viewId: item.Id };
+      } else {
+        switch (item.Type) {
+          case 'Series':
+            routeName = 'series-itemId';
+            routeParams = { itemId: item.Id };
+            break;
+          case 'Person':
+            routeName = 'person-itemId';
+            routeParams = { itemId: item.Id };
+            break;
+          case 'MusicArtist':
+            routeName = 'artist-itemId';
+            routeParams = { itemId: item.Id };
+            break;
+          case 'MusicAlbum':
+            routeName = 'musicalbum-itemId';
+            routeParams = { itemId: item.Id };
+            break;
+          case 'Genre':
+            routeName = 'genre-itemId';
+            routeParams = { itemId: item.Id };
+            break;
+          default:
+            routeName = 'item-itemId';
+            routeParams = { itemId: item.Id };
+            break;
+        }
+      }
+
+      return this.$router.resolve({
+        name: routeName,
+        params: routeParams
+      }).href;
     }
   }
 });

--- a/mixins/itemHelper.ts
+++ b/mixins/itemHelper.ts
@@ -11,13 +11,13 @@ declare module '@nuxt/types' {
   interface Context {
     canPlay: (item: BaseItemDto) => boolean;
     canResume: (item: BaseItemDto) => boolean;
-    getItemDetailsLink: (item: BaseItemDto) => string;
+    getItemDetailsLink: (item: BaseItemDto, overrideType?: string) => string;
   }
 
   interface NuxtAppOptions {
     canPlay: (item: BaseItemDto) => boolean;
     canResume: (item: BaseItemDto) => boolean;
-    getItemDetailsLink: (item: BaseItemDto) => string;
+    getItemDetailsLink: (item: BaseItemDto, overrideType?: string) => string;
   }
 }
 
@@ -25,7 +25,7 @@ declare module 'vue/types/vue' {
   interface Vue {
     canPlay: (item: BaseItemDto) => boolean;
     canResume: (item: BaseItemDto) => boolean;
-    getItemDetailsLink: (item: BaseItemDto) => string;
+    getItemDetailsLink: (item: BaseItemDto, overrideType?: string) => string;
   }
 }
 
@@ -72,9 +72,10 @@ const itemHelper = Vue.extend({
      * Generate a link to the item's details page route
      *
      * @param {BaseItemDto} item - The item used to generate the route
+     * @param {string} overrideType - Force the type to use
      * @returns {string} A valid route to the item's details page
      */
-    getItemDetailsLink(item: BaseItemDto): string {
+    getItemDetailsLink(item: BaseItemDto, overrideType?: string): string {
       let routeName: string;
       let routeParams: Record<never, never>;
 
@@ -82,7 +83,8 @@ const itemHelper = Vue.extend({
         routeName = 'library-viewId';
         routeParams = { viewId: item.Id };
       } else {
-        switch (item.Type) {
+        const type = overrideType || item.Type;
+        switch (type) {
           case 'Series':
             routeName = 'series-itemId';
             routeParams = { itemId: item.Id };

--- a/pages/artist/_itemId/index.vue
+++ b/pages/artist/_itemId/index.vue
@@ -1,106 +1,115 @@
 <template>
-  <v-container>
-    <v-row>
-      <v-col cols="9">
-        <v-row>
-          <v-col cols="9" class="d-flex flex-row">
-            <v-img
-              v-if="item.ImageTags && item.ImageTags.Primary"
-              class="person-image elevation-2 ml-2"
-              cover
-              aspect-ratio="1"
-              :src="getImageUrl(item.Id, 'Primary')"
-            />
-            <div class="ml-4 d-flex flex-column">
-              <div
-                class="text-subtitle-1 text--secondary font-weight-medium text-capitalize"
-              >
-                {{ $t('artist') }}
-              </div>
-              <h1 class="text-h2 font-weight-light">{{ item.Name }}</h1>
+  <item-cols>
+    <template #left>
+      <v-row justify="center" justify-sm="start">
+        <v-col cols="6" sm="3" class="d-flex flex-row">
+          <v-img
+            v-if="item.ImageTags && item.ImageTags.Primary"
+            class="person-image elevation-2 ml-2"
+            cover
+            aspect-ratio="1"
+            :src="getImageUrl(item.Id, 'Primary')"
+          />
+        </v-col>
+        <v-col cols="12" sm="7">
+          <div class="ml-sm-4 d-flex flex-column">
+            <div
+              class="text-subtitle-1 text--secondary font-weight-medium text-capitalize"
+            >
+              {{ $t('artist') }}
             </div>
-          </v-col>
-        </v-row>
-        <v-row>
-          <v-col>
-            <v-tabs v-model="activeTab" background-color="transparent">
-              <v-tab v-for="(tab, index) in tabs" :key="index">{{ tab }}</v-tab>
-            </v-tabs>
-            <v-tabs-items v-model="activeTab" class="transparent">
-              <v-tab-item :key="0">
-                <v-row>
-                  <v-col cols="12" class="mx-3">
-                    <h2 class="text-h6">
+            <h1 class="text-h4 text-md-h2 font-weight-light">
+              {{ item.Name }}
+            </h1>
+          </div>
+        </v-col>
+      </v-row>
+      <v-row>
+        <v-col>
+          <v-tabs v-model="activeTab" background-color="transparent">
+            <v-tab :key="0">{{ $t('overview') }}</v-tab>
+            <v-tab :key="1">{{ $t('about') }}</v-tab>
+          </v-tabs>
+          <v-tabs-items v-model="activeTab" class="transparent">
+            <v-tab-item :key="0">
+              <v-row no-gutters>
+                <v-col cols="12" class="ma-3">
+                  <v-row>
+                    <h2 class="text-h6 my-3">
                       <span>{{ $t('albums') }}</span>
                     </h2>
-                    <v-row
-                      v-for="appearance in appearances"
-                      :key="appearance.Id"
-                    >
-                      <v-col cols="12">
-                        <div class="d-flex flex-column">
-                          <v-row>
-                            <v-col cols="1">
-                              <card :item="appearance" no-text no-margin />
-                            </v-col>
-                            <v-col>
-                              <div
-                                class="text-subtitle-1 text--secondary font-weight-medium text-capitalize"
-                              >
-                                {{ appearance.ProductionYear }}
-                              </div>
-                              <nuxt-link
-                                class="link"
-                                tag="h2"
-                                :to="`/item/${appearance.Id}/`"
-                              >
-                                {{ appearance.Name }}
-                              </nuxt-link>
-                            </v-col>
-                          </v-row>
-                          <v-row>
-                            <v-col>
-                              <track-list
-                                v-if="appearance.Type === 'MusicAlbum'"
-                                :item="appearance"
-                              />
-                            </v-col>
-                          </v-row>
-                        </div>
-                      </v-col>
-                    </v-row>
-                  </v-col>
-                </v-row>
-              </v-tab-item>
-              <v-tab-item :key="1">
-                <v-container>
-                  <v-row>
-                    <v-col>
-                      <v-img cover :src="getImageUrl(item.Id, 'Backdrop')" />
-                      <div v-if="item.Overview">
-                        <h2 class="text-h6 mt-2">
-                          <span>{{ $t('biography') }}</span>
-                        </h2>
-                        <v-col cols="9" class="pl-0 pr-0">
-                          <!-- eslint-disable-next-line vue/no-v-html -->
-                          <p class="item-overview" v-html="overview" />
-                        </v-col>
+                  </v-row>
+                  <v-row v-for="appearance in appearances" :key="appearance.Id">
+                    <v-col cols="12">
+                      <div class="d-flex flex-column">
+                        <v-row>
+                          <div
+                            style="width: 125px"
+                            class="ma-2 d-none d-md-block"
+                          >
+                            <card :item="appearance" no-text no-margin />
+                          </div>
+                          <div class="py-2">
+                            <div
+                              class="text-subtitle-1 text--secondary font-weight-medium"
+                            >
+                              {{ appearance.ProductionYear }}
+                            </div>
+                            <nuxt-link
+                              class="link font-weight-bold text-h6 text-md-h4"
+                              tag="h2"
+                              :to="`/item/${appearance.Id}/`"
+                            >
+                              {{ appearance.Name }}
+                            </nuxt-link>
+                          </div>
+                        </v-row>
+                        <v-row class="my-2">
+                          <v-col>
+                            <track-list
+                              v-if="appearance.Type === 'MusicAlbum'"
+                              :item="appearance"
+                            />
+                          </v-col>
+                        </v-row>
                       </div>
                     </v-col>
                   </v-row>
-                </v-container>
-              </v-tab-item>
-            </v-tabs-items>
-          </v-col>
-        </v-row>
-      </v-col>
-      <v-col cols="3">
-        <related-items :item="item" vertical>
-          {{ $t('moreLikeArtist', { artist: item.Name }) }}
-        </related-items>
-      </v-col>
-    </v-row>
-  </v-container>
+                </v-col>
+              </v-row>
+            </v-tab-item>
+            <v-tab-item :key="1">
+              <v-container>
+                <v-row>
+                  <v-col>
+                    <v-img
+                      cover
+                      aspect-ratio="1.7778"
+                      :src="getImageUrl(item.Id, 'Backdrop')"
+                    />
+                    <div v-if="item.Overview">
+                      <h2 class="text-h6 mt-2">
+                        <span>{{ $t('biography') }}</span>
+                      </h2>
+                      <v-col cols="12" sm="9" class="pl-0 pr-0">
+                        <!-- eslint-disable-next-line vue/no-v-html -->
+                        <p class="item-overview" v-html="overview" />
+                      </v-col>
+                    </div>
+                  </v-col>
+                </v-row>
+              </v-container>
+            </v-tab-item>
+          </v-tabs-items>
+        </v-col>
+      </v-row>
+    </template>
+    <template #right>
+      <related-items :item="item" vertical>
+        {{ $t('moreLikeArtist', { artist: item.Name }) }}
+      </related-items>
+    </template>
+  </item-cols>
 </template>
 
 <script lang="ts">
@@ -137,7 +146,6 @@ export default Vue.extend({
   data() {
     return {
       activeTab: 0,
-      tabs: ['Overview', 'About'],
       item: {} as BaseItemDto,
       appearances: [] as BaseItemDto[]
     };
@@ -156,11 +164,19 @@ export default Vue.extend({
       }
     }
   },
-  beforeMount() {
-    this.setPageTitle({ title: this.item.Name });
+  watch: {
+    item: {
+      handler(val: BaseItemDto): void {
+        this.setPageTitle({ title: val.Name });
+        const hash = this.getBlurhash(val, ImageType.Backdrop);
+        this.setBackdrop({ hash });
+      },
+      immediate: true,
+      deep: true
+    }
+  },
+  created() {
     this.setAppBarOpacity({ opaqueAppBar: false });
-    const hash = this.getBlurhash(this.item, ImageType.Backdrop);
-    this.setBackdrop({ hash });
   },
   destroyed() {
     this.setAppBarOpacity({ opaqueAppBar: true });
@@ -182,7 +198,6 @@ export default Vue.extend({
 
 <style lang="scss" scoped>
 .person-image {
-  max-width: 8em;
   border-radius: 50%;
 }
 .header span {

--- a/pages/artist/_itemId/index.vue
+++ b/pages/artist/_itemId/index.vue
@@ -214,10 +214,4 @@ export default Vue.extend({
   left: 0;
   width: 1.25em;
 }
-.link {
-  cursor: pointer;
-}
-.link:hover {
-  text-decoration: underline;
-}
 </style>

--- a/pages/artist/_itemId/index.vue
+++ b/pages/artist/_itemId/index.vue
@@ -58,7 +58,7 @@
                             <nuxt-link
                               class="link font-weight-bold text-h6 text-md-h4"
                               tag="h2"
-                              :to="`/item/${appearance.Id}/`"
+                              :to="getItemDetailsLink(appearance)"
                             >
                               {{ appearance.Name }}
                             </nuxt-link>
@@ -119,9 +119,10 @@ import { BaseItemDto, ImageType } from '@jellyfin/client-axios';
 import htmlHelper from '~/mixins/htmlHelper';
 import imageHelper from '~/mixins/imageHelper';
 import timeUtils from '~/mixins/timeUtils';
+import itemHelper from '~/mixins/itemHelper';
 
 export default Vue.extend({
-  mixins: [htmlHelper, imageHelper, timeUtils],
+  mixins: [htmlHelper, imageHelper, timeUtils, itemHelper],
   async asyncData({ params, $api, $auth }) {
     const item = (
       await $api.userLibrary.getItem({

--- a/pages/item/_itemId/index.vue
+++ b/pages/item/_itemId/index.vue
@@ -94,7 +94,7 @@
                     v-for="director in directors"
                     :key="director.Id"
                   >
-                    <v-chip small link nuxt :to="`/person/${director.Id}`">
+                    <v-chip small link nuxt :to="getItemDetailsLink(director)">
                       {{ director.Name }}
                     </v-chip>
                   </v-slide-item>
@@ -119,7 +119,7 @@
               >
                 <v-slide-group>
                   <v-slide-item v-for="writer in writers" :key="writer.Id">
-                    <v-chip small link nuxt :to="`/person/${writer.Id}`">
+                    <v-chip small link nuxt :to="getItemDetailsLink(writer)">
                       {{ writer.Name }}
                     </v-chip>
                   </v-slide-item>

--- a/pages/item/_itemId/index.vue
+++ b/pages/item/_itemId/index.vue
@@ -94,7 +94,12 @@
                     v-for="director in directors"
                     :key="director.Id"
                   >
-                    <v-chip small link nuxt :to="getItemDetailsLink(director)">
+                    <v-chip
+                      small
+                      link
+                      nuxt
+                      :to="getItemDetailsLink(director, 'Person')"
+                    >
                       {{ director.Name }}
                     </v-chip>
                   </v-slide-item>
@@ -119,7 +124,12 @@
               >
                 <v-slide-group>
                   <v-slide-item v-for="writer in writers" :key="writer.Id">
-                    <v-chip small link nuxt :to="getItemDetailsLink(writer)">
+                    <v-chip
+                      small
+                      link
+                      nuxt
+                      :to="getItemDetailsLink(writer, 'Person')"
+                    >
                       {{ writer.Name }}
                     </v-chip>
                   </v-slide-item>

--- a/pages/item/_itemId/index.vue
+++ b/pages/item/_itemId/index.vue
@@ -427,15 +427,3 @@ export default Vue.extend({
   }
 });
 </script>
-
-<style lang="scss" scoped>
-.link {
-  cursor: pointer;
-}
-.link:hover {
-  text-decoration: underline;
-}
-.flex-0 {
-  flex: 0;
-}
-</style>

--- a/pages/musicalbum/_itemId/index.vue
+++ b/pages/musicalbum/_itemId/index.vue
@@ -1,0 +1,193 @@
+<template>
+  <item-cols>
+    <template #left>
+      <v-row justify="center" justify-md="start">
+        <v-col cols="7" md="3">
+          <card :item="item" no-text no-margin />
+        </v-col>
+        <v-col cols="12" md="9">
+          <h1
+            class="text-h4 font-weight-light"
+            :class="{ 'text-center': !$vuetify.breakpoint.mdAndUp }"
+          >
+            {{ item.Name }}
+          </h1>
+          <h2
+            v-if="item.AlbumArtist"
+            class="text-subtitle-1 text-truncate mt-2"
+            :class="{ 'text-center': !$vuetify.breakpoint.mdAndUp }"
+          >
+            {{ $t('byArtist') }}
+            <nuxt-link
+              tag="span"
+              class="link"
+              :to="`/artist/${item.AlbumArtists[0].Id}`"
+            >
+              {{ item.AlbumArtist }}
+            </nuxt-link>
+          </h2>
+          <div
+            class="text-caption text-h4 font-weight-medium mt-2"
+            :class="{ 'text-center': !$vuetify.breakpoint.mdAndUp }"
+          >
+            <media-info :item="item" year runtime rating ends-at />
+          </div>
+          <v-row
+            class="my-4 align-center"
+            :class="{
+              'justify-center': !$vuetify.breakpoint.mdAndUp,
+              'ml-1': $vuetify.breakpoint.mdAndUp
+            }"
+          >
+            <v-btn
+              v-if="canPlay(item)"
+              class="play-button mr-2"
+              color="primary"
+              min-width="8em"
+              depressed
+              rounded
+              @click="play({ items: [item] })"
+            >
+              {{ $t('play') }}
+            </v-btn>
+            <item-menu :item="item" outlined :absolute="false" />
+          </v-row>
+          <v-col cols="12" md="10">
+            <v-row
+              v-if="item && item.GenreItems && item.GenreItems.length > 0"
+              align="center"
+            >
+              <v-col
+                :cols="twoColsInfoColumn.lCols"
+                :sm="twoColsInfoColumn.lSm"
+                :class="twoColsInfoColumn.lClass"
+              >
+                <label class="text--secondary">{{ $t('genres') }}</label>
+              </v-col>
+              <v-col
+                class="px-0"
+                :cols="twoColsInfoColumn.rCols"
+                :sm="twoColsInfoColumn.rSm"
+              >
+                <v-slide-group>
+                  <v-slide-item
+                    v-for="(genre, index) in item.GenreItems"
+                    :key="`genre-${genre.Id}`"
+                  >
+                    <v-chip
+                      small
+                      link
+                      :class="{ 'ml-2': index > 0 }"
+                      nuxt
+                      :to="`/genre/${genre.Id}?type=${item.Type}`"
+                    >
+                      {{ genre.Name }}
+                    </v-chip>
+                  </v-slide-item>
+                </v-slide-group>
+              </v-col>
+            </v-row>
+          </v-col>
+        </v-col>
+      </v-row>
+      <v-row>
+        <v-col cols="12">
+          <track-list v-if="item.Type === 'MusicAlbum'" :item="item" />
+        </v-col>
+      </v-row>
+    </template>
+    <template #right>
+      <related-items :item="item" vertical />
+    </template>
+  </item-cols>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import { mapActions } from 'vuex';
+import { BaseItemDto, ImageType } from '@jellyfin/client-axios';
+import imageHelper from '~/mixins/imageHelper';
+import formsHelper from '~/mixins/formsHelper';
+import itemHelper from '~/mixins/itemHelper';
+
+interface TwoColsInfoColumn {
+  lCols: number;
+  lSm: number;
+  rCols: number;
+  rSm: number;
+  lClass: { [key: string]: boolean };
+}
+
+export default Vue.extend({
+  mixins: [imageHelper, formsHelper, itemHelper],
+  async asyncData({ params, $api, $auth }) {
+    const item = (
+      await $api.userLibrary.getItem({
+        userId: $auth.user?.Id,
+        itemId: params.itemId
+      })
+    ).data;
+
+    return {
+      item
+    };
+  },
+  data() {
+    return {
+      item: {} as BaseItemDto
+    };
+  },
+  head() {
+    return {
+      title: this.$store.state.page.title
+    };
+  },
+  computed: {
+    twoColsInfoColumn: {
+      get(): TwoColsInfoColumn {
+        return {
+          lCols: 12,
+          lSm: 2,
+          lClass: {
+            'mt-3': !this.$vuetify.breakpoint.smAndUp,
+            'py-0': !this.$vuetify.breakpoint.smAndUp,
+            'px-0': true,
+            'text-truncate': true
+          },
+          rCols: 12,
+          rSm: 10
+        };
+      }
+    }
+  },
+  watch: {
+    item: {
+      handler(val: BaseItemDto): void {
+        this.setPageTitle({ title: val.Name });
+        const hash = this.getBlurhash(val, ImageType.Backdrop);
+        this.setBackdrop({ hash });
+      },
+      immediate: true,
+      deep: true
+    }
+  },
+  created() {
+    this.setAppBarOpacity({ opaqueAppBar: false });
+  },
+  destroyed() {
+    this.setAppBarOpacity({ opaqueAppBar: true });
+    this.clearBackdrop();
+  },
+  methods: {
+    ...mapActions('playbackManager', ['play']),
+    ...mapActions('page', ['setPageTitle', 'setAppBarOpacity']),
+    ...mapActions('backdrop', ['setBackdrop', 'clearBackdrop'])
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.flex-0 {
+  flex: 0;
+}
+</style>

--- a/pages/musicalbum/_itemId/index.vue
+++ b/pages/musicalbum/_itemId/index.vue
@@ -19,7 +19,6 @@
           >
             {{ $t('byArtist') }}
             <nuxt-link
-              tag="span"
               class="link"
               :to="getItemDetailsLink(item.AlbumArtists[0])"
             >
@@ -185,9 +184,3 @@ export default Vue.extend({
   }
 });
 </script>
-
-<style lang="scss" scoped>
-.flex-0 {
-  flex: 0;
-}
-</style>

--- a/pages/musicalbum/_itemId/index.vue
+++ b/pages/musicalbum/_itemId/index.vue
@@ -20,7 +20,7 @@
             {{ $t('byArtist') }}
             <nuxt-link
               class="link"
-              :to="getItemDetailsLink(item.AlbumArtists[0])"
+              :to="getItemDetailsLink(item.AlbumArtists[0], 'MusicArtist')"
             >
               {{ item.AlbumArtist }}
             </nuxt-link>

--- a/pages/musicalbum/_itemId/index.vue
+++ b/pages/musicalbum/_itemId/index.vue
@@ -21,7 +21,7 @@
             <nuxt-link
               tag="span"
               class="link"
-              :to="`/artist/${item.AlbumArtists[0].Id}`"
+              :to="getItemDetailsLink(item.AlbumArtist[0])"
             >
               {{ item.AlbumArtist }}
             </nuxt-link>

--- a/pages/musicalbum/_itemId/index.vue
+++ b/pages/musicalbum/_itemId/index.vue
@@ -21,7 +21,7 @@
             <nuxt-link
               tag="span"
               class="link"
-              :to="getItemDetailsLink(item.AlbumArtist[0])"
+              :to="getItemDetailsLink(item.AlbumArtists[0])"
             >
               {{ item.AlbumArtist }}
             </nuxt-link>

--- a/pages/person/_itemId/index.vue
+++ b/pages/person/_itemId/index.vue
@@ -150,14 +150,26 @@ export default Vue.extend({
       }
     }
   },
-  beforeMount() {
-    const hash = this.getBlurhash(this.item, ImageType.Backdrop);
-    this.setBackdrop({ hash });
+  watch: {
+    item: {
+      handler(val: BaseItemDto): void {
+        this.setPageTitle({ title: val.Name });
+        const hash = this.getBlurhash(val, ImageType.Backdrop);
+        this.setBackdrop({ hash });
+      },
+      immediate: true,
+      deep: true
+    }
+  },
+  created() {
+    this.setAppBarOpacity({ opaqueAppBar: false });
   },
   destroyed() {
+    this.setAppBarOpacity({ opaqueAppBar: true });
     this.clearBackdrop();
   },
   methods: {
+    ...mapActions('page', ['setPageTitle', 'setAppBarOpacity']),
     ...mapActions('backdrop', ['setBackdrop', 'clearBackdrop']),
     getImageUrl(itemId: string | undefined): string | undefined {
       const element = this.$refs.personImg as HTMLElement;

--- a/pages/series/_itemId/index.vue
+++ b/pages/series/_itemId/index.vue
@@ -104,7 +104,7 @@
                     :key="director.Id"
                     cols="auto"
                   >
-                    <v-chip small link nuxt :to="`/person/${director.Id}`">
+                    <v-chip small link nuxt :to="getItemDetailsLink(director)">
                       {{ director.Name }}
                     </v-chip>
                   </v-col>
@@ -128,7 +128,7 @@
               >
                 <v-row dense>
                   <v-col v-for="writer in writers" :key="writer.Id" cols="auto">
-                    <v-chip small link nuxt :to="`/person/${writer.Id}`">
+                    <v-chip small link nuxt :to="getItemDetailsLink(writer)">
                       {{ writer.Name }}
                     </v-chip>
                   </v-col>

--- a/pages/series/_itemId/index.vue
+++ b/pages/series/_itemId/index.vue
@@ -104,7 +104,12 @@
                     :key="director.Id"
                     cols="auto"
                   >
-                    <v-chip small link nuxt :to="getItemDetailsLink(director)">
+                    <v-chip
+                      small
+                      link
+                      nuxt
+                      :to="getItemDetailsLink(director, 'Person')"
+                    >
                       {{ director.Name }}
                     </v-chip>
                   </v-col>
@@ -128,7 +133,12 @@
               >
                 <v-row dense>
                   <v-col v-for="writer in writers" :key="writer.Id" cols="auto">
-                    <v-chip small link nuxt :to="getItemDetailsLink(writer)">
+                    <v-chip
+                      small
+                      link
+                      nuxt
+                      :to="getItemDetailsLink(writer, 'Person')"
+                    >
                       {{ writer.Name }}
                     </v-chip>
                   </v-col>

--- a/pages/series/_itemId/index.vue
+++ b/pages/series/_itemId/index.vue
@@ -326,15 +326,3 @@ export default Vue.extend({
   }
 });
 </script>
-
-<style lang="scss" scoped>
-.link {
-  cursor: pointer;
-}
-.link:hover {
-  text-decoration: underline;
-}
-.flex-0 {
-  flex: 0;
-}
-</style>

--- a/pages/series/_itemId/index.vue
+++ b/pages/series/_itemId/index.vue
@@ -2,12 +2,12 @@
   <item-cols>
     <template #left>
       <v-row justify="center" justify-md="start">
-        <v-col cols="6" md="3">
-          <card :item="item" :overlay="false" :link="false" no-text no-margin />
+        <v-col cols="7" md="3">
+          <card :item="item" no-text no-margin />
         </v-col>
         <v-col cols="12" md="9">
           <h1
-            class="text-h5 text-sm-h4 font-weight-light"
+            class="text-h4 font-weight-light"
             :class="{ 'text-center': !$vuetify.breakpoint.mdAndUp }"
           >
             {{ item.Name }}
@@ -32,9 +32,19 @@
               'ml-1': $vuetify.breakpoint.mdAndUp
             }"
           >
-            <play-button class="mr-2" :item="item" />
+            <v-btn
+              v-if="canPlay(item)"
+              class="play-button mr-2"
+              color="primary"
+              min-width="8em"
+              :disabled="!isPlayable"
+              depressed
+              rounded
+              @click="play({ items: [item] })"
+            >
+              {{ $t('play') }}
+            </v-btn>
             <item-menu :item="item" outlined :absolute="false" />
-            <like-button :item="item" class="ml-2" />
           </v-row>
           <v-col cols="12" md="10">
             <v-row
@@ -85,20 +95,20 @@
                 <label class="text--secondary">{{ $t('directing') }}</label>
               </v-col>
               <v-col
-                class="px-0"
                 :cols="twoColsInfoColumn.rCols"
                 :sm="twoColsInfoColumn.rSm"
               >
-                <v-slide-group>
-                  <v-slide-item
+                <v-row dense>
+                  <v-col
                     v-for="director in directors"
                     :key="director.Id"
+                    cols="auto"
                   >
                     <v-chip small link nuxt :to="`/person/${director.Id}`">
                       {{ director.Name }}
                     </v-chip>
-                  </v-slide-item>
-                </v-slide-group>
+                  </v-col>
+                </v-row>
               </v-col>
             </v-row>
             <v-row
@@ -113,130 +123,18 @@
                 <label class="text--secondary">{{ $t('writing') }}</label>
               </v-col>
               <v-col
-                class="px-0"
                 :cols="twoColsInfoColumn.rCols"
                 :sm="twoColsInfoColumn.rSm"
               >
-                <v-slide-group>
-                  <v-slide-item v-for="writer in writers" :key="writer.Id">
+                <v-row dense>
+                  <v-col v-for="writer in writers" :key="writer.Id" cols="auto">
                     <v-chip small link nuxt :to="`/person/${writer.Id}`">
                       {{ writer.Name }}
                     </v-chip>
-                  </v-slide-item>
-                </v-slide-group>
+                  </v-col>
+                </v-row>
               </v-col>
             </v-row>
-            <div
-              v-if="item && item.MediaSources && item.MediaSources.length > 0"
-              class="mt-2"
-            >
-              <v-row v-if="item.MediaSources.length > 1" align="center">
-                <v-col
-                  :cols="twoColsInfoColumn.lCols"
-                  :sm="twoColsInfoColumn.lSm"
-                  :class="twoColsInfoColumn.lClass"
-                >
-                  <label class="text--secondary">{{ $t('version') }}</label>
-                </v-col>
-                <v-col
-                  class="px-0"
-                  :cols="twoColsInfoColumn.rCols"
-                  :sm="twoColsInfoColumn.rSm"
-                >
-                  <v-select
-                    v-model="currentSource"
-                    :items="getItemizedSelect(item.MediaSources)"
-                    outlined
-                    filled
-                    flat
-                    dense
-                    single-line
-                    hide-details
-                    class="text-truncate"
-                  >
-                    <template slot="selection" slot-scope="{ item: i }">
-                      {{ i.value.Name }}
-                    </template>
-                    <template slot="item" slot-scope="{ item: i }">
-                      {{ i.value.Name }}
-                    </template>
-                  </v-select>
-                </v-col>
-              </v-row>
-              <v-row align="center">
-                <v-col
-                  :cols="twoColsInfoColumn.lCols"
-                  :sm="twoColsInfoColumn.lSm"
-                  :class="twoColsInfoColumn.lClass"
-                >
-                  <label class="text--secondary">{{ $t('video') }}</label>
-                </v-col>
-                <v-col
-                  class="px-0"
-                  :cols="twoColsInfoColumn.rCols"
-                  :sm="twoColsInfoColumn.rSm"
-                >
-                  <track-selector
-                    :item="item"
-                    :media-source-index="currentSourceIndex"
-                    :type="'Video'"
-                    @input="currentVideoTrack = $event"
-                  />
-                </v-col>
-              </v-row>
-              <v-row align="center">
-                <v-col
-                  :cols="twoColsInfoColumn.lCols"
-                  :sm="twoColsInfoColumn.lSm"
-                  :class="twoColsInfoColumn.lClass"
-                >
-                  <label class="text--secondary">{{ $t('audio') }}</label>
-                </v-col>
-                <v-col
-                  class="px-0"
-                  :cols="twoColsInfoColumn.rCols"
-                  :sm="twoColsInfoColumn.rSm"
-                >
-                  <track-selector
-                    :item="item"
-                    :media-source-index="currentSourceIndex"
-                    :type="'Audio'"
-                    @input="currentAudioTrack = $event"
-                  />
-                </v-col>
-              </v-row>
-              <v-row align="center">
-                <v-col
-                  :cols="twoColsInfoColumn.lCols"
-                  :sm="twoColsInfoColumn.lSm"
-                  :class="twoColsInfoColumn.lClass"
-                >
-                  <label class="text--secondary">{{ $t('subtitles') }}</label>
-                </v-col>
-                <v-col
-                  class="px-0"
-                  :cols="twoColsInfoColumn.rCols"
-                  :sm="twoColsInfoColumn.rSm"
-                >
-                  <track-selector
-                    :item="item"
-                    :media-source-index="currentSourceIndex"
-                    :type="'Subtitle'"
-                    @input="currentSubtitleTrack = $event"
-                  />
-                </v-col>
-              </v-row>
-            </div>
-            <div
-              v-else-if="
-                item &&
-                item.MediaType === 'Video' &&
-                (!item.MediaSources || item.MediaSources.length === 0)
-              "
-              class="text-h5 my-4"
-            >
-              {{ $t('NoMediaSourcesAvailable') }}
-            </div>
           </v-col>
           <div>
             <p
@@ -251,7 +149,7 @@
       </v-row>
       <v-row>
         <v-col cols="12">
-          <related-items :id="$route.params.itemId" :item="item" />
+          <season-tabs v-if="item.Type === 'Series'" :item="item" />
         </v-col>
       </v-row>
     </template>
@@ -264,6 +162,7 @@
         <h2 class="text-h6 text-sm-h5">{{ $t('item.cast') }}</h2>
         <person-list :items="actors" />
       </div>
+      <related-items :item="item" vertical />
     </template>
   </item-cols>
 </template>


### PR DESCRIPTION
* Refactors the way we get URLs for details pages, by querying `vue-router` directly for a name and parameters. This means we're not using straight strings anymore, making future changes easier.
* Splits some of the details page to remove complexity in the templates. We currently have:
  * artist
  * item (generic one)
  * musicalbum
  * person
  * series
* Creates a two-column layout component for details pages, making it easier to create new ones
* Uses said component on all details pages, to make them responsive
* Makes some small adjustments to improve small device versions of pages 