### PR TITLE
chore: add newly opened Pull Requests to 'Ongoing development' project

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -1,0 +1,16 @@
+name: Move new pull request to "Ongoing development" project
+
+on:
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  automate-project-columns:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: alex-page/github-project-automation-plus@v0.5.1
+        with:
+          project: Ongoing development
+          column: In progress
+          repo-token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
Created an action that adds all the new Pull Requests to the "Ongoing development" project, so reviewed PRs can be tracked easily.