### PR TITLE
fix(artist details page): fix no albums appearing in artist details page

### DIFF
--- a/pages/artist/_itemId/index.vue
+++ b/pages/artist/_itemId/index.vue
@@ -124,9 +124,11 @@ export default Vue.extend({
     const appearances = (
       await $api.items.getItems({
         userId: $auth.user?.Id,
-        parentId: params.itemId,
+        albumArtistIds: [params.itemId],
         sortBy: 'PremiereDate,ProductionYear,SortName',
-        sortOrder: 'Descending'
+        sortOrder: 'Descending',
+        recursive: true,
+        includeItemTypes: ['MusicAlbum']
       })
     ).data.Items;
 


### PR DESCRIPTION
Should fix #637

Jf-web params:
```
SortOrder: Descending
IncludeItemTypes: MusicAlbum
Recursive: true
Fields: AudioInfo,ParentId,PrimaryImageAspectRatio,BasicSyncInfo,AudioInfo,ParentId,PrimaryImageAspectRatio,BasicSyncInfo
Limit: 100
StartIndex: 0
CollapseBoxSetItems: false
AlbumArtistIds: --
SortBy: PremiereDate,ProductionYear,Sortname
```

jf-vue params (old):
```
userId: --
sortOrder: Descending
parentId: --
sortBy: PremiereDate,ProductionYear,SortName
```

jf-vue params (new):
```
userId: --
sortOrder: Descending
albumArtistIds: --
sortBy: PremiereDate,ProductionYear,SortName,
recursive: true,
includeItemTypes: MusicAlbum
```

