### PR TITLE
perf(build): optimize build size

### DIFF
--- a/components/Forms/LoginForm.vue
+++ b/components/Forms/LoginForm.vue
@@ -62,7 +62,7 @@
 </template>
 
 <script lang="ts">
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import Vue from 'vue';
 import { mapActions } from 'vuex';
 import { UserDto } from '@jellyfin/client-axios';

--- a/components/Item/ItemGrid.vue
+++ b/components/Item/ItemGrid.vue
@@ -48,7 +48,7 @@
 </template>
 
 <script lang="ts">
-import { chunk } from 'lodash';
+import chunk from 'lodash/chunk';
 import Vue from 'vue';
 import { BaseItemDto } from '@jellyfin/client-axios';
 

--- a/components/Item/Metadata/MetadataEditor.vue
+++ b/components/Item/Metadata/MetadataEditor.vue
@@ -211,7 +211,8 @@
 
 <script lang="ts">
 import Vue from 'vue';
-import { pick, set } from 'lodash';
+import pick from 'lodash/pick';
+import set from 'lodash/set';
 import { BaseItemDto, BaseItemPerson } from '@jellyfin/client-axios';
 
 export default Vue.extend({

--- a/components/Players/AudioPlayer.vue
+++ b/components/Players/AudioPlayer.vue
@@ -12,7 +12,7 @@
 <script lang="ts">
 import Vue from 'vue';
 import { stringify } from 'qs';
-import { throttle } from 'lodash';
+import throttle from 'lodash/throttle';
 // @ts-expect-error - This module doesn't have typings
 import muxjs from 'mux.js';
 import { mapActions, mapGetters, mapState } from 'vuex';

--- a/components/Players/TrackList.vue
+++ b/components/Players/TrackList.vue
@@ -74,7 +74,7 @@
 <script lang="ts">
 import Vue from 'vue';
 import { mapActions, mapGetters } from 'vuex';
-import { Dictionary, groupBy } from 'lodash';
+import groupBy from 'lodash/groupBy';
 import { BaseItemDto, BaseItemDtoQueryResult } from '@jellyfin/client-axios';
 import timeUtils from '~/mixins/timeUtils';
 import itemHelper from '~/mixins/itemHelper';
@@ -103,7 +103,7 @@ export default Vue.extend({
     ).data;
   },
   computed: {
-    tracksPerDisc(): Dictionary<BaseItemDto[]> {
+    tracksPerDisc(): Record<string, BaseItemDto[]> {
       return groupBy(this.$data.tracks.Items, 'ParentIndexNumber');
     }
   },

--- a/components/Players/VideoPlayer.vue
+++ b/components/Players/VideoPlayer.vue
@@ -15,7 +15,7 @@
 <script lang="ts">
 import Vue from 'vue';
 import { stringify } from 'qs';
-import { throttle } from 'lodash';
+import throttle from 'lodash/throttle';
 // @ts-expect-error - This module doesn't have typings
 import muxjs from 'mux.js';
 import { mapActions, mapGetters, mapState } from 'vuex';

--- a/mixins/timeUtils.ts
+++ b/mixins/timeUtils.ts
@@ -5,7 +5,7 @@
  */
 import Vue from 'vue';
 import { intervalToDuration } from 'date-fns';
-import { sumBy } from 'lodash';
+import sumBy from 'lodash/sumBy';
 import { BaseItemDto } from '@jellyfin/client-axios';
 
 /**

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -268,6 +268,8 @@ const config: NuxtConfig = {
         server: '#424242'
       }
     },
+    optimizeCSS: true,
+    extractCSS: true,
     babel: {
       // envName: server, client, modern
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -15,7 +15,7 @@
 <script lang="ts">
 import Vue from 'vue';
 import { mapActions, mapGetters } from 'vuex';
-import { pickBy } from 'lodash';
+import pickBy from 'lodash/pickBy';
 import { BaseItemDto } from '@jellyfin/client-axios';
 import { getShapeFromCollectionType } from '~/utils/items';
 import { HomeSection } from '~/store/homeSection';

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -48,7 +48,7 @@
 </template>
 
 <script lang="ts">
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import Vue from 'vue';
 import { mapActions } from 'vuex';
 import { UserDto } from '@jellyfin/client-axios';

--- a/pages/settings/index.vue
+++ b/pages/settings/index.vue
@@ -126,7 +126,7 @@
 <script lang="ts">
 import Vue from 'vue';
 import { mapActions } from 'vuex';
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import { SystemInfo } from '@jellyfin/client-axios';
 import { version } from '~/package.json';
 import htmlHelper from '~/mixins/htmlHelper';

--- a/store/__tests__/backdrop.spec.ts
+++ b/store/__tests__/backdrop.spec.ts
@@ -1,7 +1,7 @@
 import Vue, { VueConstructor } from 'vue';
 import { createLocalVue } from '@vue/test-utils';
 import Vuex, { Store } from 'vuex';
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 import {
   state,
   mutations,

--- a/store/__tests__/deviceProfile.spec.ts
+++ b/store/__tests__/deviceProfile.spec.ts
@@ -1,7 +1,7 @@
 import Vue, { VueConstructor } from 'vue';
 import { createLocalVue } from '@vue/test-utils';
 import Vuex, { Store } from 'vuex';
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 import {
   state,
   mutations,

--- a/store/__tests__/page.spec.ts
+++ b/store/__tests__/page.spec.ts
@@ -1,7 +1,7 @@
 import Vue, { VueConstructor } from 'vue';
 import { createLocalVue } from '@vue/test-utils';
 import Vuex, { Store } from 'vuex';
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 import { state, mutations, actions, PageState, defaultState } from '../page';
 
 const PAGE_SET_TEST_VALUE = {

--- a/store/__tests__/playbackManager.spec.ts
+++ b/store/__tests__/playbackManager.spec.ts
@@ -1,7 +1,7 @@
 import Vue, { VueConstructor } from 'vue';
 import { createLocalVue } from '@vue/test-utils';
 import Vuex, { Store } from 'vuex';
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 import {
   BaseItemDto,
   MediaSourceInfo,

--- a/store/__tests__/servers.spec.ts
+++ b/store/__tests__/servers.spec.ts
@@ -1,7 +1,7 @@
 import Vue, { VueConstructor } from 'vue';
 import { createLocalVue } from '@vue/test-utils';
 import Vuex, { Store } from 'vuex';
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 import {
   state,
   mutations,

--- a/store/__tests__/snackbar.spec.ts
+++ b/store/__tests__/snackbar.spec.ts
@@ -1,7 +1,7 @@
 import Vue, { VueConstructor } from 'vue';
 import { createLocalVue } from '@vue/test-utils';
 import Vuex, { Store } from 'vuex';
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 import {
   state,
   mutations,

--- a/store/__tests__/tvShows.spec.ts
+++ b/store/__tests__/tvShows.spec.ts
@@ -1,7 +1,7 @@
 import Vue, { VueConstructor } from 'vue';
 import { createLocalVue } from '@vue/test-utils';
 import Vuex, { Store } from 'vuex';
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 import { BaseItemDto, BaseItemDtoQueryResult } from '@jellyfin/client-axios';
 import {
   state,

--- a/store/__tests__/userViews.spec.ts
+++ b/store/__tests__/userViews.spec.ts
@@ -1,7 +1,7 @@
 import Vue, { VueConstructor } from 'vue';
 import { createLocalVue } from '@vue/test-utils';
 import Vuex, { Store } from 'vuex';
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 import { BaseItemDto } from '@jellyfin/client-axios';
 import {
   state,

--- a/store/playbackManager.ts
+++ b/store/playbackManager.ts
@@ -1,5 +1,6 @@
 import { ActionTree, GetterTree, MutationTree } from 'vuex';
-import { clamp, shuffle } from 'lodash';
+import clamp from 'lodash/clamp';
+import shuffle from 'lodash/shuffle';
 import {
   BaseItemDto,
   ChapterInfo,

--- a/utils/playbackUtils.ts
+++ b/utils/playbackUtils.ts
@@ -4,7 +4,8 @@ import {
   ItemFields,
   ItemFilter
 } from '@jellyfin/client-axios';
-import { union, uniqBy } from 'lodash';
+import union from 'lodash/union';
+import uniqBy from 'lodash/uniqBy';
 
 /**
  * Converts an item into a set of playable items for the playback manager to handle.


### PR DESCRIPTION
Quick pass for optimizing our bundle size.

We might need to do the same for all the imports of the axios client, however, unless we don't have the sources (https://github.com/jellyfin/jellyfin-meta/issues/10), I can't check if we can prepare it for better treeshaking