### PR TITLE
Reduce code smells on Sonarcloud

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,6 +30,7 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 'error',
     '@typescript-eslint/prefer-ts-expect-error': 'error',
     'prefer-arrow-callback': 'error',
+    curly: 'error',
     // Force some component order stuff, formatting and such, for consistency
     'vue/component-name-in-template-casing': [
       'error',

--- a/components/Buttons/LikeButton.vue
+++ b/components/Buttons/LikeButton.vue
@@ -55,7 +55,9 @@ export default Vue.extend({
   methods: {
     ...mapActions('snackbar', ['pushSnackbarMessage']),
     async toggleFavorite(): Promise<void> {
-      if (!this.item.Id) return;
+      if (!this.item.Id) {
+        return;
+      }
 
       try {
         if (!this.isFavorite) {

--- a/components/Item/Card/Card.vue
+++ b/components/Item/Card/Card.vue
@@ -149,7 +149,9 @@ export default Vue.extend({
     cardTitle(): string {
       if (this.item.Type !== 'Episode') {
         return this.item.Name || '';
-      } else return this.item.SeriesName || '';
+      } else {
+        return this.item.SeriesName || '';
+      }
     },
     /**
      * @returns {string} Either a string representing the production year(s) for the current item

--- a/components/Item/Metadata/ImageSearch.vue
+++ b/components/Item/Metadata/ImageSearch.vue
@@ -107,7 +107,9 @@ import {
 export default Vue.extend({
   filters: {
     fixed(val: number): string | number {
-      if (!val) return val;
+      if (!val) {
+        return val;
+      }
       return val.toFixed(1);
     }
   },

--- a/components/Item/Metadata/MetadataEditor.vue
+++ b/components/Item/Metadata/MetadataEditor.vue
@@ -241,7 +241,9 @@ export default Vue.extend({
   computed: {
     premiereDate: {
       get(): string {
-        if (!this.metadata.PremiereDate) return '';
+        if (!this.metadata.PremiereDate) {
+          return '';
+        }
         const dateStr = this.$dateFns.format(
           new Date(this.metadata.PremiereDate),
           'yyyy-MM-dd',
@@ -252,7 +254,9 @@ export default Vue.extend({
     },
     dateCreated: {
       get(): string {
-        if (!this.metadata.DateCreated) return '';
+        if (!this.metadata.DateCreated) {
+          return '';
+        }
         const dateStr = this.$dateFns.format(
           new Date(this.metadata.DateCreated),
           'yyyy-MM-dd',

--- a/components/Item/Metadata/PersonEditor.vue
+++ b/components/Item/Metadata/PersonEditor.vue
@@ -91,7 +91,9 @@ export default Vue.extend({
   },
   watch: {
     person(value: BaseItemPerson): void {
-      if (!value) return;
+      if (!value) {
+        return;
+      }
       this.editState = value;
     }
   },

--- a/components/Item/RelatedItems.vue
+++ b/components/Item/RelatedItems.vue
@@ -114,7 +114,9 @@ export default Vue.extend({
           limit: this.vertical ? 5 : 12
         });
 
-        if (response.data.Items) this.relatedItems = response.data.Items;
+        if (response.data.Items) {
+          this.relatedItems = response.data.Items;
+        }
       }
 
       this.loading = false;

--- a/components/Item/TrackSelector.vue
+++ b/components/Item/TrackSelector.vue
@@ -94,7 +94,9 @@ export default Vue.extend({
        * @returns {MediaStream[]} List of MediaStream of the specified type
        */
       get(): MediaStream[] {
-        if (!this.mediaSourceItem.MediaStreams) return [];
+        if (!this.mediaSourceItem.MediaStreams) {
+          return [];
+        }
         return this.mediaSourceItem.MediaStreams.filter(
           (mediaStream) => mediaStream.Type === this.type
         );
@@ -117,8 +119,12 @@ export default Vue.extend({
        * @returns {boolean} Whether to disable the v-select
        */
       get(): boolean {
-        if (this.tracks.length <= 0) return true;
-        if (this.type !== 'Subtitle' && this.tracks.length <= 1) return true;
+        if (this.tracks.length <= 0) {
+          return true;
+        }
+        if (this.type !== 'Subtitle' && this.tracks.length <= 1) {
+          return true;
+        }
         return false;
       }
     },
@@ -127,18 +133,24 @@ export default Vue.extend({
        * @returns {string} Placeholder to use
        */
       get(): string {
-        if (this.type === 'Audio' && this.tracks.length === 0)
+        if (this.type === 'Audio' && this.tracks.length === 0) {
           return this.$t('noAudioTracksAvailable');
-        if (this.type === 'Audio' && this.tracks.length !== 0)
+        }
+        if (this.type === 'Audio' && this.tracks.length !== 0) {
           return this.$t('noAudioTrackSelected');
-        if (this.type === 'Subtitle' && this.tracks.length === 0)
+        }
+        if (this.type === 'Subtitle' && this.tracks.length === 0) {
           return this.$t('noSubtitlesAvailable');
-        if (this.type === 'Subtitle' && this.tracks.length !== 0)
+        }
+        if (this.type === 'Subtitle' && this.tracks.length !== 0) {
           return this.$t('noSubtitleSelected');
-        if (this.type === 'Video' && this.tracks.length === 0)
+        }
+        if (this.type === 'Video' && this.tracks.length === 0) {
           return this.$t('noVideoTracksAvailable');
-        if (this.type === 'Video' && this.tracks.length !== 0)
+        }
+        if (this.type === 'Video' && this.tracks.length !== 0) {
           return this.$t('noVideoTrackSelected');
+        }
         return this.$t('noTracksAvailable');
       }
     },
@@ -156,8 +168,11 @@ export default Vue.extend({
     defaultIndex: {
       get(): number | undefined {
         const defaultTrack = this.tracks.findIndex((track) => track.IsDefault);
-        if (defaultTrack !== -1) return defaultTrack;
-        else if (this.type === 'Subtitle') return undefined;
+        if (defaultTrack !== -1) {
+          return defaultTrack;
+        } else if (this.type === 'Subtitle') {
+          return undefined;
+        }
         return 0;
       }
     }
@@ -194,7 +209,9 @@ export default Vue.extend({
      * @returns {string} Text to display in select when track is choosen
      */
     getTrackSelection(track: MediaStream): string {
-      if (track.DisplayTitle) return track.DisplayTitle;
+      if (track.DisplayTitle) {
+        return track.DisplayTitle;
+      }
       return '';
     },
     /**
@@ -202,8 +219,9 @@ export default Vue.extend({
      * @returns {string|undefined} Optional icon to use for the track line in the v-select menu
      */
     getTrackIcon(track: MediaStream): string | undefined {
-      if (this.type === 'Audio' && track.ChannelLayout)
+      if (this.type === 'Audio' && track.ChannelLayout) {
         return this.getSurroundIcon(track.ChannelLayout);
+      }
       return undefined;
     },
     /**
@@ -211,7 +229,9 @@ export default Vue.extend({
      * @returns {string} Text to use for the track line in the v-select menu
      */
     getTrackTitle(track: MediaStream): string {
-      if (track.DisplayTitle) return track.DisplayTitle;
+      if (track.DisplayTitle) {
+        return track.DisplayTitle;
+      }
       return '';
     },
     /**
@@ -219,10 +239,14 @@ export default Vue.extend({
      * @returns {string|undefined} Optional subtitle to use for the track line in the v-select menu
      */
     getTrackSubtitle(track: MediaStream): string | undefined {
-      if ((this.type === 'Audio' || this.type === 'Subtitle') && track.Language)
+      if (
+        (this.type === 'Audio' || this.type === 'Subtitle') &&
+        track.Language
+      ) {
         return this.getLanguageName(track.Language);
-      else if (this.type === 'Audio' || this.type === 'Subtitle')
+      } else if (this.type === 'Audio' || this.type === 'Subtitle') {
         return this.$t('undefined');
+      }
 
       return undefined;
     },

--- a/components/Players/PlayerDialog.vue
+++ b/components/Players/PlayerDialog.vue
@@ -17,8 +17,9 @@ export default Vue.extend({
           ) ||
           // https://github.com/vuetifyjs/vuetify/issues/4715
           (e.target as HTMLElement).isContentEditable
-        )
+        ) {
           return;
+        }
 
         const up = [keyCodes.up, keyCodes.pageup];
         const down = [keyCodes.down, keyCodes.pagedown];

--- a/package.json
+++ b/package.json
@@ -52,10 +52,13 @@
     "swiper": "5.x",
     "uuid": "^8.3.2",
     "vee-validate": "^3.4.5",
+    "vue": "^2.6.12",
     "vue-awesome-swiper": "^4.1.1",
     "vue-native-websocket": "^2.0.14",
     "vue-virtual-scroller": "^1.0.10",
     "vuedraggable": "^2.24.3",
+    "vuetify": "^2.4.5",
+    "vuex": "^3.6.2",
     "vuex-persistedstate": "^4.0.0-beta.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "@types/uuid": "^8.3.0",
     "@types/wicg-mediasession": "^1.1.0",
     "@vue/test-utils": "^1.1.3",
+    "axe": "^8.0.0",
     "axe-core": "^4.1.3",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "^10.1.0",

--- a/pages/item/_itemId/index.vue
+++ b/pages/item/_itemId/index.vue
@@ -319,8 +319,9 @@ export default Vue.extend({
 
     let currentSource: MediaSourceInfo = {};
 
-    if (item.MediaSources && item.MediaSources.length > 0)
+    if (item.MediaSources && item.MediaSources.length > 0) {
       currentSource = item.MediaSources[0];
+    }
 
     return {
       item,

--- a/pages/series/_itemId/index.vue
+++ b/pages/series/_itemId/index.vue
@@ -217,8 +217,9 @@ export default Vue.extend({
 
     let currentSource: MediaSourceInfo = {};
 
-    if (item.MediaSources && item.MediaSources.length > 0)
+    if (item.MediaSources && item.MediaSources.length > 0) {
       currentSource = item.MediaSources[0];
+    }
 
     return {
       item,

--- a/pages/wizard.vue
+++ b/pages/wizard.vue
@@ -135,12 +135,16 @@ export default Vue.extend({
       }
     },
     changeStep({ step }: { step: number }): void {
-      if (step === 4) this.completeWizard();
-      else this.wizardStage += 1;
+      if (step === 4) {
+        this.completeWizard();
+      } else {
+        this.wizardStage += 1;
+      }
 
       // This allows the return to previous steps, but not going forward past incomplete steps
-      if (this.wizardStage > this.maxWizardStage)
+      if (this.wizardStage > this.maxWizardStage) {
         this.maxWizardStage = this.wizardStage;
+      }
     },
     previousStep(): void {
       this.wizardStage -= 1;

--- a/schemes/jellyfinScheme.ts
+++ b/schemes/jellyfinScheme.ts
@@ -127,7 +127,9 @@ export default class JellyfinScheme {
     // Fetch the user, then set it in Nuxt Auth
     const user = (await this.$auth.ctx.app.$api.user.getCurrentUser()).data;
 
-    if (!user.Id) this.logout();
+    if (!user.Id) {
+      this.logout();
+    }
 
     this.$auth.setUser(user);
     await this.$auth.ctx.app.store.dispatch('displayPreferences/initState');

--- a/store/displayPreferences.ts
+++ b/store/displayPreferences.ts
@@ -32,18 +32,22 @@ const defaultState = (): DisplayPreferencesState => ({
  */
 const updateMethods: { [key: string]: (value: string) => void } = {
   darkMode: (value: string) => {
-    if (window.$nuxt) window.$nuxt.$vuetify.theme.dark = stringToBoolean(value);
+    if (window.$nuxt) {
+      window.$nuxt.$vuetify.theme.dark = stringToBoolean(value);
+    }
   },
 
   locale: (value: string) => {
     if (window.$nuxt) {
-      if (value !== 'auto') window.$nuxt.$i18n.setLocale(value);
-      else
+      if (value !== 'auto') {
+        window.$nuxt.$i18n.setLocale(value);
+      } else {
         window.$nuxt.$i18n.setLocale(
           window.$nuxt.$i18n.getBrowserLocale() ||
             window.$nuxt.$i18n.defaultLocale ||
             'en'
         );
+      }
     }
   }
 };
@@ -110,7 +114,9 @@ export const mutations: MutationTree<DisplayPreferencesState> = {
     { pref }: { pref: SingleCustomPrefMutationPayload }
   ) {
     Vue.set(state.CustomPrefs, pref.key, pref.value);
-    if (pref.key in updateMethods) updateMethods[pref.key](pref.value);
+    if (pref.key in updateMethods) {
+      updateMethods[pref.key](pref.value);
+    }
   }
 };
 
@@ -134,10 +140,11 @@ export const actions: ActionTree<
         }
       );
 
-      if (response.status !== 200)
+      if (response.status !== 200) {
         throw new Error(
           'get display preferences status response = ' + response.status
         );
+      }
 
       await dispatch('initStateSuccess', { displayPreferences: response.data });
     } catch (error) {
@@ -192,10 +199,11 @@ export const actions: ActionTree<
           displayPreferencesDto: state
         }
       );
-      if (response.status !== 204)
+      if (response.status !== 204) {
         throw new Error(
           'set display preferences status response = ' + response.status
         );
+      }
       await dispatch('pushStateSuccess');
     } catch (error) {
       await dispatch('pushStateFailure', { error });
@@ -236,7 +244,9 @@ export const actions: ActionTree<
     { key, value }: { key: string; value: string }
   ) {
     commit('EDIT_CUSTOM_PREF', { pref: { key, value } });
-    if (this.$auth.loggedIn) await dispatch('pushState');
+    if (this.$auth.loggedIn) {
+      await dispatch('pushState');
+    }
   },
 
   /**
@@ -275,7 +285,9 @@ export const actions: ActionTree<
    */
   callAllCallbacks({ state }) {
     Object.keys(state.CustomPrefs).forEach((key) => {
-      if (key in updateMethods) updateMethods[key](state.CustomPrefs[key]);
+      if (key in updateMethods) {
+        updateMethods[key](state.CustomPrefs[key]);
+      }
     });
   },
 

--- a/utils/playbackProfiles/helpers/codecProfiles.ts
+++ b/utils/playbackProfiles/helpers/codecProfiles.ts
@@ -32,9 +32,15 @@ function getGlobalMaxVideoBitrate(): number | null {
   // TODO: These valus are taken directly from Jellyfin-web.
   // The source of them needs to be investigated.
 
-  if (browserDetector.isPs4()) return 8000000;
-  if (browserDetector.isXbox()) return 12000000;
-  if (browserDetector.isTizen && isTizenFhd) return 20000000;
+  if (browserDetector.isPs4()) {
+    return 8000000;
+  }
+  if (browserDetector.isXbox()) {
+    return 12000000;
+  }
+  if (browserDetector.isTizen && isTizenFhd) {
+    return 20000000;
+  }
   return null;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14091,6 +14091,11 @@ vuetify@^2.4.2:
   resolved "https://registry.npmjs.org/vuetify/-/vuetify-2.4.4.tgz#529de23b6b0c65ccfd43fe11f0f3a8a0333e68e6"
   integrity sha512-/4+xX9XbcwXBjrtptDxm5S4NXVaVGF8UJ3U7Nk20fl4aM84PGgGyqVCfi8hVa8t1gd+2Wz4FCztbR7JgJcBIQQ==
 
+vuetify@^2.4.5:
+  version "2.4.5"
+  resolved "https://registry.npmjs.org/vuetify/-/vuetify-2.4.5.tgz#86de190720d25511df9be37ff3c16a568972fc2d"
+  integrity sha512-P4bN9xwyU91Iq1iW/XBCzgVMQ9fHG0HgJeiPDRoHzC0fX6ZPYBZIN6xPCuoG7zLyGSSoc6JnQqnO7H5mPEsVuA==
+
 vuex-persistedstate@^4.0.0-beta.3:
   version "4.0.0-beta.3"
   resolved "https://registry.npmjs.org/vuex-persistedstate/-/vuex-persistedstate-4.0.0-beta.3.tgz#89dd712de72d28e85cc95467d066002c1405f277"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1430,6 +1430,11 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
+"@ladjs/format-util@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.npmjs.org/@ladjs/format-util/-/format-util-1.0.4.tgz#dd16ecee7b9d1deb56e1a4968dc5e9ac54499df3"
+  integrity sha512-hZere0rUga8kTzSTFbHREXpD9E/jwi94+B5RyLAmMIzl/w/EK1z7rFEnMHzPkU4AZkL42JWSsGXoV8LXMihybg==
+
 "@mdi/font@^5.9.55":
   version "5.9.55"
   resolved "https://registry.npmjs.org/@mdi/font/-/font-5.9.55.tgz#41acd50b88073ded7095fc3029d8712b6e12f38e"
@@ -3165,6 +3170,23 @@ axe-core@^4.1.3:
   resolved "https://registry.npmjs.org/axe-core/-/axe-core-4.1.3.tgz#64a4c85509e0991f5168340edc4bedd1ceea6966"
   integrity sha512-vwPpH4Aj4122EW38mxO/fxhGKtwWTMLDIJfZ1He0Edbtjcfna/R3YB67yVhezUMzqc3Jr3+Ii50KRntlENL4xQ==
 
+axe@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.npmjs.org/axe/-/axe-8.0.0.tgz#cd1be48899ec6afb0fa21fb869b59035994885f3"
+  integrity sha512-JZGXiErVcTp6inY3xKUfYwq49XTeC2e8y3JJgfaAv5K/L+6Is2FcgnqZcBWQg39ts6tbBjDho/mP30RFy4h9Ag==
+  dependencies:
+    "@ladjs/format-util" "^1.0.4"
+    boolean "^3.0.2"
+    console-polyfill "^0.3.0"
+    cuid "^2.1.8"
+    fast-safe-stringify "^2.0.7"
+    format-specifiers "^1.0.0"
+    iserror "^0.0.2"
+    lodash.omit "^4.5.0"
+    parse-app-info "^4.0.2"
+    parse-err "^0.0.12"
+    superagent "^6.1.0"
+
 axios-retry@^3.1.9:
   version "3.1.9"
   resolved "https://registry.npmjs.org/axios-retry/-/axios-retry-3.1.9.tgz#6c30fc9aeb4519aebaec758b90ef56fa03fe72e8"
@@ -3541,6 +3563,11 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
+
+boolean@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.npmjs.org/boolean/-/boolean-3.0.2.tgz#df1baa18b6a2b0e70840475e1d93ec8fe75b2570"
+  integrity sha512-RwywHlpCRc3/Wh81MiCKun4ydaIFyW5Ea6JbL6sRCVx5q5irDw7pMXBUFYF/jArQ6YrG36q0kpovc9P/Kd3I4g==
 
 boxen@^5.0.0:
   version "5.0.0"
@@ -4304,7 +4331,7 @@ colorette@^1.2.1:
   resolved "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz#4d0b921325c14faf92633086a536db6e89564b1b"
   integrity sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==
 
-combined-stream@^1.0.6, combined-stream@~1.0.6:
+combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
@@ -4384,7 +4411,7 @@ compare-versions@^3.6.0:
   resolved "https://registry.npmjs.org/compare-versions/-/compare-versions-3.6.0.tgz#1a5689913685e5a87637b8d3ffca75514ec41d62"
   integrity sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==
 
-component-emitter@^1.2.1:
+component-emitter@^1.2.1, component-emitter@^1.3.0:
   version "1.3.0"
   resolved "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
   integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
@@ -4460,6 +4487,11 @@ console-browserify@^1.1.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz#67063cef57ceb6cf4993a2ab3a55840ae8c49336"
   integrity sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==
+
+console-polyfill@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.npmjs.org/console-polyfill/-/console-polyfill-0.3.0.tgz#84900902a18c47a5eba932be75fa44d23e8af861"
+  integrity sha512-w+JSDZS7XML43Xnwo2x5O5vxB0ID7T5BdqDtyqT6uiCAX2kZAgcWxNaGqT97tZfSHzfOcvrfsDAodKcJ3UvnXQ==
 
 console-stream@^0.1.1:
   version "0.1.1"
@@ -4546,6 +4578,11 @@ cookie@^0.4.0, cookie@^0.4.1:
   version "0.4.1"
   resolved "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz#afd713fe26ebd21ba95ceb61f9a8116e50a537d1"
   integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
+
+cookiejar@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz#dd8a235530752f988f9a0844f3fc589e3111125c"
+  integrity sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==
 
 copy-concurrently@^1.0.0:
   version "1.0.5"
@@ -4918,6 +4955,11 @@ cssstyle@^2.2.0:
   integrity sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==
   dependencies:
     cssom "~0.3.6"
+
+cuid@^2.1.8:
+  version "2.1.8"
+  resolved "https://registry.npmjs.org/cuid/-/cuid-2.1.8.tgz#cbb88f954171e0d5747606c0139fb65c5101eac0"
+  integrity sha512-xiEMER6E7TlTPnDxrM4eRiC6TRgjNX9xzEZ5U/Se2YJKr7Mq4pJn/2XEHjl3STcSh96GmkHPcBXLES8M29wyyg==
 
 cuint@^0.2.2:
   version "0.2.2"
@@ -5357,6 +5399,13 @@ dotenv@^8.2.0:
   version "8.2.0"
   resolved "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
   integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
+
+dotgitconfig@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/dotgitconfig/-/dotgitconfig-1.1.1.tgz#0e854a409f005c48bf820825e94f05215db41ed0"
+  integrity sha512-gkaAQMmhlE7N6NYtvckQ32f/xTX6Hv7RTtF9qKCYJEQgL/d6zJZk/D0eLFuuGPRCbpRj2PR/HcBLxtIh3MSB6Q==
+  dependencies:
+    ini "^1.3.5"
 
 download@^6.2.2:
   version "6.2.5"
@@ -6211,6 +6260,11 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   resolved "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
+fast-safe-stringify@^2.0.7:
+  version "2.0.7"
+  resolved "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz#124aa885899261f68aedb42a7c080de9da608743"
+  integrity sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==
+
 fastest-levenshtein@^1.0.12:
   version "1.0.12"
   resolved "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz#9990f7d3a88cc5a9ffd1f1745745251700d497e2"
@@ -6533,6 +6587,15 @@ fork-ts-checker-webpack-plugin@^6.1.0:
     semver "^7.3.2"
     tapable "^1.0.0"
 
+form-data@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
+  integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
 form-data@~2.3.2:
   version "2.3.3"
   resolved "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
@@ -6541,6 +6604,16 @@ form-data@~2.3.2:
     asynckit "^0.4.0"
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
+
+format-specifiers@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/format-specifiers/-/format-specifiers-1.0.0.tgz#75df845916598b3472a6f60000284ad94ccf6f55"
+  integrity sha512-/xcmy6xn/DsR+V6flFj3E47yCbrsk70r90moAMENVkKckUPUG9CRE79S/2xajLVx1iADIoWx+1R304uMXB/riQ==
+
+formidable@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.npmjs.org/formidable/-/formidable-1.2.2.tgz#bf69aea2972982675f00865342b982986f6b8dd9"
+  integrity sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q==
 
 fragment-cache@^0.2.1:
   version "0.2.1"
@@ -8032,6 +8105,11 @@ isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   resolved "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
 
+iserror@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.npmjs.org/iserror/-/iserror-0.0.2.tgz#bd53451fe2f668b9f2402c1966787aaa2c7c0bf5"
+  integrity sha1-vVNFH+L2aLnyQCwZZnh6qix8C/U=
+
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
@@ -8753,6 +8831,13 @@ last-call-webpack-plugin@^3.0.0:
     lodash "^4.17.5"
     webpack-sources "^1.1.0"
 
+last-commit-log@^3.0.4:
+  version "3.1.1"
+  resolved "https://registry.npmjs.org/last-commit-log/-/last-commit-log-3.1.1.tgz#bd44195f795c69ae61b18f09d2460e41a15a59d3"
+  integrity sha512-UodrtHrAC9v+saELwRPRBsQolp/LnIdJcqqFZ6RuMRkAwXFiZyJce2ioabn5mY3seJUrSdn70k3gqACrtPiIMg==
+  dependencies:
+    dotgitconfig "^1.1.0"
+
 launch-editor-middleware@^2.2.1:
   version "2.2.1"
   resolved "https://registry.npmjs.org/launch-editor-middleware/-/launch-editor-middleware-2.2.1.tgz#e14b07e6c7154b0a4b86a0fd345784e45804c157"
@@ -8938,6 +9023,11 @@ lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
+
+lodash.omit@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz#6eb19ae5a1ee1dd9df0b969e66ce0b7fa30b5e60"
+  integrity sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA=
 
 lodash.sortby@^4.7.0:
   version "4.7.0"
@@ -9307,6 +9397,11 @@ merge@^1.2.1:
   resolved "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz#38bebf80c3220a8a487b6fcfb3941bb11720c145"
   integrity sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==
 
+methods@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
+  integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
+
 micromark@~2.11.0:
   version "2.11.4"
   resolved "https://registry.npmjs.org/micromark/-/micromark-2.11.4.tgz#d13436138eea826383e822449c9a5c50ee44665a"
@@ -9367,7 +9462,7 @@ mime@1.6.0:
   resolved "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
-mime@^2.3.1:
+mime@^2.3.1, mime@^2.4.6:
   version "2.5.2"
   resolved "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz#6e3dc6cc2b9510643830e5f19d5cb753da5eeabe"
   integrity sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==
@@ -10264,6 +10359,17 @@ parent-module@^1.0.0:
   dependencies:
     callsites "^3.0.0"
 
+parse-app-info@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.npmjs.org/parse-app-info/-/parse-app-info-4.0.2.tgz#29def0399df86fcb79018c6ea4b0dad5b50f9b38"
+  integrity sha512-L+ZMasW/MnCKHYncUQhj0mkkngqvK/FGzZPEGxjvCbpZpVtKvUgpXhe3c0xNqWRbvez9h12x3e3W/gweNHtTlg==
+  dependencies:
+    debug "^4.3.1"
+    last-commit-log "^3.0.4"
+    lodash "^4.17.20"
+    read-pkg-up "^7.0.1"
+    semver "^7.3.2"
+
 parse-asn1@^5.0.0, parse-asn1@^5.1.5:
   version "5.1.6"
   resolved "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.6.tgz#385080a3ec13cb62a62d39409cb3e88844cdaed4"
@@ -10286,6 +10392,13 @@ parse-entities@^2.0.0:
     is-alphanumerical "^1.0.0"
     is-decimal "^1.0.0"
     is-hexadecimal "^1.0.0"
+
+parse-err@^0.0.12:
+  version "0.0.12"
+  resolved "https://registry.npmjs.org/parse-err/-/parse-err-0.0.12.tgz#5e6f98b183dd4151fb6e1d2ca7e15d931b6658cb"
+  integrity sha512-q9bGpXmSFfTCAoz0/YfZB62p73h3SXP4YpZNnVHQXC9svNSrhZtzqubqtztL37YWmMsdINHOMimg8aC1EKNg7g==
+  dependencies:
+    iserror "^0.0.2"
 
 parse-git-config@^3.0.0:
   version "3.0.0"
@@ -13019,6 +13132,23 @@ sugarss@^2.0.0:
   integrity sha512-WfxjozUk0UVA4jm+U1d736AUpzSrNsQcIbyOkoE364GrtWmIrFdk5lksEupgWMD4VaT/0kVx1dobpiDumSgmJQ==
   dependencies:
     postcss "^7.0.2"
+
+superagent@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.npmjs.org/superagent/-/superagent-6.1.0.tgz#09f08807bc41108ef164cfb4be293cebd480f4a6"
+  integrity sha512-OUDHEssirmplo3F+1HWKUrUjvnQuA+nZI6i/JJBdXb5eq9IyEQwPyPpqND+SSsxf6TygpBEkUjISVRN4/VOpeg==
+  dependencies:
+    component-emitter "^1.3.0"
+    cookiejar "^2.1.2"
+    debug "^4.1.1"
+    fast-safe-stringify "^2.0.7"
+    form-data "^3.0.0"
+    formidable "^1.2.2"
+    methods "^1.1.2"
+    mime "^2.4.6"
+    qs "^6.9.4"
+    readable-stream "^3.6.0"
+    semver "^7.3.2"
 
 supports-color@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This aims to reduce our amount of code smells a bit:

* It adds explicit dependencies for modules we import that weren't in our dependencies before (Vue, Vuetify, Vuex, Axe, etc). This gives us a bit more control over which versions we may want, but also makes it clearer that we directly depend on these.
* It adds the `curly` rule to ESLint. This prevents usage of if statements without curly braces. The reasoning behind this is that this syntax, while allowed in JavaScript and TypeScript, can be confusing at a glance. This rule makes blocks more obvious, leading to less potential for mistakes.