### PR TITLE
feat: cover viewport and avoid scaling in mobile devices

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -53,7 +53,11 @@ const config: NuxtConfig = {
     title: 'Jellyfin',
     meta: [
       { charset: 'utf-8' },
-      { name: 'viewport', content: 'width=device-width, initial-scale=1' },
+      {
+        name: 'viewport',
+        content:
+          'width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover'
+      },
       {
         hid: 'description',
         name: 'description',


### PR DESCRIPTION
Cherrypicked from #633 

Takes the settings of jellyfin-web for the meta-viewport label, which avoids user scaling and covers the full viewport of the device