### PR TITLE
fix: rotate 90 degrees progress circular

### DIFF
--- a/components/Item/Card.vue
+++ b/components/Item/Card.vue
@@ -16,6 +16,7 @@
           <v-progress-circular
             v-if="refreshProgress > 0"
             class="card-chip"
+            rotate="-90"
             :value="refreshProgress"
             color="white"
             size="24"


### PR DESCRIPTION
Maybe this is subjective, but I always recall seeing this kind of progress indicators starting from the bottom.

**Before**:

https://user-images.githubusercontent.com/10274099/105772891-2e698380-5f63-11eb-9b1a-be151f4d099e.mp4

**After**

https://user-images.githubusercontent.com/10274099/105772910-36c1be80-5f63-11eb-9c77-07876416db32.mp4
