### PR TITLE
refactor(like-button): remove color on the like button

### DIFF
--- a/components/Buttons/LikeButton.vue
+++ b/components/Buttons/LikeButton.vue
@@ -1,8 +1,7 @@
 <template>
   <v-btn :dark="dark" icon @click.stop.prevent="toggleFavorite">
-    <v-icon :class="isFavorite ? 'red--text' : ''">
-      {{ isFavorite ? 'mdi-heart' : 'mdi-heart-outline' }}
-    </v-icon>
+    <v-icon v-if="isFavorite">mdi-heart</v-icon>
+    <v-icon v-else>mdi-heart-outline</v-icon>
   </v-btn>
 </template>
 

--- a/components/Buttons/__tests__/LikeButton.spec.ts
+++ b/components/Buttons/__tests__/LikeButton.spec.ts
@@ -41,7 +41,6 @@ describe('component: LikeButton', () => {
     expect(wrapper.find('.mdi').exists()).toBe(true);
     expect(wrapper.find('.mdi-heart').exists()).toBe(true);
     expect(wrapper.find('.v-btn--icon').exists()).toBe(true);
-    expect(wrapper.find('.red--text').exists()).toBe(true);
   });
 
   it('updates the icon when the IsFavorite user data is changed', async (): Promise<void> => {


### PR DESCRIPTION
Removes the red color used on the like button when an item is added.

Using two indicator for the state of the icon is superfluous (Color + filled/outlined) and the red clashes with the rest of the colors on the page. It was also not customizable, since it used the red class from Vuetify.

Now the button only has an outlined or filled icon.

![image](https://user-images.githubusercontent.com/19396809/111756087-1abf0700-889a-11eb-9e81-e17680c8a778.png)
