### PR TITLE
refactor(item menu): remove unused prop 'absolute' from item-menu

### DIFF
--- a/pages/item/_itemId/index.vue
+++ b/pages/item/_itemId/index.vue
@@ -33,7 +33,7 @@
             }"
           >
             <play-button class="mr-2" :item="item" />
-            <item-menu :item="item" outlined :absolute="false" />
+            <item-menu :item="item" outlined />
             <like-button :item="item" class="ml-2" />
           </v-row>
           <v-col cols="12" md="10">

--- a/pages/musicalbum/_itemId/index.vue
+++ b/pages/musicalbum/_itemId/index.vue
@@ -49,7 +49,7 @@
             >
               {{ $t('play') }}
             </v-btn>
-            <item-menu :item="item" outlined :absolute="false" />
+            <item-menu :item="item" outlined />
           </v-row>
           <v-col cols="12" md="10">
             <v-row

--- a/pages/series/_itemId/index.vue
+++ b/pages/series/_itemId/index.vue
@@ -44,7 +44,7 @@
             >
               {{ $t('play') }}
             </v-btn>
-            <item-menu :item="item" outlined :absolute="false" />
+            <item-menu :item="item" outlined />
           </v-row>
           <v-col cols="12" md="10">
             <v-row


### PR DESCRIPTION
Absolute prop was removed here:
a3bb45e: feat: implement favorites