### PR TITLE
build(docker): restore dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,37 @@
+# Dockerfile
+Dockerfile
+Dockerfile.static
+
+# Coverage directory used by tools like istanbul
+coverage
+
+# Dependency directories
+node_modules/
+
+# Optional npm cache directory
+.npm
+
+# Optional eslint cache
+.eslintcache
+
+# Output of 'npm pack'
+*.tgz
+
+# dotenv environment variables file
+.env
+
+# IDE / Editor
+.idea
+.run
+.vscode
+
+# macOS
+.DS_Store
+
+# Vim swap files
+*.swp
+
+# Github & CI
+.github
+.devcontainer
+.ci


### PR DESCRIPTION
The Dockerfile was wrongly removed in #767 .

This makes building the docker images locally unnecessarily long (due to copying node_modules then removing it by running `npm ci`) and copies unnecessary stuff on the CI.

This restores the original file, and cleans it up a bit.