### PR TITLE
refactor(user-card): fix user-image and refactor user-card

### DIFF
--- a/assets/global.scss
+++ b/assets/global.scss
@@ -79,6 +79,10 @@ body {
 
 /* Custom utility classes */
 
+.pointer {
+  cursor: pointer;
+}
+
 .link {
   cursor: pointer;
   color: inherit !important;

--- a/components/Buttons/UserButton.vue
+++ b/components/Buttons/UserButton.vue
@@ -7,7 +7,7 @@
         v-bind="attrs"
         v-on="on"
       >
-        <user-image :user="$auth.user" />
+        <user-image v-if="$auth.user" :user="$auth.user" />
         <h1
           v-if="$auth.user"
           class="flex-grow-1 font-weight-light ml-3 pb-1 text-truncate user-select-none"

--- a/components/Buttons/UserButton.vue
+++ b/components/Buttons/UserButton.vue
@@ -7,7 +7,7 @@
         v-bind="attrs"
         v-on="on"
       >
-        <user-image />
+        <user-image :user="$auth.user" />
         <h1
           v-if="$auth.user"
           class="flex-grow-1 font-weight-light ml-3 pb-1 text-truncate user-select-none"

--- a/components/Layout/Images/UserImage.vue
+++ b/components/Layout/Images/UserImage.vue
@@ -1,27 +1,27 @@
 <template>
-  <v-avatar v-if="userImage">
-    <v-img :src="userImage" :alt="$auth.user.Name" class="userImage">
+  <v-avatar color="primary darken-3" :size="size">
+    <v-img :src="userImage" :alt="user.Name" class="userImage">
       <template #placeholder>
-        <v-avatar color="primary">
-          <v-icon dark>mdi-account</v-icon>
-        </v-avatar>
+        <v-icon :size="size - 32" dark>mdi-account</v-icon>
       </template>
     </v-img>
-  </v-avatar>
-  <v-avatar v-else color="primary">
-    <v-icon dark>mdi-account</v-icon>
   </v-avatar>
 </template>
 
 <script lang="ts">
+import { UserDto } from '@jellyfin/client-axios';
 import Vue from 'vue';
 
 export default Vue.extend({
   props: {
-    id: {
-      type: String,
+    user: {
+      type: Object as () => UserDto,
+      required: true
+    },
+    size: {
+      type: Number,
       required: false,
-      default: undefined
+      default: 64
     },
     quality: {
       type: Number,
@@ -32,14 +32,8 @@ export default Vue.extend({
   computed: {
     userImage: {
       get(): string | undefined {
-        if (
-          !this.id &&
-          this.$auth.user?.Id &&
-          this.$auth.user?.PrimaryImageTag
-        ) {
-          return `${this.$axios.defaults.baseURL}/Users/${this.$auth.user.Id}/Images/Primary/?tag=${this.$auth.user.PrimaryImageTag}&quality=${this.quality}`;
-        } else if (this.id) {
-          return `${this.$axios.defaults.baseURL}/Users/${this.id}/Images/Primary/?tag=${this.$auth.user.PrimaryImageTag}&quality=${this.quality}`;
+        if (this.user?.Id && this.user?.PrimaryImageTag) {
+          return `${this.$axios.defaults.baseURL}/Users/${this.user.Id}/Images/Primary/?tag=${this.user.PrimaryImageTag}&quality=${this.quality}`;
         } else {
           return undefined;
         }
@@ -48,9 +42,3 @@ export default Vue.extend({
   }
 });
 </script>
-
-<style lang="scss" scoped>
-.userImage {
-  image-rendering: crisp-edges;
-}
-</style>

--- a/components/Users/UserCard.vue
+++ b/components/Users/UserCard.vue
@@ -1,10 +1,11 @@
 <template>
-  <div
-    class="user-card mx-auto d-flex flex-column"
-    @click="$emit('connect', user)"
-  >
-    <user-image :size="128" :user="user" />
-    <span class="text-subtitle-1 text-center mt-2">{{ user.Name }}</span>
+  <div class="ma-2 d-flex flex-column pointer" @click="$emit('connect', user)">
+    <v-btn plain ripple :height="128" :width="128" class="rounded">
+      <user-image :size="128" :user="user" />
+    </v-btn>
+    <a class="text-subtitle-1 text-center mt-2 link">
+      {{ user.Name }}
+    </a>
   </div>
 </template>
 
@@ -35,3 +36,8 @@ export default Vue.extend({
   }
 });
 </script>
+<style lang="scss" scoped>
+.rounded {
+  border-radius: 100% !important;
+}
+</style>

--- a/components/Users/UserCard.vue
+++ b/components/Users/UserCard.vue
@@ -1,29 +1,11 @@
 <template>
-  <v-card class="mx-auto d-flex flex-column">
-    <div class="user-image primary darken-4">
-      <v-responsive :aspect-ratio="1 / 1">
-        <user-image v-if="user.PrimaryImageTag" :id="user.Id" />
-        <div
-          v-if="!user.PrimaryImageTag"
-          class="empty-picture d-flex align-center justify-center"
-        >
-          <v-icon dark size="96">mdi-account</v-icon>
-        </div>
-      </v-responsive>
-    </div>
-    <v-card-title>
-      {{ user.Name }}
-    </v-card-title>
-    <v-card-subtitle class="pb-0 text-capitalize-first-letter">
-      {{ formatDistance(user.LastActivityDate) }}
-    </v-card-subtitle>
-    <v-spacer />
-    <v-card-actions>
-      <v-btn text block color="primary" @click="$emit('connect', user)">
-        {{ $t('login.connect') }}
-      </v-btn>
-    </v-card-actions>
-  </v-card>
+  <div
+    class="user-card mx-auto d-flex flex-column"
+    @click="$emit('connect', user)"
+  >
+    <user-image size="128" :user="user" />
+    <span class="text-subtitle-1 text-center mt-2">{{ user.Name }}</span>
+  </div>
 </template>
 
 <script lang="ts">
@@ -53,29 +35,3 @@ export default Vue.extend({
   }
 });
 </script>
-
-<style lang="scss" scoped>
-.portrait-card {
-  display: block;
-  position: relative;
-  contain: strict;
-}
-
-.card-content {
-  overflow: hidden;
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  margin: 0 !important;
-  height: 100%;
-  width: 100%;
-  contain: strict;
-  -webkit-tap-highlight-color: transparent;
-}
-
-.empty-picture {
-  height: 100%;
-}
-</style>

--- a/components/Users/UserCard.vue
+++ b/components/Users/UserCard.vue
@@ -3,7 +3,7 @@
     class="user-card mx-auto d-flex flex-column"
     @click="$emit('connect', user)"
   >
-    <user-image size="128" :user="user" />
+    <user-image :size="128" :user="user" />
     <span class="text-subtitle-1 text-center mt-2">{{ user.Name }}</span>
   </div>
 </template>


### PR DESCRIPTION
Fixes UserImage essentially being broken and fairly useless, and refactors UserCard.

UserImage relied *heavily* on `$auth.user`, making it completely useless in a lot of situations (And breaking the client completely if a public user had an avatar set).

The structure of UserCard was also fairly nonsensical, having a `v-avatar` with a `v-image` in it, whose placeholder was another `v-avatar` with a `v-icon` in it...  
This cleans up the structure and reworks the component to look like this:
![image](https://user-images.githubusercontent.com/19396809/107296510-d312b780-6a71-11eb-8241-edc94c4dfe62.png)

One remaining issue is that, since Vuetify is limited, there is no way to easily get these to have button-like hover effects while also being tied to Vuetify's styles without essentially rewriting a custom `v-btn`.