### PR TITLE
feat(clickable-artist): add link to card-subtitle

### DIFF
--- a/components/Item/Card/Card.vue
+++ b/components/Item/Card/Card.vue
@@ -71,7 +71,15 @@
       </div>
       <div v-if="text" class="card-text">
         <div class="card-title mt-1 text-truncate">{{ cardTitle }}</div>
-        <div class="card-subtitle text--secondary text-truncate">
+        <nuxt-link
+          v-if="item.Type === 'MusicAlbum'"
+          tag="div"
+          class="card-subtitle text--secondary text-truncate link"
+          :to="getItemDetailsLink(item.AlbumArtists[0], 'MusicArtist')"
+        >
+          {{ cardSubtitle }}
+        </nuxt-link>
+        <div v-else class="card-subtitle text--secondary text-truncate">
           {{ cardSubtitle }}
         </div>
       </div>


### PR DESCRIPTION
Make the artist name in the item subtitle clickable. fix https://github.com/jellyfin/jellyfin-vue/issues/835. 

I'm not sure if this is the most elegant solution though. The display: block is necessary, since the nuxt-link element sets it to inline and it gets shifted ever so slightly down.