### PR TITLE
fix(login): fix bugged redirection when auto reconnecting to offline …

### DIFF
--- a/pages/login.vue
+++ b/pages/login.vue
@@ -63,16 +63,16 @@ export default Vue.extend({
         'servers/connectServer',
         store.state.servers.serverUsed.address
       );
+
+      const publicUsers = (await $api.user.getPublicUsers({})).data;
+
+      const brandingData = (await $api.branding.getBrandingOptions()).data;
+      const disclaimer = brandingData.LoginDisclaimer || '';
+
+      return { publicUsers, disclaimer };
     } catch {
       redirect('/selectserver');
     }
-
-    const publicUsers = (await $api.user.getPublicUsers({})).data;
-
-    const brandingData = (await $api.branding.getBrandingOptions()).data;
-    const disclaimer = brandingData.LoginDisclaimer || '';
-
-    return { publicUsers, disclaimer };
   },
   data() {
     return {


### PR DESCRIPTION
…server

if you loaded the page while previously signed on and the associated server offline, the
redirections would crash due to an unhandled bad api call

fix #707