### PR TITLE
Improve page navigation and refactor home screen

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -98,7 +98,7 @@
     </v-app-bar>
     <v-main>
       <div class="pa-s">
-        <nuxt />
+        <nuxt keep-alive :keep-alive-props="{ max: 10 }" />
       </div>
     </v-main>
     <audio-controls />

--- a/layouts/fullpage.vue
+++ b/layouts/fullpage.vue
@@ -1,7 +1,7 @@
 <template>
   <v-app>
     <v-main>
-      <nuxt />
+      <nuxt keep-alive :keep-alive-props="{ max: 10 }" />
     </v-main>
     <v-footer app color="rgba(0, 0, 0, 0)">
       <locale-switcher large top />

--- a/store/homeSection.ts
+++ b/store/homeSection.ts
@@ -10,7 +10,7 @@ import { AppState } from './index';
 
 export interface HomeSection {
   name: string;
-  libraryName: string | undefined;
+  libraryName?: string | null | undefined;
   libraryId: string;
   shape: string;
   type: string;


### PR DESCRIPTION
* Adds `keep-alive` prop to the Nuxt root component, in order to keep some pages in memory, which improved the navigation experience.
  This should eventually be coupled with using `fetch()` for all the data fetching around the app, and the use of the `activated` hook with a timestamp check, in order to refresh stale data upon navigation after a certain time (likely after 30s).

https://user-images.githubusercontent.com/19396809/111021546-720e3480-83cd-11eb-8464-4d342838da74.mp4

* Move the data fetching logic of the home page to the `fetch()` hook.