### PR TITLE
fix: recommended extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -7,7 +7,7 @@
     "octref.vetur",
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode",
-    "antfu.i18n-ally"
+    "lokalise.i18n-ally"
   ],
   // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
   "unwantedRecommendations": [


### PR DESCRIPTION
That extension is deprecated and has been replaced by ``lokalise.i18n-ally``