### PR TITLE
perf(memory): unsubscribe from mutation watchers on destroy

### DIFF
--- a/components/Players/AudioPlayer.vue
+++ b/components/Players/AudioPlayer.vue
@@ -35,7 +35,9 @@ export default Vue.extend({
       playbackInfo: {} as PlaybackInfoResponse,
       source: '',
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      player: null as any
+      player: null as any,
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      unsubscribe(): void {}
     };
   },
   computed: {
@@ -76,40 +78,42 @@ export default Vue.extend({
         // Register player events
         this.player.addEventListener('error', this.onPlayerError);
         // Subscribe to Vuex actions
-        this.$store.subscribe((mutation, _state: AppState) => {
-          switch (mutation.type) {
-            case 'playbackManager/PAUSE_PLAYBACK':
-              if (this.$refs.audioPlayer) {
-                (this.$refs.audioPlayer as HTMLAudioElement).pause();
-              }
-              break;
-            case 'playbackManager/UNPAUSE_PLAYBACK':
-              if (this.$refs.audioPlayer) {
-                (this.$refs.audioPlayer as HTMLAudioElement).play();
-              }
-              break;
-            case 'playbackManager/CHANGE_CURRENT_TIME':
-              if (this.$refs.audioPlayer) {
-                (this.$refs
-                  .audioPlayer as HTMLAudioElement).currentTime = this.currentTime;
-              }
-              break;
-            case 'playbackManager/SET_VOLUME':
-              if (this.$refs.audioPlayer) {
-                (this.$refs.audioPlayer as HTMLAudioElement).volume =
-                  this.currentVolume / 100;
-              }
-              break;
-            case 'playbackManager/SET_REPEAT_MODE':
-              if (this.$refs.audioPlayer) {
-                if (mutation?.payload?.mode === RepeatMode.RepeatOne) {
-                  (this.$refs.audioPlayer as HTMLAudioElement).loop = true;
-                } else {
-                  (this.$refs.audioPlayer as HTMLAudioElement).loop = false;
+        this.unsubscribe = this.$store.subscribe(
+          (mutation, _state: AppState) => {
+            switch (mutation.type) {
+              case 'playbackManager/PAUSE_PLAYBACK':
+                if (this.$refs.audioPlayer) {
+                  (this.$refs.audioPlayer as HTMLAudioElement).pause();
                 }
-              }
+                break;
+              case 'playbackManager/UNPAUSE_PLAYBACK':
+                if (this.$refs.audioPlayer) {
+                  (this.$refs.audioPlayer as HTMLAudioElement).play();
+                }
+                break;
+              case 'playbackManager/CHANGE_CURRENT_TIME':
+                if (this.$refs.audioPlayer) {
+                  (this.$refs
+                    .audioPlayer as HTMLAudioElement).currentTime = this.currentTime;
+                }
+                break;
+              case 'playbackManager/SET_VOLUME':
+                if (this.$refs.audioPlayer) {
+                  (this.$refs.audioPlayer as HTMLAudioElement).volume =
+                    this.currentVolume / 100;
+                }
+                break;
+              case 'playbackManager/SET_REPEAT_MODE':
+                if (this.$refs.audioPlayer) {
+                  if (mutation?.payload?.mode === RepeatMode.RepeatOne) {
+                    (this.$refs.audioPlayer as HTMLAudioElement).loop = true;
+                  } else {
+                    (this.$refs.audioPlayer as HTMLAudioElement).loop = false;
+                  }
+                }
+            }
           }
-        });
+        );
       } else {
         this.$nuxt.error({
           message: this.$t('browserNotSupported') as string
@@ -130,6 +134,7 @@ export default Vue.extend({
       this.player.unload();
       this.player.destroy();
     }
+    this.unsubscribe();
   },
   methods: {
     ...mapActions('snackbar', ['pushSnackbarMessage']),

--- a/components/Players/PlayerManager.vue
+++ b/components/Players/PlayerManager.vue
@@ -164,7 +164,9 @@ export default Vue.extend({
     return {
       showFullScreenOverlay: false,
       fullScreenOverlayTimer: null as number | null,
-      supportedFeatures: {} as SupportedFeaturesInterface
+      supportedFeatures: {} as SupportedFeaturesInterface,
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      unsubscribe(): void {}
     };
   },
   computed: {
@@ -195,9 +197,23 @@ export default Vue.extend({
       }
     }
   },
-  created() {
-    this.$store.subscribe((mutation, state: AppState) => {
+  beforeMount() {
+    this.supportedFeatures = getSupportedFeatures();
+  },
+  mounted() {
+    document.addEventListener('mousemove', this.handleMouseMove);
+
+    this.addMediaHandlers();
+
+    this.unsubscribe = this.$store.subscribe((mutation, state: AppState) => {
       switch (mutation.type) {
+        case 'playbackManager/TOGGLE_MINIMIZE':
+          if (state.playbackManager.isMinimized === true) {
+            window.removeEventListener('keydown', this.handleKeyPress);
+          } else if (state.playbackManager.isMinimized === false) {
+            window.addEventListener('keydown', this.handleKeyPress);
+          }
+          break;
         case 'playbackManager/INCREASE_QUEUE_INDEX':
         case 'playbackManager/DECREASE_QUEUE_INDEX':
         case 'playbackManager/SET_CURRENT_ITEM_INDEX':
@@ -315,30 +331,13 @@ export default Vue.extend({
       }
     });
   },
-  beforeMount() {
-    this.supportedFeatures = getSupportedFeatures();
-  },
-  mounted() {
-    document.addEventListener('mousemove', this.handleMouseMove);
-
-    this.addMediaHandlers();
-
-    this.$store.subscribe((mutation, state: AppState) => {
-      switch (mutation.type) {
-        case 'playbackManager/TOGGLE_MINIMIZE':
-          if (state.playbackManager.isMinimized === true) {
-            window.removeEventListener('keydown', this.handleKeyPress);
-          } else if (state.playbackManager.isMinimized === false) {
-            window.addEventListener('keydown', this.handleKeyPress);
-          }
-      }
-    });
-  },
   beforeDestroy() {
     if (this.fullScreenOverlayTimer) {
       clearTimeout(this.fullScreenOverlayTimer);
     }
     document.removeEventListener('mousemove', this.handleMouseMove);
+    this.removeMediaHandlers();
+    this.unsubscribe();
   },
   methods: {
     ...mapActions('playbackManager', [

--- a/components/Players/VideoPlayer.vue
+++ b/components/Players/VideoPlayer.vue
@@ -44,7 +44,9 @@ export default Vue.extend({
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       player: null as any,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      ui: null as any
+      ui: null as any,
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      unsubscribe(): void {}
     };
   },
   computed: {
@@ -90,34 +92,36 @@ export default Vue.extend({
         // Register player events
         this.player.addEventListener('error', this.onPlayerError);
         // Subscribe to Vuex actions
-        this.$store.subscribe((mutation, _state: AppState) => {
-          switch (mutation.type) {
-            case 'playbackManager/PAUSE_PLAYBACK':
-              if (this.$refs.videoPlayer) {
-                (this.$refs.videoPlayer as HTMLVideoElement).pause();
-              }
-              break;
-            case 'playbackManager/UNPAUSE_PLAYBACK':
-              if (this.$refs.videoPlayer) {
-                (this.$refs.videoPlayer as HTMLVideoElement).play();
-              }
-              break;
-            case 'playbackManager/CHANGE_CURRENT_TIME':
-              if (this.$refs.videoPlayer && mutation?.payload?.time) {
-                (this.$refs.videoPlayer as HTMLVideoElement).currentTime =
-                  mutation?.payload?.time;
-              }
-              break;
-            case 'playbackManager/SET_REPEAT_MODE':
-              if (this.$refs.videoPlayer) {
-                if (mutation?.payload?.mode === RepeatMode.RepeatOne) {
-                  (this.$refs.videoPlayer as HTMLVideoElement).loop = true;
-                } else {
-                  (this.$refs.videoPlayer as HTMLVideoElement).loop = false;
+        this.unsubscribe = this.$store.subscribe(
+          (mutation, _state: AppState) => {
+            switch (mutation.type) {
+              case 'playbackManager/PAUSE_PLAYBACK':
+                if (this.$refs.videoPlayer) {
+                  (this.$refs.videoPlayer as HTMLVideoElement).pause();
                 }
-              }
+                break;
+              case 'playbackManager/UNPAUSE_PLAYBACK':
+                if (this.$refs.videoPlayer) {
+                  (this.$refs.videoPlayer as HTMLVideoElement).play();
+                }
+                break;
+              case 'playbackManager/CHANGE_CURRENT_TIME':
+                if (this.$refs.videoPlayer && mutation?.payload?.time) {
+                  (this.$refs.videoPlayer as HTMLVideoElement).currentTime =
+                    mutation?.payload?.time;
+                }
+                break;
+              case 'playbackManager/SET_REPEAT_MODE':
+                if (this.$refs.videoPlayer) {
+                  if (mutation?.payload?.mode === RepeatMode.RepeatOne) {
+                    (this.$refs.videoPlayer as HTMLVideoElement).loop = true;
+                  } else {
+                    (this.$refs.videoPlayer as HTMLVideoElement).loop = false;
+                  }
+                }
+            }
           }
-        });
+        );
       } else {
         this.$nuxt.error({
           message: this.$t('browserNotSupported')
@@ -138,6 +142,7 @@ export default Vue.extend({
       this.player.unload();
       this.player.destroy();
     }
+    this.unsubscribe();
   },
   methods: {
     ...mapActions('snackbar', ['pushSnackbarMessage']),


### PR DESCRIPTION
Unsubscribes the stores of PlaybackManager, AudioPlayer and VideoPlayer, in an attempt to fix the memory leak the client is facing right now. The rest of the components that contain store watchers won't need those as soon as #801 and #764 are done, so I didn't change those.

Although normally the components where I added unsubscribe are not destroyed and recreated (like cards, which are the problematic ones), they are recreated on logout and a relogin, causing the memory leak to appear, which will be a problem for an user that swaps between accounts frequently.