### PR TITLE
fix(docker): fix dockerfile not building the SSR version properly

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -37,7 +37,7 @@ jobs:
         run: npm ci --no-audit
 
       - name: Build client
-        run: npm run build --production --standalone
+        run: npm run build:standalone
 
       - name: Configure QEMU
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -37,7 +37,7 @@ jobs:
         run: npm ci --no-audit
 
       - name: Build client
-        run: npm run build:standalone
+        run: 'npm run build:standalone'
 
       - name: Configure QEMU
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,7 +44,7 @@ jobs:
         run: npm ci --no-audit
 
       - name: Build client
-        run: npm run build --production --standalone
+        run: npm run build:standalone
 
       - name: Configure QEMU
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,7 +44,7 @@ jobs:
         run: npm ci --no-audit
 
       - name: Build client
-        run: npm run build:standalone
+        run: 'npm run build:standalone'
 
       - name: Configure QEMU
         uses: docker/setup-qemu-action@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,7 @@ COPY . .
 RUN npm ci --no-audit
 
 # Build SSR app for production in standalone mode
-
-RUN npm run build --production --standalone
+RUN npm run build:standalone
 
 # Build final image
 FROM node:14-alpine

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ When using the SSR version of the client, you can run the client in standalone m
 $ npm install
 
 # build for production in standalone mode, with server-side rendering
-$ npm run build --standalone
+$ npm run build:standalone
 
 # move the server and required files to a dedicated directory
 $ mkdir -p /opt/jellyfin-vue

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "NUXT_SSR=1 nuxt",
     "dev:static": "nuxt",
     "build": "NUXT_SSR=1 nuxt build",
+    "build:standalone": "NUXT_SSR=1 nuxt build --standalone",
     "build:static": "nuxt build",
     "prod": "npm run build && npm run start",
     "prod:static": "npm run build:static && npm run start:static",


### PR DESCRIPTION
For some reason, npm wasn't passing down the standalone flag to nuxt-build. As a result, dependencies weren't bundled anymore, leading to errors when trying to run it.

This adds a dedicated standalone build command to avoid having to pass down flags.