### PR TITLE
chore: push docker images to ghcr.io alongside DockerHub

### DIFF
--- a/.github/workflows/Dockerfile.nginx
+++ b/.github/workflows/Dockerfile.nginx
@@ -3,8 +3,8 @@
 
 FROM nginx:alpine
 
-LABEL maintainer "Jellyfin Packaging Team - packaging@jellyfin.org"
-LABEL org.opencontainers.image.source https://github.com/jellyfin/jellyfin-vue
+LABEL maintainer="Jellyfin Packaging Team - packaging@jellyfin.org"
+LABEL org.opencontainers.image.source="https://github.com/jellyfin/jellyfin-vue"
 
 COPY dist/ /usr/share/nginx/html/
 COPY .docker/nginx.conf /etc/nginx/conf.d/default.conf

--- a/.github/workflows/Dockerfile.nginx
+++ b/.github/workflows/Dockerfile.nginx
@@ -2,6 +2,10 @@
 # built in the host in order to be created and deployed
 
 FROM nginx:alpine
+
+LABEL maintainer "Jellyfin Packaging Team - packaging@jellyfin.org"
+LABEL org.opencontainers.image.source https://github.com/jellyfin/jellyfin-vue
+
 COPY dist/ /usr/share/nginx/html/
 COPY .docker/nginx.conf /etc/nginx/conf.d/default.conf
 COPY .docker/mime.types /etc/nginx/mime.types

--- a/.github/workflows/Dockerfile.ssr
+++ b/.github/workflows/Dockerfile.ssr
@@ -3,8 +3,8 @@
 
 FROM node:14-alpine
 
-LABEL maintainer "Jellyfin Packaging Team - packaging@jellyfin.org"
-LABEL org.opencontainers.image.source https://github.com/jellyfin/jellyfin-vue
+LABEL maintainer="Jellyfin Packaging Team - packaging@jellyfin.org"
+LABEL org.opencontainers.image.source="https://github.com/jellyfin/jellyfin-vue"
 
 COPY .docker/package.json ./.docker/nuxt.config.js ./
 COPY .nuxt ./.nuxt

--- a/.github/workflows/Dockerfile.ssr
+++ b/.github/workflows/Dockerfile.ssr
@@ -3,6 +3,9 @@
 
 FROM node:14-alpine
 
+LABEL maintainer "Jellyfin Packaging Team - packaging@jellyfin.org"
+LABEL org.opencontainers.image.source https://github.com/jellyfin/jellyfin-vue
+
 COPY .docker/package.json ./.docker/nuxt.config.js ./
 COPY .nuxt ./.nuxt
 COPY static ./static

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -51,6 +51,13 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1 
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GH_TOKEN }}
+
       - name: Build and push stable SSR images
         if: github.event.action == 'released'
         uses: docker/build-push-action@v2
@@ -64,6 +71,10 @@ jobs:
             jellyfin/jellyfin-vue:stable-ssr
             jellyfin/jellyfin-vue:stable-ssr.${{ github.event.release.tag_name }}
             jellyfin/jellyfin-vue:latest
+            ghcr.io/jellyfin/jellyfin-vue:stable
+            ghcr.io/jellyfin/jellyfin-vue:stable-ssr
+            ghcr.io/jellyfin/jellyfin-vue:stable-ssr.${{ github.event.release.tag_name }}
+            ghcr.io/jellyfin/jellyfin-vue:latest
 
       - name: Build and push release candidate SSR images
         if: github.event.action == 'prereleased'
@@ -76,6 +87,8 @@ jobs:
           tags: |
             jellyfin/jellyfin-vue:stable-rc-ssr
             jellyfin/jellyfin-vue:stable-rc-ssr.${{ github.event.release.tag_name }}
+            ghcr.io/jellyfin/jellyfin-vue:stable-rc-ssr
+            ghcr.io/jellyfin/jellyfin-vue:stable-rc-ssr.${{ github.event.release.tag_name }}
 
   static:
     name: Build static images
@@ -121,6 +134,13 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1 
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GH_TOKEN }}
+
       - name: Build and push stable static images
         if: github.event.action == 'released'
         uses: docker/build-push-action@v2
@@ -132,6 +152,8 @@ jobs:
           tags: |
             jellyfin/jellyfin-vue:stable-static
             jellyfin/jellyfin-vue:stable-static.${{ github.event.release.tag_name }}
+            ghcr.io/jellyfin/jellyfin-vue:stable-static
+            ghcr.io/jellyfin/jellyfin-vue:stable-static.${{ github.event.release.tag_name }}
 
       - name: Build and push release candidate static images
         if: github.event.action == 'prereleased'
