### PR TITLE
feat(pages): validate item IDs when navigating to the pages

### DIFF
--- a/pages/artist/_itemId/index.vue
+++ b/pages/artist/_itemId/index.vue
@@ -114,13 +114,18 @@
 import Vue from 'vue';
 import { mapActions } from 'vuex';
 import { BaseItemDto, ImageType } from '@jellyfin/client-axios';
+import { Context } from '@nuxt/types';
 import htmlHelper from '~/mixins/htmlHelper';
 import imageHelper from '~/mixins/imageHelper';
 import timeUtils from '~/mixins/timeUtils';
 import itemHelper from '~/mixins/itemHelper';
+import { isValidMD5 } from '~/utils/items';
 
 export default Vue.extend({
   mixins: [htmlHelper, imageHelper, timeUtils, itemHelper],
+  validate(ctx: Context) {
+    return isValidMD5(ctx.route.params.itemId);
+  },
   async asyncData({ params, $api, $auth }) {
     const item = (
       await $api.userLibrary.getItem({

--- a/pages/genre/_itemId/index.vue
+++ b/pages/genre/_itemId/index.vue
@@ -49,8 +49,13 @@
 import Vue from 'vue';
 import { mapActions } from 'vuex';
 import { BaseItemDto } from '@jellyfin/client-axios';
+import { Context } from '@nuxt/types';
+import { isValidMD5 } from '~/utils/items';
 
 export default Vue.extend({
+  validate(ctx: Context) {
+    return isValidMD5(ctx.route.params.itemId);
+  },
   async asyncData({ params, $api, $auth }) {
     const genre = (
       await $api.userLibrary.getItem({

--- a/pages/item/_itemId/index.vue
+++ b/pages/item/_itemId/index.vue
@@ -288,9 +288,11 @@ import {
   ImageType,
   MediaSourceInfo
 } from '@jellyfin/client-axios';
+import { Context } from '@nuxt/types';
 import imageHelper from '~/mixins/imageHelper';
 import formsHelper from '~/mixins/formsHelper';
 import itemHelper from '~/mixins/itemHelper';
+import { isValidMD5 } from '~/utils/items';
 
 interface TwoColsInfoColumn {
   lCols: number;
@@ -302,6 +304,9 @@ interface TwoColsInfoColumn {
 
 export default Vue.extend({
   mixins: [imageHelper, formsHelper, itemHelper],
+  validate(ctx: Context) {
+    return isValidMD5(ctx.route.params.itemId);
+  },
   async asyncData({ params, $api, $auth }) {
     const item = (
       await $api.userLibrary.getItem({

--- a/pages/library/_viewId.vue
+++ b/pages/library/_viewId.vue
@@ -52,9 +52,13 @@
 import Vue from 'vue';
 import { mapActions } from 'vuex';
 import { BaseItemDto } from '@jellyfin/client-axios';
-import { validLibraryTypes } from '~/utils/items';
+import { Context } from '@nuxt/types';
+import { isValidMD5, validLibraryTypes } from '~/utils/items';
 
 export default Vue.extend({
+  validate(ctx: Context) {
+    return isValidMD5(ctx.route.params.viewId);
+  },
   async asyncData({ params, $api, $auth }) {
     const collectionInfo = (
       await $api.items.getItems({

--- a/pages/musicalbum/_itemId/index.vue
+++ b/pages/musicalbum/_itemId/index.vue
@@ -97,9 +97,11 @@
 import Vue from 'vue';
 import { mapActions } from 'vuex';
 import { BaseItemDto, ImageType } from '@jellyfin/client-axios';
+import { Context } from '@nuxt/types';
 import imageHelper from '~/mixins/imageHelper';
 import formsHelper from '~/mixins/formsHelper';
 import itemHelper from '~/mixins/itemHelper';
+import { isValidMD5 } from '~/utils/items';
 
 interface TwoColsInfoColumn {
   lCols: number;
@@ -111,6 +113,9 @@ interface TwoColsInfoColumn {
 
 export default Vue.extend({
   mixins: [imageHelper, formsHelper, itemHelper],
+  validate(ctx: Context) {
+    return isValidMD5(ctx.route.params.itemId);
+  },
   async asyncData({ params, $api, $auth }) {
     const item = (
       await $api.userLibrary.getItem({

--- a/pages/person/_itemId/index.vue
+++ b/pages/person/_itemId/index.vue
@@ -75,11 +75,16 @@
 import Vue from 'vue';
 import { mapActions } from 'vuex';
 import { BaseItemDto, ImageType } from '@jellyfin/client-axios';
+import { Context } from '@nuxt/types';
 import imageHelper from '~/mixins/imageHelper';
 import timeUtils from '~/mixins/timeUtils';
+import { isValidMD5 } from '~/utils/items';
 
 export default Vue.extend({
   mixins: [imageHelper, timeUtils],
+  validate(ctx: Context) {
+    return isValidMD5(ctx.route.params.itemId);
+  },
   async asyncData({ params, $api, $auth }) {
     const item = (
       await $api.userLibrary.getItem({

--- a/pages/series/_itemId/index.vue
+++ b/pages/series/_itemId/index.vue
@@ -177,9 +177,11 @@ import {
   ImageType,
   MediaSourceInfo
 } from '@jellyfin/client-axios';
+import { Context } from '@nuxt/types';
 import imageHelper from '~/mixins/imageHelper';
 import formsHelper from '~/mixins/formsHelper';
 import itemHelper from '~/mixins/itemHelper';
+import { isValidMD5 } from '~/utils/items';
 
 interface TwoColsInfoColumn {
   lCols: number;
@@ -191,6 +193,9 @@ interface TwoColsInfoColumn {
 
 export default Vue.extend({
   mixins: [imageHelper, formsHelper, itemHelper],
+  validate(ctx: Context) {
+    return isValidMD5(ctx.route.params.itemId);
+  },
   async asyncData({ params, $api, $auth }) {
     const item = (
       await $api.userLibrary.getItem({

--- a/utils/items.ts
+++ b/utils/items.ts
@@ -10,6 +10,17 @@ export const validLibraryTypes = [
 ];
 
 /**
+ * Checks if the string is a valid MD5 hash.
+ *
+ * @exports
+ * @param {string} input - The string to check for validity
+ * @returns {boolean} - A boolean representing the validity of the input string
+ */
+export function isValidMD5(input: string): boolean {
+  return /[a-fA-F0-9]{32}/.test(input);
+}
+
+/**
  * Get the Material Design Icon name associated with a type of library
  *
  * @param {(string | undefined | null)} libraryType - Type of the library


### PR DESCRIPTION
Our item IDs are MD5 hashes in v10, so this isn't doing proper UUID checks but a basic MD5 validity
check.