### PR TITLE
Fix FMP4-HLS playback on Edge and Safari

### DIFF
--- a/components/Players/PlayerManager.vue
+++ b/components/Players/PlayerManager.vue
@@ -359,7 +359,7 @@ export default Vue.extend({
         this.fullScreenOverlayTimer = window.setTimeout(() => {
           this.showFullScreenOverlay = false;
           this.fullScreenOverlayTimer = null;
-        }, 5000);
+        }, 3000);
       }
     },
     getContentClass(): string {

--- a/plugins/browserDetection.ts
+++ b/plugins/browserDetection.ts
@@ -74,7 +74,17 @@ class BrowserDetector {
    * @memberof BrowserDetector
    */
   isEdge(): boolean {
-    return this.userAgentContains('Edge/');
+    return this.userAgentContains('Edg/') || this.userAgentContains('Edge/');
+  }
+
+  /**
+   * Check if the current platform is Chromium based.
+   *
+   * @returns {boolean} Determines if browser is Chromium based
+   * @memberof BrowserDetector
+   */
+  isChromiumBased(): boolean {
+    return this.userAgentContains('Chrome');
   }
 
   /**

--- a/store/deviceProfile.ts
+++ b/store/deviceProfile.ts
@@ -45,7 +45,7 @@ function getDeviceName(): string {
   // See: https://github.com/tc39/proposal-pattern-matching
   if (browserDetector.isChrome()) {
     deviceName = 'Chrome';
-  } else if (browserDetector.isEdge() && !browserDetector.isChrome()) {
+  } else if (browserDetector.isEdge() && !browserDetector.isChromiumBased()) {
     deviceName = 'Edge (EdgeHTML)';
   } else if (browserDetector.isEdge()) {
     deviceName = 'Edge (Chromium)';

--- a/utils/playbackProfiles/directPlayProfile.ts
+++ b/utils/playbackProfiles/directPlayProfile.ts
@@ -1,5 +1,6 @@
 import { DirectPlayProfile, DlnaProfileType } from '@jellyfin/client-axios';
 import { getSupportedMP4VideoCodecs } from './helpers/mp4VideoFormats';
+import { getSupportedMP4AudioCodecs } from './helpers/mp4AudioFormats';
 import { hasMkvSupport } from './helpers/transcodingFormats';
 import { getSupportedWebMAudioCodecs } from './helpers/webmAudioFormats';
 import { getSupportedWebMVideoCodecs } from './helpers/webmVideoFormats';
@@ -19,7 +20,7 @@ export function getDirectPlayProfiles(
   const webmAudioCodecs = getSupportedWebMAudioCodecs(videoTestElement);
 
   const mp4VideoCodecs = getSupportedMP4VideoCodecs(videoTestElement);
-  const mp4AudioCodecs = getSupportedWebMAudioCodecs(videoTestElement);
+  const mp4AudioCodecs = getSupportedMP4AudioCodecs(videoTestElement);
 
   if (webmVideoCodecs.length) {
     DirectPlayProfiles.push({

--- a/utils/playbackProfiles/helpers/codecProfiles.ts
+++ b/utils/playbackProfiles/helpers/codecProfiles.ts
@@ -147,6 +147,14 @@ export function getCodecProfiles(
     maxH264Level = 51;
   }
 
+  if (
+    videoTestElement
+      .canPlayType('video/mp4; codecs="avc1.640834"')
+      .replace(/no/, '')
+  ) {
+    maxH264Level = 52;
+  }
+
   // Support H264 Level 52 (Tizen 5.0) - app only
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
@@ -164,7 +172,7 @@ export function getCodecProfiles(
     if (
       !browserDetector.isApple() ||
       !browserDetector.isWebOS() ||
-      !browserDetector.isEdge()
+      !(browserDetector.isEdge() && !browserDetector.isChromiumBased())
     ) {
       h264Profiles += '|high 10';
     }

--- a/utils/playbackProfiles/helpers/fmp4AudioFormats.ts
+++ b/utils/playbackProfiles/helpers/fmp4AudioFormats.ts
@@ -6,6 +6,7 @@ import {
   hasEac3Support,
   hasMp3AudioSupport
 } from './mp4AudioFormats';
+import { browserDetector } from '~/plugins/browserDetection';
 
 /**
  * @param {HTMLVideoElement} videoTestElement - A HTML video element for testing codecs
@@ -35,7 +36,9 @@ export function getSupportedFmp4AudioCodecs(
   }
 
   if (getSupportedAudioCodecs('flac')) {
-    codecs.push('flac');
+    if (!browserDetector.isEdge()) {
+      codecs.push('flac');
+    }
   }
 
   if (getSupportedAudioCodecs('alac')) {

--- a/utils/playbackProfiles/helpers/fmp4VideoFormats.ts
+++ b/utils/playbackProfiles/helpers/fmp4VideoFormats.ts
@@ -12,6 +12,7 @@ export function getSupportedFmp4VideoCodecs(
 
   if (
     (browserDetector.isApple() ||
+      browserDetector.isEdge() ||
       browserDetector.isTizen() ||
       browserDetector.isWebOS()) &&
     hasHevcSupport(videoTestElement)
@@ -22,6 +23,7 @@ export function getSupportedFmp4VideoCodecs(
   if (hasH264Support(videoTestElement)) {
     if (
       browserDetector.isApple() ||
+      browserDetector.isEdge() ||
       browserDetector.isTizen() ||
       browserDetector.isWebOS()
     ) {

--- a/utils/playbackProfiles/helpers/mp4VideoFormats.ts
+++ b/utils/playbackProfiles/helpers/mp4VideoFormats.ts
@@ -134,7 +134,9 @@ export function getSupportedMP4VideoCodecs(
 
   if (hasHevcSupport(videoTestElement)) {
     // safari is lying on HDR and 60fps videos, use fMP4 instead
-    codecs.push('hevc');
+    if (!browserDetector.isApple()) {
+      codecs.push('hevc');
+    }
   }
 
   if (browserDetector.isTv()) {

--- a/utils/playbackProfiles/helpers/transcodingFormats.ts
+++ b/utils/playbackProfiles/helpers/transcodingFormats.ts
@@ -22,6 +22,13 @@ export function canPlayNativeHls(videoTestElement: HTMLVideoElement): boolean {
 }
 
 /**
+ * @returns {boolean} Determines if the browser can play Hls with Media Source Extensions
+ */
+export function canPlayHlsWithMSE(): boolean {
+  return browserDetector.supportsMediaSource();
+}
+
+/**
  * @param {HTMLVideoElement} videoTestElement - A HTML video element for testing codecs
  * @returns {boolean} Determines if the browser can play Mkvs
  */


### PR DESCRIPTION
**Changes**
- Fix browser detection for Edge chromium
- Fix fmp4-hls playback on Edge and Safari
- Reduce OSD timeout from 5 seconds to 3 (https://github.com/jellyfin/jellyfin-web/pull/903)
