### PR TITLE
chore: disable void html elements erroring on self-close

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -42,7 +42,14 @@ module.exports = {
     'vue/v-on-style': 'error',
     'vue/v-slot-style': 'error',
     'vue/attributes-order': 'error',
-    'vue/html-self-closing': 'error',
+    'vue/html-self-closing': [
+      'error',
+      {
+        html: {
+          void: 'always'
+        }
+      }
+    ],
     'vue/multiline-html-element-content-newline': 'error'
   },
   settings: {

--- a/components/Layout/Images/BlurhashImage.vue
+++ b/components/Layout/Images/BlurhashImage.vue
@@ -11,7 +11,6 @@
         class="absolute"
       />
       <v-fade-transition>
-        <!-- eslint-disable-next-line vue/html-self-closing -->
         <img
           v-show="!loading"
           :key="`blurhashimage-${item.Id}`"


### PR DESCRIPTION
Cherry picked from #633 

This conflicts with our prettier config and it doesn't make so much sense anyway.