@@ -144,3 +166,5 @@ jobs:
           tags: |
             jellyfin/jellyfin-vue:stable-rc-static
             jellyfin/jellyfin-vue:stable-rc-static.${{ github.event.release.tag_name }}
+            ghcr.io/jellyfin/jellyfin-vue:stable-rc-static
+            ghcr.io/jellyfin/jellyfin-vue:stable-rc-static.${{ github.event.release.tag_name }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,7 +16,8 @@ jobs:
         run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
 
       - name: Get commit hash
-        run: echo "SHORT_SHA=${GITHUB_SHA::7}" >> $GITHUB_ENV
+        id: sha
+        run: echo "::set-output name=sha::${GITHUB_SHA::7}"
 
       - name: Checkout
         uses: actions/checkout@v2
@@ -74,10 +75,10 @@ jobs:
           tags: |
             jellyfin/jellyfin-vue:unstable
             jellyfin/jellyfin-vue:unstable-ssr
-            jellyfin/jellyfin-vue:unstable-ssr.${{ steps.date.outputs.date }}.${{ env.SHORT_SHA }}
+            jellyfin/jellyfin-vue:unstable-ssr.${{ steps.date.outputs.date }}.${{ steps.sha.outputs.sha }}
             ghcr.io/jellyfin/jellyfin-vue:unstable
             ghcr.io/jellyfin/jellyfin-vue:unstable-ssr
-            ghcr.io/jellyfin/jellyfin-vue:unstable-ssr.${{ steps.date.outputs.date }}.${{ env.SHORT_SHA }}
+            ghcr.io/jellyfin/jellyfin-vue:unstable-ssr.${{ steps.date.outputs.date }}.${{ steps.sha.outputs.sha }}
 
   static:
     name: Build static images
@@ -89,7 +90,8 @@ jobs:
         run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
 
       - name: Get commit hash
-        run: echo "SHORT_SHA=${GITHUB_SHA::7}" >> $GITHUB_ENV
+        id: sha
+        run: echo "::set-output name=sha::${GITHUB_SHA::7}"
 
       - name: Checkout
         uses: actions/checkout@v2
@@ -131,7 +133,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v1
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -146,6 +148,6 @@ jobs:
           file: '.github/workflows/Dockerfile.nginx'
           tags: |
             jellyfin/jellyfin-vue:unstable-static
-            jellyfin/jellyfin-vue:unstable-static.${{ steps.date.outputs.date }}.${{ env.SHORT_SHA }}
+            jellyfin/jellyfin-vue:unstable-static.${{ steps.date.outputs.date }}.${{ steps.sha.outputs.sha }}
             ghcr.io/jellyfin/jellyfin-vue:unstable-static
-            ghcr.io/jellyfin/jellyfin-vue:unstable-static.${{ steps.date.outputs.date }}.${{ env.SHORT_SHA }}
+            ghcr.io/jellyfin/jellyfin-vue:unstable-static.${{ steps.date.outputs.date }}.${{ steps.sha.outputs.sha }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -57,6 +57,13 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GH_TOKEN }}
+
       - name: Build images and push
         uses: docker/build-push-action@v2
         with:
@@ -68,6 +75,9 @@ jobs:
             jellyfin/jellyfin-vue:unstable
             jellyfin/jellyfin-vue:unstable-ssr
             jellyfin/jellyfin-vue:unstable-ssr.${{ steps.date.outputs.date }}.${{ env.SHORT_SHA }}
+            ghcr.io/jellyfin/jellyfin-vue:unstable
+            ghcr.io/jellyfin/jellyfin-vue:unstable-ssr
+            ghcr.io/jellyfin/jellyfin-vue:unstable-ssr.${{ steps.date.outputs.date }}.${{ env.SHORT_SHA }}
 
   static:
     name: Build static images
@@ -120,6 +130,13 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1 
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GH_TOKEN }}
+
       - name: Build images and push
         uses: docker/build-push-action@v2
         with:
@@ -130,3 +147,5 @@ jobs:
           tags: |
             jellyfin/jellyfin-vue:unstable-static
             jellyfin/jellyfin-vue:unstable-static.${{ steps.date.outputs.date }}.${{ env.SHORT_SHA }}
+            ghcr.io/jellyfin/jellyfin-vue:unstable-static
+            ghcr.io/jellyfin/jellyfin-vue:unstable-static.${{ steps.date.outputs.date }}.${{ env.SHORT_SHA }}


### PR DESCRIPTION
Blocked by #767 as it's build on top of it

Pushes Docker images to ghcr.io alongside DockerHub.

Organization-wide changes at jellyfin/jellyfin-metapackages#7