### PR TITLE
ci: use the jellyfin-bot token for Github Actions

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,4 +1,4 @@
-name: "Label pull requests"
+name: 'Label pull requests'
 on:
   - pull_request_target
 
@@ -9,4 +9,4 @@ jobs:
       - uses: actions/labeler@main
         continue-on-error: true
         with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          repo-token: '${{ secrets.GH_TOKEN }}'

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -6,7 +6,7 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@main
+      - uses: actions/labeler@v3
         continue-on-error: true
         with:
           repo-token: '${{ secrets.GH_TOKEN }}'

--- a/.github/workflows/merge-conflicts.yml
+++ b/.github/workflows/merge-conflicts.yml
@@ -1,4 +1,4 @@
-name: "Merge Conflicts"
+name: 'Merge Conflicts'
 
 on:
   push:
@@ -11,5 +11,5 @@ jobs:
     steps:
       - uses: mschilde/auto-label-merge-conflicts@master
         with:
-          CONFLICT_LABEL_NAME: "merge conflict"
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CONFLICT_LABEL_NAME: 'merge conflict'
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/merge-conflicts.yml
+++ b/.github/workflows/merge-conflicts.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'jellyfin/jellyfin-vue'
     steps:
-      - uses: mschilde/auto-label-merge-conflicts@master
+      - uses: mschilde/auto-label-merge-conflicts@v2
         with:
           CONFLICT_LABEL_NAME: 'merge conflict'
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
A few of the actions (labeler and the merge conflicts one) show up as `github-actions` while they should be `jellyfin-bot` for consistency.