### PR TITLE
fix(snackbar): display the string instead of translating it

### DIFF
--- a/components/System/Snackbar.vue
+++ b/components/System/Snackbar.vue
@@ -1,6 +1,6 @@
 <template>
   <v-snackbar v-model="model" app :color="color" bottom left>
-    {{ $t(message) }}
+    {{ message }}
   </v-snackbar>
 </template>
 


### PR DESCRIPTION
Everywhere in the code base, we pass already translated string to the snackbar store and therefore
the snackbar component. But this one tried to translate it, and of course it didn't work. Visually
there wasn't a problem as i18n displays the strings as is when it doesn't find them, but it's a bug
nonetheless.

fix #765