### PR TITLE
fix(ssr): fix refresh in SSR mode not keeping the server list and current server

### DIFF
--- a/components/Item/RelatedItems.vue
+++ b/components/Item/RelatedItems.vue
@@ -1,7 +1,13 @@
 <template>
   <div>
     <div v-if="!vertical" class="related-items">
-      <swiper-section :title="title" :items="relatedItems" :loading="loading" />
+      <client-only>
+        <swiper-section
+          :title="title"
+          :items="relatedItems"
+          :loading="loading"
+        />
+      </client-only>
     </div>
     <div v-else-if="vertical">
       <h2 v-if="!loading && relatedItems.length > 0">

--- a/components/Layout/HomeSection.vue
+++ b/components/Layout/HomeSection.vue
@@ -1,10 +1,12 @@
 <template>
-  <swiper-section
-    :title="section.name"
-    :items="items"
-    :shape="section.shape"
-    :loading="$fetchState.pending"
-  />
+  <client-only>
+    <swiper-section
+      :title="section.name"
+      :items="items"
+      :shape="section.shape"
+      :loading="$fetchState.pending"
+    />
+  </client-only>
 </template>
 
 <script lang="ts">

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -74,7 +74,8 @@ const config: NuxtConfig = {
     // Development
     'plugins/axe.ts',
     // General
-    { src: 'plugins/appInitPlugin.ts', mode: 'client' },
+    'plugins/persistedState.ts',
+    'plugins/appInitPlugin.ts',
     'plugins/veeValidate.ts',
     'plugins/nativeWebsocketPlugin.ts',
     // Components
@@ -111,7 +112,7 @@ const config: NuxtConfig = {
     [
       'nuxt-vuex-localstorage',
       {
-        localStorage: ['user', 'deviceProfile', 'servers']
+        localStorage: ['user', 'deviceProfile']
       }
     ],
     // Doc: https://axios.nuxtjs.org/usage

--- a/package.json
+++ b/package.json
@@ -45,9 +45,11 @@
     "@types/uuid": "^8.3.0",
     "blurhash": "^1.1.3",
     "compare-versions": "^3.6.0",
+    "cookie": "^0.4.1",
     "date-fns": "^2.16.1",
     "dompurify": "^2.2.6",
     "entities": "^2.2.0",
+    "js-cookie": "^2.2.1",
     "langs": "^2.0.0",
     "lodash": "^4.17.20",
     "mux.js": "^5.9.1",
@@ -62,7 +64,8 @@
     "vue-awesome-swiper": "^4.1.1",
     "vue-native-websocket": "^2.0.14",
     "vue-virtual-scroller": "^1.0.10",
-    "vuedraggable": "^2.24.3"
+    "vuedraggable": "^2.24.3",
+    "vuex-persistedstate": "^4.0.0-beta.3"
   },
   "devDependencies": {
     "@commitlint/cli": "^11.0.0",
@@ -77,6 +80,8 @@
     "@nuxtjs/imagemin": "^0.2.0",
     "@nuxtjs/stylelint-module": "^4.0.0",
     "@nuxtjs/vuetify": "^1.11.3",
+    "@types/cookie": "^0.4.0",
+    "@types/js-cookie": "^2.2.6",
     "@types/nuxtjs__auth": "^4.8.7",
     "@types/qs": "^6.9.5",
     "@types/wicg-mediasession": "^1.1.0",

--- a/pages/person/_itemId/index.vue
+++ b/pages/person/_itemId/index.vue
@@ -53,13 +53,17 @@
         </v-row>
         <v-row v-if="movies.length > 0">
           <v-col>
-            <swiper-section :title="$t('movies')" :items="movies" />
+            <client-only>
+              <swiper-section :title="$t('movies')" :items="movies" />
+            </client-only>
           </v-col>
         </v-row>
 
         <v-row v-if="shows.length > 0">
           <v-col>
-            <swiper-section :title="$t('shows')" :items="shows" />
+            <client-only>
+              <swiper-section :title="$t('shows')" :items="shows" />
+            </client-only>
           </v-col>
         </v-row>
       </v-col>

--- a/plugins/persistedState.ts
+++ b/plugins/persistedState.ts
@@ -1,0 +1,34 @@
+import { Plugin } from '@nuxt/types';
+import createPersistedState from 'vuex-persistedstate';
+import * as Cookies from 'js-cookie';
+import cookie from 'cookie';
+
+const persistState: Plugin = ({ store, req, res, isDev }) => {
+  createPersistedState({
+    paths: ['servers'],
+    storage: {
+      getItem: (key: string): string | undefined => {
+        if (process.server) {
+          const parsedCookies = cookie.parse(req.headers.cookie || '');
+          return parsedCookies[key];
+        } else {
+          return Cookies.get(key);
+        }
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      setItem: (key: string, value: any): void => {
+        if (process.server) {
+          res.setHeader(
+            'Set-Cookie',
+            cookie.serialize(key, value, { maxAge: 365, secure: !isDev })
+          );
+        } else {
+          Cookies.set(key, value, { expires: 365, secure: !isDev });
+        }
+      },
+      removeItem: (key: string): void => Cookies.remove(key)
+    }
+  })(store);
+};
+
+export default persistState;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2082,6 +2082,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/cookie@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.4.0.tgz#14f854c0f93d326e39da6e3b6f34f7d37513d108"
+  integrity sha512-y7mImlc/rNkvCRmg8gC3/lj87S7pTUIJ6QGjwHR9WQJcFs+ZMTOaoPrkdFA/YdbuqVEmEbb5RdhVxMkAcgOnpg==
+
 "@types/dompurify@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@types/dompurify/-/dompurify-2.2.1.tgz#eebf3af8afe2f577a53acab9d98a3a4cb04bbbe7"
@@ -2197,6 +2202,11 @@
   dependencies:
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"
+
+"@types/js-cookie@^2.2.6":
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/@types/js-cookie/-/js-cookie-2.2.6.tgz#f1a1cb35aff47bc5cfb05cb0c441ca91e914c26f"
+  integrity sha512-+oY0FDTO2GYKEV0YPvSshGq9t7YozVkgvXLty7zogQNuCxBhT9/3INX9Q7H1aRZ4SUDRXAKlJuA4EA5nTt7SNw==
 
 "@types/json-schema@*", "@types/json-schema@^7.0.3", "@types/json-schema@^7.0.4", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.6":
   version "7.0.6"
@@ -4581,7 +4591,7 @@ cookie@^0.3.1:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
   integrity sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=
 
-cookie@^0.4.0:
+cookie@^0.4.0, cookie@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.1.tgz#afd713fe26ebd21ba95ceb61f9a8116e50a537d1"
   integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
@@ -12563,6 +12573,11 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
+shvl@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/shvl/-/shvl-2.0.2.tgz#eca7decb9bbd4e8dd93f06ea9ab94036319cd351"
+  integrity sha512-G3KkIXPza3dgkt6Bo8zIl5K/KvAAhbG6o9KfAjhPvrIIzzAhnfc2ztv1i+iPTbNNM43MaBUqIaZwqVjkSgY/rw==
+
 sigmund@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/sigmund/-/sigmund-1.0.1.tgz#3ff21f198cad2175f9f3b781853fd94d0d19b590"
@@ -14216,6 +14231,14 @@ vuetify@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/vuetify/-/vuetify-2.4.2.tgz#d37d160c1fc6b241fc166a32980b34590a017d6e"
   integrity sha512-8W1928Fv6GKwLiOThutYf2wtD5C9+vcCavlI8NT0YxNOVvluoL8xrep8mGGwDsCkay+4LzaAX92owKeNi3kpWg==
+
+vuex-persistedstate@^4.0.0-beta.3:
+  version "4.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/vuex-persistedstate/-/vuex-persistedstate-4.0.0-beta.3.tgz#89dd712de72d28e85cc95467d066002c1405f277"
+  integrity sha512-T4IRD27qoUWh+8qr6T6zVp15xO7x/nPgnU13OD0C2uUwA7U9PhGozrj6lvVmMYDyRgc36J0msMXn3GvwHjkIhA==
+  dependencies:
+    deepmerge "^4.2.2"
+    shvl "^2.0.2"
 
 vuex@^3.6.0:
   version "3.6.0"


### PR DESCRIPTION
This moves the persistence of the `server` Vuex module to use cookies (Via vuex-persistedstate).


https://user-images.githubusercontent.com/19396809/106182473-239b3280-619f-11eb-9f0b-04b21820c61d.mp4

As a result, some errors about the Swipers showed up, so I set these components to be client-only.