### PR TITLE
ci(actions): mark always as successful labeling and organization workflows

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -7,5 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/labeler@main
+        continue-on-error: true
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: alex-page/github-project-automation-plus@v0.5.1
+        continue-on-error: true
         with:
           project: Ongoing development
           column: In progress


### PR DESCRIPTION
Some commits to master and PRs are being marked  with error marks due to the organization workflows failing (probably because GitHub API outages or changes). This clutters and makes it more difficult to differentiate the real PRs that are having check issues.