### PR TITLE
Move Websocket message handling to a Vuex plugin

### DIFF
--- a/store/index.ts
+++ b/store/index.ts
@@ -11,6 +11,9 @@ import { PlaybackManagerState } from './playbackManager';
 import { BackdropState } from './backdrop';
 import { DeviceState } from './deviceProfile';
 import { DisplayPreferencesState } from './displayPreferences';
+import { websocketPlugin } from './plugins/websocket';
+
+export const plugins = [websocketPlugin];
 
 export interface RootState {
   socket: {

--- a/store/plugins/websocket.ts
+++ b/store/plugins/websocket.ts
@@ -1,0 +1,45 @@
+import { Plugin } from 'vuex';
+import { AppState } from '..';
+
+interface WebSocketMessage {
+  MessageType: string;
+  Data?: Record<string, never>;
+}
+
+export const websocketPlugin: Plugin<AppState> = (store) => {
+  let keepAliveInterval: number;
+
+  /**
+   * Builds and sends a websocket message of a given type, with the specified payload.
+   *
+   * @param {string} name - Name of the message type to send
+   * @param {Record<string, any>} data - Contents of the payload of the message
+   */
+  function sendWebsocketMessage(
+    name: string,
+    data?: Record<string, never>
+  ): void {
+    const msg: WebSocketMessage = {
+      MessageType: name,
+      ...(data ? { Data: data } : {})
+    };
+
+    store.state.socket.instance?.send(JSON.stringify(msg));
+  }
+
+  store.subscribe((mutation, state) => {
+    if (
+      mutation.type === 'SOCKET_ONMESSAGE' &&
+      state.socket.message.MessageType === 'ForceKeepAlive'
+    ) {
+      sendWebsocketMessage('KeepAlive');
+      keepAliveInterval = window.setInterval(() => {
+        sendWebsocketMessage('KeepAlive');
+      }, state.socket.message.Data * 1000 * 0.5);
+    } else if (mutation.type === 'SOCKET_ONCLOSE') {
+      if (keepAliveInterval) {
+        clearInterval(keepAliveInterval);
+      }
+    }
+  });
+};


### PR DESCRIPTION
This moves the message handling of the Websocket to a Vuex plugin, in order to avoid cluttering components with having to handle socket messages.

After the Items store refactor, most of the other instances of `subscribe()` should be able to move here or be outright removed.