### PR TITLE
fix(skeleton home section): fix missing margin on skeleton home sections heading

### DIFF
--- a/components/Skeletons/SkeletonHomeSection.vue
+++ b/components/Skeletons/SkeletonHomeSection.vue
@@ -1,6 +1,6 @@
 <template>
   <v-col>
-    <v-skeleton-loader type="heading" max-width="25em" />
+    <v-skeleton-loader type="heading" max-width="25em" class="ml-2" />
     <v-row class="space-around ma-0">
       <skeleton-card
         v-for="i in cardNumber"


### PR DESCRIPTION
**Before**
![image](https://user-images.githubusercontent.com/18101008/107874787-dc59b500-6eb3-11eb-8baf-f7c1b3d50ea9.png)


**After**
![image](https://user-images.githubusercontent.com/18101008/107874783-d2d04d00-6eb3-11eb-8ac5-8b6a012c043e.png)
