### PR TITLE
build(node): downgrade to node 12

### DIFF
--- a/.ci/azure-pipelines-build.yml
+++ b/.ci/azure-pipelines-build.yml
@@ -9,7 +9,7 @@ jobs:
       - task: NodeTool@0
         displayName: "Install Node"
         inputs:
-          versionSpec: "14.x"
+          versionSpec: "12.x"
 
       - task: Cache@2
         displayName: "Check Cache"
@@ -41,7 +41,7 @@ jobs:
       - task: NodeTool@0
         displayName: "Install Node"
         inputs:
-          versionSpec: "14.x"
+          versionSpec: "12.x"
 
       - task: Cache@2
         displayName: "Check Cache"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-alpine AS build
+FROM node:12-alpine AS build
 
 WORKDIR /app
 
@@ -15,7 +15,7 @@ COPY . .
 RUN yarn build --production --standalone
 
 # Build final image
-FROM node:14-alpine
+FROM node:12-alpine
 
 WORKDIR /app
 

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,5 +1,5 @@
 # Build final image
-FROM node:14-alpine
+FROM node:12-alpine
 
 WORKDIR /app
 

--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -1,4 +1,4 @@
-FROM node:14-alpine AS build
+FROM node:12-alpine AS build
 
 # Install build dependencies for node modules
 RUN apk add git python make g++


### PR DESCRIPTION
Node 14 occasionally crashes with 
```
➜ docker logs -f jellyfin-vue
yarn run v1.22.5
$ nuxt-start
ℹ Modern bundles are detected. Modern mode (server) is enabled now.
ℹ Listening on: http://172.18.0.4:80/

<--- Last few GCs --->

[28:0x55951a5f4e20]   187782 ms: Scavenge (reduce) 4088.1 (4103.6) -> 4087.7 (4104.1) MB, 14.0 / 0.0 ms  (average mu = 0.178, current mu = 0.061) allocation failure
[28:0x55951a5f4e20]   190374 ms: Mark-sweep (reduce) 4088.5 (4101.1) -> 4087.7 (4102.3) MB, 2577.2 / 0.4 ms  (average mu = 0.106, current mu = 0.024) allocation failure scavenge might not succeed


<--- JS stacktrace --->

FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
error Command failed with signal "SIGABRT".
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

```