### PR TITLE
style: introduce padding-line-between-statements rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -52,7 +52,45 @@ module.exports = {
         }
       }
     ],
-    'vue/multiline-html-element-content-newline': 'error'
+    'vue/multiline-html-element-content-newline': 'error',
+    'padding-line-between-statements': [
+      'error',
+      // Always require blank lines after directives (like 'use-strict'), except between directives
+      { blankLine: 'always', prev: 'directive', next: '*' },
+      { blankLine: 'any', prev: 'directive', next: 'directive' },
+      // Always require blank lines after import, except between imports
+      { blankLine: 'always', prev: 'import', next: '*' },
+      { blankLine: 'any', prev: 'import', next: 'import' },
+      // Always require blank lines before and after every sequence of variable declarations and export
+      {
+        blankLine: 'always',
+        prev: '*',
+        next: ['const', 'let', 'var', 'export']
+      },
+      {
+        blankLine: 'always',
+        prev: ['const', 'let', 'var', 'export'],
+        next: '*'
+      },
+      {
+        blankLine: 'any',
+        prev: ['const', 'let', 'var', 'export'],
+        next: ['const', 'let', 'var', 'export']
+      },
+      // Always require blank lines before and after class declaration, if, do/while, switch, try
+      {
+        blankLine: 'always',
+        prev: '*',
+        next: ['if', 'class', 'for', 'do', 'while', 'switch', 'try']
+      },
+      {
+        blankLine: 'always',
+        prev: ['if', 'class', 'for', 'do', 'while', 'switch', 'try'],
+        next: '*'
+      },
+      // Always require blank lines before return statements
+      { blankLine: 'always', prev: '*', next: 'return' }
+    ]
   },
   settings: {
     'import/resolver': {

--- a/components/Buttons/LikeButton.vue
+++ b/components/Buttons/LikeButton.vue
@@ -41,6 +41,7 @@ export default Vue.extend({
         mutation?.payload?.MessageType === 'UserDataChanged'
       ) {
         const payloadData = mutation?.payload?.Data?.UserDataList;
+
         if (payloadData) {
           for (const payloadItem of payloadData) {
             if (payloadItem.ItemId === this.item.Id) {

--- a/components/Buttons/QueueButton.vue
+++ b/components/Buttons/QueueButton.vue
@@ -138,6 +138,7 @@ export default Vue.extend({
         if (this.item.AlbumId === this.playbackInitiator?.Id) {
           return this.playbackInitiator;
         }
+
         return null;
       }
     },

--- a/components/Forms/AddServerForm.vue
+++ b/components/Forms/AddServerForm.vue
@@ -71,8 +71,10 @@ export default Vue.extend({
     ...mapActions('servers', ['connectServer']),
     async connectToServer(): Promise<void> {
       this.loading = true;
+
       try {
         await this.connectServer(this.serverUrl);
+
         if (this.previousServerLength === 0) {
           this.$router.push('/login');
         } else {

--- a/components/Forms/LoginForm.vue
+++ b/components/Forms/LoginForm.vue
@@ -104,6 +104,7 @@ export default Vue.extend({
 
       this.loading = true;
       await this.setDeviceProfile();
+
       try {
         await this.loginRequest(this.login);
         this.$router.replace('/');

--- a/components/Item/Card/Card.vue
+++ b/components/Item/Card/Card.vue
@@ -183,17 +183,21 @@ export default Vue.extend({
               'en-us',
               { year: 'numeric' }
             );
+
             if (this.item.ProductionYear?.toString() === endYear) {
               return this.item.ProductionYear.toString();
             }
+
             return `${this.item.ProductionYear} - ${endYear}`;
           }
+
           break;
         }
         case 'Movie':
         default:
           return `${this.item.ProductionYear ? this.item.ProductionYear : ''}`;
       }
+
       return '';
     },
     progress: {

--- a/components/Item/Card/ServerCard.vue
+++ b/components/Item/Card/ServerCard.vue
@@ -45,6 +45,7 @@ export default Vue.extend({
     ...mapActions('servers', ['connectServer', 'removeServer']),
     async setServer(): Promise<void> {
       this.loading = true;
+
       try {
         await this.connectServer(this.serverInfo.address);
         this.$router.push('/login');

--- a/components/Item/Metadata/ImageSearch.vue
+++ b/components/Item/Metadata/ImageSearch.vue
@@ -110,6 +110,7 @@ export default Vue.extend({
       if (!val) {
         return val;
       }
+
       return val.toFixed(1);
     }
   },
@@ -190,6 +191,7 @@ export default Vue.extend({
             ) {
               return true;
             }
+
             return false;
           }
         );
@@ -198,6 +200,7 @@ export default Vue.extend({
             return provider.Name as string;
           }
         );
+
         return [this.$t('metadata.sourceAll')].concat(providerNames);
       }
     },

--- a/components/Item/Metadata/MetadataEditor.vue
+++ b/components/Item/Metadata/MetadataEditor.vue
@@ -245,11 +245,13 @@ export default Vue.extend({
         if (!this.metadata.PremiereDate) {
           return '';
         }
+
         const dateStr = this.$dateFns.format(
           new Date(this.metadata.PremiereDate),
           'yyyy-MM-dd',
           { locale: this.$i18n.locale }
         );
+
         return dateStr;
       }
     },
@@ -258,11 +260,13 @@ export default Vue.extend({
         if (!this.metadata.DateCreated) {
           return '';
         }
+
         const dateStr = this.$dateFns.format(
           new Date(this.metadata.DateCreated),
           'yyyy-MM-dd',
           { locale: this.$i18n.locale }
         );
+
         return dateStr;
       }
     }
@@ -282,12 +286,14 @@ export default Vue.extend({
   methods: {
     async getData(): Promise<void> {
       await this.fetchItemInfo();
+
       const ancestors = await this.$api.library.getAncestors({
         itemId: this.metadata.Id as string,
         userId: this.$auth.user?.Id
       });
       const libraryInfo =
         ancestors.data.find((i) => i.Type === 'CollectionFolder') || {};
+
       this.getGenres(libraryInfo.Id);
     },
     async fetchItemInfo(): Promise<void> {
@@ -298,6 +304,7 @@ export default Vue.extend({
           itemId: this.itemId
         })
       ).data;
+
       this.$data.metadata = itemInfo;
     },
     async getGenres(parentId = ''): Promise<void> {
@@ -347,6 +354,7 @@ export default Vue.extend({
         'PreferredMetadataCountryCode',
         'Taglines'
       ]);
+
       try {
         this.loading = true;
         await this.$api.itemUpdate.updateItem({
@@ -384,9 +392,11 @@ export default Vue.extend({
       if (!this.metadata.People) {
         this.metadata.People = [];
       }
+
       const target = this.metadata.People?.find(
         (person) => person.Id === item.Id
       );
+
       if (target) {
         Object.assign(target, item);
       } else {

--- a/components/Item/Metadata/PersonEditor.vue
+++ b/components/Item/Metadata/PersonEditor.vue
@@ -94,6 +94,7 @@ export default Vue.extend({
       if (!value) {
         return;
       }
+
       this.editState = value;
     }
   },

--- a/components/Item/PersonList.vue
+++ b/components/Item/PersonList.vue
@@ -58,6 +58,7 @@ export default Vue.extend({
   methods: {
     getImageUrl(itemId: string): string | undefined {
       const element = this.$refs.personImg as HTMLElement;
+
       return this.getImageUrlForElement(ImageType.Primary, {
         itemId,
         element

--- a/components/Item/RelatedItems.vue
+++ b/components/Item/RelatedItems.vue
@@ -123,6 +123,7 @@ export default Vue.extend({
     },
     getImageUrl(itemId: string): string | undefined {
       const element = this.$refs.avatarImg as HTMLElement;
+
       return this.getImageUrlForElement(ImageType.Primary, { itemId, element });
     }
   }

--- a/components/Item/TrackSelector.vue
+++ b/components/Item/TrackSelector.vue
@@ -97,6 +97,7 @@ export default Vue.extend({
         if (!this.mediaSourceItem.MediaStreams) {
           return [];
         }
+
         return this.mediaSourceItem.MediaStreams.filter(
           (mediaStream) => mediaStream.Type === this.type
         );
@@ -122,9 +123,11 @@ export default Vue.extend({
         if (this.tracks.length <= 0) {
           return true;
         }
+
         if (this.type !== 'Subtitle' && this.tracks.length <= 1) {
           return true;
         }
+
         return false;
       }
     },
@@ -136,21 +139,27 @@ export default Vue.extend({
         if (this.type === 'Audio' && this.tracks.length === 0) {
           return this.$t('noAudioTracksAvailable');
         }
+
         if (this.type === 'Audio' && this.tracks.length !== 0) {
           return this.$t('noAudioTrackSelected');
         }
+
         if (this.type === 'Subtitle' && this.tracks.length === 0) {
           return this.$t('noSubtitlesAvailable');
         }
+
         if (this.type === 'Subtitle' && this.tracks.length !== 0) {
           return this.$t('noSubtitleSelected');
         }
+
         if (this.type === 'Video' && this.tracks.length === 0) {
           return this.$t('noVideoTracksAvailable');
         }
+
         if (this.type === 'Video' && this.tracks.length !== 0) {
           return this.$t('noVideoTrackSelected');
         }
+
         return this.$t('noTracksAvailable');
       }
     },
@@ -168,11 +177,13 @@ export default Vue.extend({
     defaultIndex: {
       get(): number | undefined {
         const defaultTrack = this.tracks.findIndex((track) => track.IsDefault);
+
         if (defaultTrack !== -1) {
           return defaultTrack;
         } else if (this.type === 'Subtitle') {
           return undefined;
         }
+
         return 0;
       }
     }
@@ -212,6 +223,7 @@ export default Vue.extend({
       if (track.DisplayTitle) {
         return track.DisplayTitle;
       }
+
       return '';
     },
     /**
@@ -222,6 +234,7 @@ export default Vue.extend({
       if (this.type === 'Audio' && track.ChannelLayout) {
         return this.getSurroundIcon(track.ChannelLayout);
       }
+
       return undefined;
     },
     /**
@@ -232,6 +245,7 @@ export default Vue.extend({
       if (track.DisplayTitle) {
         return track.DisplayTitle;
       }
+
       return '';
     },
     /**

--- a/components/Layout/AudioControls.vue
+++ b/components/Layout/AudioControls.vue
@@ -244,6 +244,7 @@ export default Vue.extend({
       ) {
         return 'mdi-repeat-once';
       }
+
       return 'mdi-repeat';
     },
     isShuffling(): boolean {
@@ -265,6 +266,7 @@ export default Vue.extend({
     ]),
     getImageUrl(item: BaseItemDto): string | undefined {
       const imageUrl = this.getImageUrlForElement(ImageType.Primary, { item });
+
       if (imageUrl) {
         return imageUrl;
       }

--- a/components/Layout/HomeHeader/HomeHeader.vue
+++ b/components/Layout/HomeHeader/HomeHeader.vue
@@ -53,6 +53,7 @@ export default Vue.extend({
 
     for (const [key, i] of this.items.entries()) {
       let id: string;
+
       if (i.Type === 'Episode' && i?.SeriesId) {
         id = i.SeriesId;
       } else if (i.Type === 'MusicAlbum' && i?.AlbumArtists?.[0]?.Id) {
@@ -78,12 +79,14 @@ export default Vue.extend({
     } else {
       this.extraText = this.$t('homeHeader.welcome.checkNewItems');
     }
+
     window.setTimeout(this.hideWelcomeMessage, 1500);
   },
   methods: {
     hideWelcomeMessage(): void {
       if (this.items.length === 0) {
         const elem = this.$refs.headerWelcome as HTMLElement;
+
         // As the height of the element varies as we're using automatic values, we set first
         // the screen height of the element, so the animation plays correctly when the height is set to 0
         elem.style.maxHeight = elem.scrollHeight + 'px';

--- a/components/Layout/HomeHeader/HomeHeaderItems.vue
+++ b/components/Layout/HomeHeader/HomeHeaderItems.vue
@@ -133,7 +133,9 @@ export default Vue.extend({
   },
   mounted() {
     this.swiper = (this.$refs.homeSwiper as Vue).$swiper as Swiper;
+
     const hash = this.getBlurhash(this.items[0], ImageType.Backdrop);
+
     this.setBackdrop({ hash });
   },
   beforeDestroy() {
@@ -144,9 +146,11 @@ export default Vue.extend({
     ...mapActions('backdrop', ['setBackdrop', 'clearBackdrop']),
     getRelatedItem(item: BaseItemDto): BaseItemDto {
       const rItem = this.relatedItems[this.items.indexOf(item)];
+
       if (!rItem) {
         return item;
       }
+
       return rItem;
     },
     getOverview(item: BaseItemDto): string {
@@ -158,6 +162,7 @@ export default Vue.extend({
     },
     getLogo(item: BaseItemDto): string | undefined {
       const relatedItem = this.getRelatedItem(item);
+
       return this.getImageUrlForElement(ImageType.Logo, {
         itemId: relatedItem.Id
       });
@@ -170,14 +175,17 @@ export default Vue.extend({
     // See https://github.com/nolimits4web/swiper/issues/2629 and https://github.com/surmon-china/vue-awesome-swiper/issues/483
     onSlideChange(): void {
       this.currentIndex = this.swiper?.realIndex;
+
       if (this.swiper?.isBeginning || this.swiper?.isEnd) {
         this.swiper?.updateSlides();
       }
+
       const hash =
         this.getBlurhash(
           this.items[this.currentIndex as number],
           ImageType.Backdrop
         ) || '';
+
       this.setBackdrop({ hash });
     },
     onTouch(): void {

--- a/components/Layout/HomeHeader/SwiperProgressBar.vue
+++ b/components/Layout/HomeHeader/SwiperProgressBar.vue
@@ -95,6 +95,7 @@ export default Vue.extend({
     },
     onProgressClicked(event: MouseEvent): void {
       const target = event.target as HTMLElement;
+
       this.$emit('on-progress-clicked', this.bars.indexOf(target) as number);
     },
     togglePause(): void {
@@ -106,6 +107,7 @@ export default Vue.extend({
     },
     setAnimationDuration(): void {
       const newDuration = (this.duration / 1000).toString() + 's';
+
       this.bars.forEach((el: HTMLElement) => {
         el.style.animationDuration = newDuration;
       });

--- a/components/Layout/Images/BlurhashImage.vue
+++ b/components/Layout/Images/BlurhashImage.vue
@@ -108,10 +108,12 @@ export default Vue.extend({
     },
     getImage(): void {
       const img = this.$refs.img as HTMLElement;
+
       this.image = this.getImageUrlForElement(this.type, {
         item: this.item,
         element: img
       });
+
       if (!this.image) {
         this.onError();
       }

--- a/components/Layout/SwiperSection.vue
+++ b/components/Layout/SwiperSection.vue
@@ -60,6 +60,7 @@ export default Vue.extend({
   },
   data() {
     const uuid = uuidv4();
+
     return {
       uuid,
       swiperOptions: {

--- a/components/Layout/TimeSlider.vue
+++ b/components/Layout/TimeSlider.vue
@@ -52,6 +52,7 @@ export default Vue.extend({
         if (!this.clicked) {
           return this.$store.state.playbackManager.currentTime;
         }
+
         return this.currentInput;
       }
     },

--- a/components/Players/AudioPlayer.vue
+++ b/components/Players/AudioPlayer.vue
@@ -73,6 +73,7 @@ export default Vue.extend({
 
       window.muxjs = muxjs;
       shaka.polyfill.installAll();
+
       if (shaka.Player.isBrowserSupported()) {
         this.player = new shaka.Player(this.$refs.audioPlayer);
         // Register player events
@@ -85,23 +86,27 @@ export default Vue.extend({
                 if (this.$refs.audioPlayer) {
                   (this.$refs.audioPlayer as HTMLAudioElement).pause();
                 }
+
                 break;
               case 'playbackManager/UNPAUSE_PLAYBACK':
                 if (this.$refs.audioPlayer) {
                   (this.$refs.audioPlayer as HTMLAudioElement).play();
                 }
+
                 break;
               case 'playbackManager/CHANGE_CURRENT_TIME':
                 if (this.$refs.audioPlayer) {
                   (this.$refs
                     .audioPlayer as HTMLAudioElement).currentTime = this.currentTime;
                 }
+
                 break;
               case 'playbackManager/SET_VOLUME':
                 if (this.$refs.audioPlayer) {
                   (this.$refs.audioPlayer as HTMLAudioElement).volume =
                     this.currentVolume / 100;
                 }
+
                 break;
               case 'playbackManager/SET_REPEAT_MODE':
                 if (this.$refs.audioPlayer) {
@@ -134,6 +139,7 @@ export default Vue.extend({
       this.player.unload();
       this.player.destroy();
     }
+
     this.unsubscribe();
   },
   methods: {
@@ -160,6 +166,7 @@ export default Vue.extend({
         this.setPlaySessionId({ id: this.playbackInfo.PlaySessionId });
 
         let mediaSource;
+
         if (this.playbackInfo?.MediaSources) {
           mediaSource = this.playbackInfo.MediaSources[0];
           this.setMediaSource({ mediaSource });
@@ -187,6 +194,7 @@ export default Vue.extend({
           }
 
           const params = stringify(directOptions);
+
           this.source = `${this.$axios.defaults.baseURL}/Audio/${mediaSource.Id}/stream.${mediaSource.Container}?${params}`;
         } else if (
           mediaSource.SupportsTranscoding &&
@@ -216,6 +224,7 @@ export default Vue.extend({
       if (this.$refs.audioPlayer) {
         const currentTime = (this.$refs.audioPlayer as HTMLAudioElement)
           .currentTime;
+
         this.setCurrentTime({ time: currentTime });
         this.pause();
       }
@@ -224,6 +233,7 @@ export default Vue.extend({
       if (this.$refs.audioPlayer) {
         const currentTime = (this.$refs.audioPlayer as HTMLAudioElement)
           .currentTime;
+
         this.setCurrentTime({ time: currentTime });
         this.setNextTrack();
       }

--- a/components/Players/PlayerManager.vue
+++ b/components/Players/PlayerManager.vue
@@ -213,6 +213,7 @@ export default Vue.extend({
           } else if (state.playbackManager.isMinimized === false) {
             window.addEventListener('keydown', this.handleKeyPress);
           }
+
           break;
         case 'playbackManager/INCREASE_QUEUE_INDEX':
         case 'playbackManager/DECREASE_QUEUE_INDEX':
@@ -285,6 +286,7 @@ export default Vue.extend({
               this.setLastProgressUpdate({ progress: new Date().getTime() });
             }
           }
+
           break;
         }
         case 'playbackManager/STOP_PLAYBACK':
@@ -308,6 +310,7 @@ export default Vue.extend({
 
             this.removeMediaHandlers();
           }
+
           break;
         case 'playbackManager/PAUSE_PLAYBACK':
           if (state.playbackManager.currentTime !== null) {
@@ -327,6 +330,7 @@ export default Vue.extend({
 
             this.setLastProgressUpdate({ progress: new Date().getTime() });
           }
+
           break;
       }
     });
@@ -335,6 +339,7 @@ export default Vue.extend({
     if (this.fullScreenOverlayTimer) {
       clearTimeout(this.fullScreenOverlayTimer);
     }
+
     document.removeEventListener('mousemove', this.handleMouseMove);
     this.removeMediaHandlers();
     this.unsubscribe();
@@ -363,6 +368,7 @@ export default Vue.extend({
         if (this.fullScreenOverlayTimer) {
           clearTimeout(this.fullScreenOverlayTimer);
         }
+
         this.showFullScreenOverlay = true;
         this.fullScreenOverlayTimer = window.setTimeout(() => {
           this.showFullScreenOverlay = false;
@@ -405,6 +411,7 @@ export default Vue.extend({
             'play',
             (): void => {
               this.unpause();
+
               if (navigator.mediaSession) {
                 navigator.mediaSession.playbackState = 'playing';
               }
@@ -414,6 +421,7 @@ export default Vue.extend({
             'pause',
             (): void => {
               this.pause();
+
               if (navigator.mediaSession) {
                 navigator.mediaSession.playbackState = 'paused';
               }
@@ -435,6 +443,7 @@ export default Vue.extend({
             'stop',
             (): void => {
               this.stopPlayback();
+
               if (navigator.mediaSession) {
                 navigator.mediaSession.playbackState = 'none';
               }

--- a/components/Players/TrackList.vue
+++ b/components/Players/TrackList.vue
@@ -117,6 +117,7 @@ export default Vue.extend({
     getRuntime(ticks: number): string {
       let seconds = this.ticksToMs(ticks) / 1000;
       const minutes = Math.floor(seconds / 60);
+
       seconds = Math.floor(seconds - minutes * 60);
 
       /**

--- a/components/Players/VideoPlayer.vue
+++ b/components/Players/VideoPlayer.vue
@@ -86,6 +86,7 @@ export default Vue.extend({
 
       window.muxjs = muxjs;
       shaka.polyfill.installAll();
+
       if (shaka.Player.isBrowserSupported()) {
         this.player = new shaka.Player(this.$refs.videoPlayer);
 
@@ -99,17 +100,20 @@ export default Vue.extend({
                 if (this.$refs.videoPlayer) {
                   (this.$refs.videoPlayer as HTMLVideoElement).pause();
                 }
+
                 break;
               case 'playbackManager/UNPAUSE_PLAYBACK':
                 if (this.$refs.videoPlayer) {
                   (this.$refs.videoPlayer as HTMLVideoElement).play();
                 }
+
                 break;
               case 'playbackManager/CHANGE_CURRENT_TIME':
                 if (this.$refs.videoPlayer && mutation?.payload?.time) {
                   (this.$refs.videoPlayer as HTMLVideoElement).currentTime =
                     mutation?.payload?.time;
                 }
+
                 break;
               case 'playbackManager/SET_REPEAT_MODE':
                 if (this.$refs.videoPlayer) {
@@ -142,6 +146,7 @@ export default Vue.extend({
       this.player.unload();
       this.player.destroy();
     }
+
     this.unsubscribe();
   },
   methods: {
@@ -168,6 +173,7 @@ export default Vue.extend({
         this.setPlaySessionId({ id: this.playbackInfo.PlaySessionId });
 
         let mediaSource;
+
         if (this.playbackInfo?.MediaSources) {
           mediaSource = this.playbackInfo.MediaSources[0];
           this.setMediaSource({ mediaSource });
@@ -195,6 +201,7 @@ export default Vue.extend({
           }
 
           const params = stringify(directOptions);
+
           this.source = `${this.$axios.defaults.baseURL}/Videos/${mediaSource.Id}/stream.${mediaSource.Container}?${params}`;
         } else if (
           mediaSource.SupportsTranscoding &&
@@ -224,6 +231,7 @@ export default Vue.extend({
       if (this.$refs.videoPlayer) {
         const currentTime = (this.$refs.videoPlayer as HTMLVideoElement)
           .currentTime;
+
         this.setCurrentTime({ time: currentTime });
         this.pause();
       }
@@ -232,6 +240,7 @@ export default Vue.extend({
       if (this.$refs.videoPlayer) {
         const currentTime = (this.$refs.videoPlayer as HTMLVideoElement)
           .currentTime;
+
         this.setCurrentTime({ time: currentTime });
         this.setNextTrack();
       }

--- a/components/Skeletons/SkeletonHomeSection.vue
+++ b/components/Skeletons/SkeletonHomeSection.vue
@@ -36,6 +36,7 @@ export default Vue.extend({
       } else if (this.$vuetify.breakpoint.width < 1904) {
         return this.cardShape === 'thumb-card' ? 4 : 8;
       }
+
       return 4;
     }
   }

--- a/components/System/AddApiKey.vue
+++ b/components/System/AddApiKey.vue
@@ -59,6 +59,7 @@ export default Vue.extend({
     ...mapActions('snackbar', ['pushSnackbarMessage']),
     async addApiKey(): Promise<void> {
       this.loading = true;
+
       try {
         await this.$api.apiKey.createKey({
           app: this.newKeyAppName
@@ -80,6 +81,7 @@ export default Vue.extend({
           color: 'error'
         });
       }
+
       this.loading = false;
       this.addingNewKey = false;
     },

--- a/components/Wizard/WizardAdminAccount.vue
+++ b/components/Wizard/WizardAdminAccount.vue
@@ -73,8 +73,10 @@ export default Vue.extend({
     ...mapActions('snackbar', ['pushSnackbarMessage']),
     async createAdminAccount(): Promise<void> {
       this.loading = true;
+
       try {
         const token = `MediaBrowser Client="${this.$store.state.deviceProfile.clientName}", Device="${this.$store.state.deviceProfile.deviceName}", DeviceId="${this.$store.state.deviceProfile.deviceId}", Version="${this.$store.state.deviceProfile.clientVersion}"`;
+
         this.$auth.ctx.app.$axios.setHeader('X-Emby-Authorization', token);
 
         await this.$api.startup.updateStartupUser({
@@ -90,6 +92,7 @@ export default Vue.extend({
           color: 'error'
         });
       }
+
       this.loading = false;
     }
   }

--- a/components/Wizard/WizardLanguage.vue
+++ b/components/Wizard/WizardLanguage.vue
@@ -36,6 +36,7 @@ export default Vue.extend({
   },
   async created() {
     this.loading = true;
+
     try {
       this.initialConfig = (
         await this.$api.startup.getStartupConfiguration()
@@ -50,12 +51,14 @@ export default Vue.extend({
       // eslint-disable-next-line no-console
       console.error(error);
     }
+
     this.loading = false;
   },
   methods: {
     ...mapActions('snackbar', ['pushSnackbarMessage']),
     async setLanguage(): Promise<void> {
       this.loading = true;
+
       try {
         this.$i18n.setLocale(this.UICulture);
         await this.$api.startup.updateInitialConfiguration({
@@ -74,6 +77,7 @@ export default Vue.extend({
           color: 'error'
         });
       }
+
       this.loading = false;
     }
   }

--- a/components/Wizard/WizardMetadata.vue
+++ b/components/Wizard/WizardMetadata.vue
@@ -62,6 +62,7 @@ export default Vue.extend({
     ...mapActions('snackbar', ['pushSnackbarMessage']),
     async setMetadata(): Promise<void> {
       this.loading = true;
+
       try {
         await this.$api.startup.updateInitialConfiguration({
           startupConfigurationDto: {
@@ -80,6 +81,7 @@ export default Vue.extend({
           color: 'error'
         });
       }
+
       this.loading = false;
     }
   }

--- a/components/Wizard/WizardRemoteAccess.vue
+++ b/components/Wizard/WizardRemoteAccess.vue
@@ -30,6 +30,7 @@ export default Vue.extend({
     ...mapActions('snackbar', ['pushSnackbarMessage']),
     async setRemoteAccess(): Promise<void> {
       this.loading = true;
+
       try {
         await this.$api.startup.setRemoteAccess({
           startupRemoteAccessDto: {
@@ -47,6 +48,7 @@ export default Vue.extend({
           color: 'error'
         });
       }
+
       this.loading = false;
     }
   }

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -171,6 +171,7 @@ export default Vue.extend({
       deviceId: this.$store.state.deviceProfile.deviceId
     });
     let socketUrl = `${this.$axios.defaults.baseURL}/socket?${socketParams}`;
+
     socketUrl = socketUrl.replace('https:', 'wss:');
     socketUrl = socketUrl.replace('http:', 'ws:');
 

--- a/mixins/htmlHelper.ts
+++ b/mixins/htmlHelper.ts
@@ -34,10 +34,12 @@ const htmlHelper = Vue.extend({
     sanitizeHtml(input: string): string {
       // Some providers have newlines, replace them with the proper tag.
       let cleanString = decode(input).replace(/(?:\r\n|\r|\n)/g, '<br>');
+
       cleanString = DOMPurify.sanitize(cleanString, {
         ALLOWED_TAGS: ['br', 'b', 'strong', 'i', 'em'],
         KEEP_CONTENT: true
       });
+
       return cleanString;
     }
   }

--- a/mixins/imageHelper.ts
+++ b/mixins/imageHelper.ts
@@ -177,26 +177,31 @@ const imageHelper = Vue.extend({
             } else if (item.ParentPrimaryImageTag) {
               return item.ParentPrimaryImageTag;
             }
+
             break;
           case ImageType.Art:
             if (item.ParentArtImageTag) {
               return item.ParentArtImageTag;
             }
+
             break;
           case ImageType.Backdrop:
             if (item.ParentBackdropImageTags?.[index]) {
               return item.ParentBackdropImageTags[index];
             }
+
             break;
           case ImageType.Logo:
             if (item.ParentLogoImageTag) {
               return item.ParentLogoImageTag;
             }
+
             break;
           case ImageType.Thumb:
             if (item.ParentThumbImageTag) {
               return item.ParentThumbImageTag;
             }
+
             break;
           default:
             return undefined;
@@ -249,6 +254,7 @@ const imageHelper = Vue.extend({
     ): string | undefined {
       if (item) {
         const tag = this.getImageTag(item, type, index, checkParent);
+
         if (
           tag &&
           !excludedBlurhashTypes.includes(type) &&
@@ -296,9 +302,11 @@ const imageHelper = Vue.extend({
       if (item) {
         if (!tag) {
           tag = this.getImageTag(item, type, backdropIndex, false);
+
           if (!tag && checkParent) {
             tag = this.getImageTag(item, type, backdropIndex, true);
             itemId = this.getParentId(item);
+
             if (!tag || !itemId) {
               return undefined;
             }
@@ -322,6 +330,7 @@ const imageHelper = Vue.extend({
       };
 
       const scaling = window.devicePixelRatio;
+
       if (limitByWidth && maxWidth) {
         params.maxWidth = Math.round(maxWidth * scaling).toString();
       } else if (maxHeight) {

--- a/mixins/itemHelper.ts
+++ b/mixins/itemHelper.ts
@@ -116,6 +116,7 @@ const itemHelper = Vue.extend({
         routeParams = { viewId: item.Id };
       } else {
         const type = overrideType || item.Type;
+
         switch (type) {
           case 'Series':
             routeName = 'series-itemId';

--- a/mixins/timeUtils.ts
+++ b/mixins/timeUtils.ts
@@ -18,6 +18,7 @@ export function ticksToMs(ticks: number | null | undefined): number {
   if (!ticks) {
     ticks = 0;
   }
+
   return Math.round(ticks / 10000);
 }
 
@@ -85,6 +86,7 @@ const timeUtils = Vue.extend({
     formatTime(seconds: number): string {
       let minutes = Math.floor(seconds / 60);
       const hours = Math.floor(minutes / 60);
+
       minutes = minutes - hours * 60;
       seconds = Math.floor(seconds - (minutes * 60 + hours * 60 * 60));
 
@@ -116,6 +118,7 @@ const timeUtils = Vue.extend({
       const ms = this.ticksToMs(ticks);
       const endTimeLong = new Date(Date.now() + ms);
       let format;
+
       if (!suffix) {
         format = endTimeLong.toLocaleString(this.$i18n.locale, {
           hour: 'numeric',
@@ -126,6 +129,7 @@ const timeUtils = Vue.extend({
           locale: this.$i18n.locale
         });
       }
+
       // TODO: Use a Date object
       return this.$t('endsAt', {
         time: format
@@ -139,6 +143,7 @@ const timeUtils = Vue.extend({
      */
     getRuntimeTime(ticks: number): string {
       const ms = this.ticksToMs(ticks);
+
       return this.$dateFns.formatDuration(
         intervalToDuration({ start: 0, end: ms }),
         {
@@ -156,6 +161,7 @@ const timeUtils = Vue.extend({
      */
     getTotalEndsAtTime(items: BaseItemDto[], suffix = true): string {
       const ticks = sumBy(items, 'RunTimeTicks');
+
       return this.getEndsAtTime(ticks, suffix);
     }
   }

--- a/pages/artist/_itemId/index.vue
+++ b/pages/artist/_itemId/index.vue
@@ -172,7 +172,9 @@ export default Vue.extend({
     item: {
       handler(val: BaseItemDto): void {
         this.setPageTitle({ title: val.Name });
+
         const hash = this.getBlurhash(val, ImageType.Backdrop);
+
         this.setBackdrop({ hash });
       },
       immediate: true,

--- a/pages/fullscreen/playback/index.vue
+++ b/pages/fullscreen/playback/index.vue
@@ -135,6 +135,7 @@ export default Vue.extend({
     ]),
     onSlideChange(): void {
       const index = this.swiper?.realIndex || 0;
+
       if (this.currentQueue[index]) {
         this.setCurrentIndex({ index });
       }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -104,6 +104,7 @@ export default Vue.extend({
 
             homeSections.push(...latestMediaSections);
           }
+
           break;
         }
         case 'resume':

--- a/pages/item/_itemId/index.vue
+++ b/pages/item/_itemId/index.vue
@@ -316,6 +316,7 @@ export default Vue.extend({
     ).data;
 
     let crew: BaseItemPerson[] = [];
+
     if (item.People) {
       crew = item.People.filter((person: BaseItemPerson) => {
         return ['Director', 'Writer'].includes(person.Type || '');
@@ -389,6 +390,7 @@ export default Vue.extend({
           ) {
             return false;
           }
+
           return true;
         }
       }
@@ -423,7 +425,9 @@ export default Vue.extend({
     item: {
       handler(val: BaseItemDto): void {
         this.setPageTitle({ title: val.Name });
+
         const hash = this.getBlurhash(val, ImageType.Backdrop);
+
         this.setBackdrop({ hash });
       },
       immediate: true,

--- a/pages/library/_viewId.vue
+++ b/pages/library/_viewId.vue
@@ -237,6 +237,7 @@ export default Vue.extend({
     async refreshItems(): Promise<void> {
       try {
         let itemsResponse;
+
         switch (this.viewType) {
           case 'MusicArtist':
             itemsResponse = (

--- a/pages/metadata/index.vue
+++ b/pages/metadata/index.vue
@@ -26,6 +26,7 @@ type ITreeNode = {
   name: string | null | undefined;
   children?: ITreeNode[];
 };
+
 export default Vue.extend({
   data() {
     return {
@@ -63,6 +64,7 @@ export default Vue.extend({
       (node.children as ITreeNode[]).push(
         ...libItems.map((item) => {
           const baseObj = { id: item.Id, name: item.Name };
+
           return item.IsFolder
             ? {
                 ...baseObj,

--- a/pages/musicalbum/_itemId/index.vue
+++ b/pages/musicalbum/_itemId/index.vue
@@ -160,7 +160,9 @@ export default Vue.extend({
     item: {
       handler(val: BaseItemDto): void {
         this.setPageTitle({ title: val.Name });
+
         const hash = this.getBlurhash(val, ImageType.Backdrop);
+
         this.setBackdrop({ hash });
       },
       immediate: true,

--- a/pages/person/_itemId/index.vue
+++ b/pages/person/_itemId/index.vue
@@ -159,7 +159,9 @@ export default Vue.extend({
     item: {
       handler(val: BaseItemDto): void {
         this.setPageTitle({ title: val.Name });
+
         const hash = this.getBlurhash(val, ImageType.Backdrop);
+
         this.setBackdrop({ hash });
       },
       immediate: true,
@@ -178,6 +180,7 @@ export default Vue.extend({
     ...mapActions('backdrop', ['setBackdrop', 'clearBackdrop']),
     getImageUrl(itemId: string | undefined): string | undefined {
       const element = this.$refs.personImg as HTMLElement;
+
       if (itemId) {
         return this.getImageUrlForElement(ImageType.Primary, {
           itemId,

--- a/pages/series/_itemId/index.vue
+++ b/pages/series/_itemId/index.vue
@@ -205,6 +205,7 @@ export default Vue.extend({
     ).data;
 
     let crew: BaseItemPerson[] = [];
+
     if (item.People) {
       crew = item.People.filter((person: BaseItemPerson) => {
         return ['Director', 'Writer'].includes(person.Type || '');
@@ -294,7 +295,9 @@ export default Vue.extend({
     item: {
       handler(val: BaseItemDto): void {
         this.setPageTitle({ title: val.Name });
+
         const hash = this.getBlurhash(val, ImageType.Backdrop);
+
         this.setBackdrop({ hash });
       },
       immediate: true,

--- a/pages/settings/devices.vue
+++ b/pages/settings/devices.vue
@@ -118,6 +118,7 @@ export default Vue.extend({
           if (this.$store.state.deviceProfile.deviceId === device.Id) {
             return;
           }
+
           await this.$api.devices.deleteDevice({ id: device.Id || '' });
         });
 
@@ -168,6 +169,7 @@ export default Vue.extend({
         // eslint-disable-next-line no-console
         console.error(error);
       }
+
       this.deviceInfoDialog = false;
     }
   }

--- a/pages/settings/logsAndActivity.vue
+++ b/pages/settings/logsAndActivity.vue
@@ -133,6 +133,7 @@ export default Vue.extend({
   middleware: 'adminMiddleware',
   async asyncData({ $api }) {
     const minDate = new Date();
+
     minDate.setDate(minDate.getDate() - 7);
 
     const activityList = (

--- a/pages/wizard.vue
+++ b/pages/wizard.vue
@@ -109,6 +109,7 @@ export default Vue.extend({
         case 4:
           return this.$t('wizard.remoteAccess');
       }
+
       return '';
     }
   },

--- a/plugins/appInitPlugin.ts
+++ b/plugins/appInitPlugin.ts
@@ -2,6 +2,7 @@ import { Plugin } from '@nuxt/types';
 
 const appInitPlugin: Plugin = (context) => {
   const { serverUsed } = context.store.state.servers;
+
   if (serverUsed) {
     context.$axios.setBaseURL(serverUsed.address);
   }

--- a/plugins/browserDetection.ts
+++ b/plugins/browserDetection.ts
@@ -51,6 +51,7 @@ class BrowserDetector {
    */
   private userAgentContains(key: string): boolean {
     const userAgent = navigator.userAgent || '';
+
     return userAgent.includes(key);
   }
 
@@ -129,6 +130,7 @@ class BrowserDetector {
     // This works for iOS Safari and desktop Safari, which contain something
     // like "Version/13.0" indicating the major Safari or iOS version.
     let match = navigator.userAgent.match(/Version\/(\d+)/);
+
     if (match) {
       return parseInt(match[1], /* base= */ 10);
     }
@@ -136,6 +138,7 @@ class BrowserDetector {
     // This works for all other browsers on iOS, which contain something like
     // "OS 13_3" indicating the major & minor iOS version.
     match = navigator.userAgent.match(/OS (\d+)(?:_\d+)?/);
+
     if (match) {
       return parseInt(match[1], /* base= */ 10);
     }

--- a/plugins/persistedState.ts
+++ b/plugins/persistedState.ts
@@ -10,6 +10,7 @@ const persistState: Plugin = ({ store, req, res }) => {
       getItem: (key: string): string | undefined => {
         if (process.server) {
           const parsedCookies = cookie.parse(req.headers.cookie || '');
+
           return parsedCookies[key];
         } else {
           return Cookies.get(key);

--- a/schemes/jellyfinScheme.ts
+++ b/schemes/jellyfinScheme.ts
@@ -43,6 +43,7 @@ export default class JellyfinScheme {
 
   mounted(): Promise<never> {
     const token = this.$auth.syncToken(this.name);
+
     this._setToken(token);
 
     return this.$auth.fetchUserOnce();
@@ -62,6 +63,7 @@ export default class JellyfinScheme {
 
     // Set the empty header needed for Jellyfin to not yell at us
     const token = `MediaBrowser Client="${this.$auth.ctx.app.store.state.deviceProfile.clientName}", Device="${this.$auth.ctx.app.store.state.deviceProfile.deviceName}", DeviceId="${this.$auth.ctx.app.store.state.deviceProfile.deviceId}", Version="${this.$auth.ctx.app.store.state.deviceProfile.clientVersion}", Token=""`;
+
     this._setToken(token);
 
     // Check the version info and implicitly check for the manifest
@@ -83,6 +85,7 @@ export default class JellyfinScheme {
 
       // Set the user's token
       const userToken = `MediaBrowser Client="${this.$auth.ctx.app.store.state.deviceProfile.clientName}", Device="${this.$auth.ctx.app.store.state.deviceProfile.deviceName}", DeviceId="${this.$auth.ctx.app.store.state.deviceProfile.deviceId}", Version="${this.$auth.ctx.app.store.state.deviceProfile.clientVersion}", Token="${authenticateResponse.data.AccessToken}"`;
+
       this.$auth.setToken(this.name, userToken);
       this._setToken(userToken);
       this.$auth.ctx.app.store.commit('user/SET_USER', {
@@ -107,6 +110,7 @@ export default class JellyfinScheme {
 
   setUserToken(tokenValue: string): Promise<void> {
     const token = `MediaBrowser Client="${this.$auth.ctx.app.store.state.deviceProfile.clientName}", Device="${this.$auth.ctx.app.store.state.deviceProfile.deviceName}", DeviceId="${this.$auth.ctx.app.store.state.deviceProfile.deviceId}", Version="${this.$auth.ctx.app.store.state.deviceProfile.clientVersion}", Token="${tokenValue}"`;
+
     this.$auth.setToken(this.name, token);
     this._setToken(token);
 
@@ -121,6 +125,7 @@ export default class JellyfinScheme {
 
     if (!this._getRememberMe()) {
       await this.logout();
+
       return;
     }
 

--- a/store/homeSection.ts
+++ b/store/homeSection.ts
@@ -92,6 +92,7 @@ export const mutations: MutationTree<HomeSectionState> = {
     if (!libraryId) {
       throw new Error('libraryId is undefined');
     }
+
     Vue.set(state.latestMedia, libraryId, latestMedia);
   },
   CLEAR_HOME_SECTION(state: HomeSectionState) {

--- a/store/index.ts
+++ b/store/index.ts
@@ -67,6 +67,7 @@ export const state = (): RootState => ({
 export const mutations: MutationTree<RootState> = {
   SOCKET_ONOPEN(state: RootState, event: Event) {
     const socketInstance = event.currentTarget;
+
     Vue.set(state.socket, 'instance', socketInstance);
     Vue.set(state.socket, 'isConnected', true);
     Vue.set(state.socket, 'reconnectError', false);
@@ -96,6 +97,7 @@ export const mutations: MutationTree<RootState> = {
 export const actions: ActionTree<RootState, RootState> = {
   async reset({ dispatch }, { clearCritical }: { clearCritical: boolean }) {
     const promises = [];
+
     promises.push(dispatch('backdrop/clearAllBackdrop', { root: true }));
     promises.push(dispatch('clientSettings/resetState', { root: true }));
     promises.push(dispatch('homeSection/clearHomeSection', { root: true }));

--- a/store/items.ts
+++ b/store/items.ts
@@ -28,14 +28,18 @@ export const mutations: MutationTree<ItemsState> = {
     if (!item.Id) {
       throw new Error("No item ID in provided item, can't store it");
     }
+
     Vue.set(state.byId, item.Id, item);
+
     if (!state.allIds.includes(item.Id)) {
       state.allIds.push(item.Id);
     }
   },
   DELETE_ITEM(state: ItemsState, { id }: { id: string }) {
     delete state.byId[id];
+
     const idx = state.allIds.indexOf(id);
+
     if (idx > -1) {
       state.allIds.splice(idx, 1);
     }
@@ -53,6 +57,7 @@ export const actions: ActionTree<ItemsState, ItemsState> = {
     if (some(items, (item) => !item.Id)) {
       throw new Error('Item missing ID');
     }
+
     forEach(items, (item) => {
       commit('ADD_ITEM', { item });
     });

--- a/store/playbackManager.ts
+++ b/store/playbackManager.ts
@@ -86,6 +86,7 @@ export const getters: GetterTree<PlaybackManagerState, PlaybackManagerState> = {
     ) {
       return state.queue[state.currentItemIndex];
     }
+
     return null;
   },
   getPreviousItem: (state) => {
@@ -97,6 +98,7 @@ export const getters: GetterTree<PlaybackManagerState, PlaybackManagerState> = {
     ) {
       return state.queue[state.lastItemIndex];
     }
+
     return null;
   },
   getNextItem: (state) => {
@@ -108,18 +110,21 @@ export const getters: GetterTree<PlaybackManagerState, PlaybackManagerState> = {
     } else if (state.repeatMode === RepeatMode.RepeatAll) {
       return state.queue[0];
     }
+
     return null;
   },
   getCurrentlyPlayingType: (state) => {
     if (state.currentItemIndex !== null) {
       return state.queue?.[state.currentItemIndex]?.Type;
     }
+
     return null;
   },
   getCurrentlyPlayingMediaType: (state) => {
     if (state.currentItemIndex !== null) {
       return state.queue?.[state.currentItemIndex]?.MediaType;
     }
+
     return null;
   }
 };
@@ -156,6 +161,7 @@ export const mutations: MutationTree<PlaybackManagerState> = {
     } else {
       state.lastItemIndex = lastItemIndex;
     }
+
     state.currentItemIndex = currentItemIndex;
   },
   SET_CURRENT_MEDIA_SOURCE(
@@ -241,8 +247,10 @@ export const mutations: MutationTree<PlaybackManagerState> = {
     if (state.queue && state.currentItemIndex !== null) {
       if (!state.isShuffling) {
         state.originalQueue = Array.from(state.queue);
+
         const item = state.queue[state.currentItemIndex];
         const itemIndex = state.queue.indexOf(item);
+
         state.queue.splice(itemIndex, 1);
         state.queue = shuffle(state.queue);
         state.queue.unshift(item);
@@ -251,6 +259,7 @@ export const mutations: MutationTree<PlaybackManagerState> = {
         state.isShuffling = true;
       } else {
         const item = state.queue[state.currentItemIndex];
+
         state.currentItemIndex = state.originalQueue.indexOf(item);
         state.queue = Array.from(state.originalQueue);
         state.originalQueue = [];
@@ -283,6 +292,7 @@ export const actions: ActionTree<PlaybackManagerState, PlaybackManagerState> = {
     }
 
     let translatedItems;
+
     if (!startShuffled) {
       translatedItems = await translateItemsForPlayback(items);
     } else {
@@ -304,6 +314,7 @@ export const actions: ActionTree<PlaybackManagerState, PlaybackManagerState> = {
     } else {
       opts = { initMode: InitMode.Unknown };
     }
+
     commit('START_PLAYBACK', opts);
   },
   async playNext({ commit, state }, { item }: { item: BaseItemDto }) {
@@ -318,6 +329,7 @@ export const actions: ActionTree<PlaybackManagerState, PlaybackManagerState> = {
   async addToQueue({ commit, state }, { item }: { item: BaseItemDto }) {
     const queue = Array.from(state.queue);
     const translatedItem = await translateItemsForPlayback([item]);
+
     queue.push(...translatedItem);
     commit('SET_QUEUE', { queue });
   },
@@ -332,6 +344,7 @@ export const actions: ActionTree<PlaybackManagerState, PlaybackManagerState> = {
     if (state.lastItemIndex !== null) {
       lastItem = state.queue[state.lastItemIndex];
     }
+
     const newIndex = state.queue?.indexOf(item as BaseItemDto);
     const lastItemNewIndex = state.queue?.indexOf(lastItem as BaseItemDto);
 

--- a/store/plugins/preferencesSyncPlugin.ts
+++ b/store/plugins/preferencesSyncPlugin.ts
@@ -64,6 +64,7 @@ export const preferencesSync: Plugin<AppState> = (store) => {
         }
 
         const displayPrefs = response.data;
+
         displayPrefs.CustomPrefs = {};
 
         // @ts-expect-error - We need a generic way to access the submodule. A string works here, despite TypeScript's protests.
@@ -81,12 +82,14 @@ export const preferencesSync: Plugin<AppState> = (store) => {
 
         for (const [key, value] of Object.entries(displayPrefs.CustomPrefs)) {
           let string = JSON.stringify(value);
+
           /**
            * Undefined can't be converted to string using JSON.stringify so we add this safeguard
            */
           if (typeof string !== 'string') {
             string = String(string);
           }
+
           displayPrefs.CustomPrefs[key] = string;
         }
 
@@ -106,6 +109,7 @@ export const preferencesSync: Plugin<AppState> = (store) => {
         }
       } catch (error) {
         const message = store.$i18n.t('failedSettingDisplayPreferences');
+
         store.dispatch(
           'snackbar/pushSnackbarMessage',
           {

--- a/store/plugins/userPlugin.ts
+++ b/store/plugins/userPlugin.ts
@@ -27,6 +27,7 @@ export interface DisplayPreferencesApiState {
  */
 function castResponse(data: DisplayPreferencesDto): ClientPreferences {
   const result = data as ClientPreferences;
+
   if (result.CustomPrefs) {
     for (const [key, value] of Object.entries(result.CustomPrefs)) {
       /**
@@ -35,8 +36,10 @@ function castResponse(data: DisplayPreferencesDto): ClientPreferences {
       // @ts-expect-error - TypeScript can't infer types from Object.entries
       result.CustomPrefs[key] = destr(value);
     }
+
     return result;
   }
+
   return {};
 }
 
@@ -67,6 +70,7 @@ export const userPlugin: Plugin<AppState> = (store) => {
           }
 
           const data = castResponse(response.data);
+
           if (data.CustomPrefs) {
             /**
              * We delete the keys that are not defined in the state's default state, so removed
@@ -78,6 +82,7 @@ export const userPlugin: Plugin<AppState> = (store) => {
                 delete data.CustomPrefs[key];
               }
             }
+
             store.dispatch(
               `${subModule}/initState`,
               { data: data.CustomPrefs },
@@ -86,6 +91,7 @@ export const userPlugin: Plugin<AppState> = (store) => {
           }
         } catch (error) {
           const message = store.$i18n.t('failedRetrievingDisplayPreferences');
+
           store.dispatch(
             'snackbar/pushSnackbarMessage',
             {

--- a/store/user.ts
+++ b/store/user.ts
@@ -52,6 +52,7 @@ export const actions: ActionTree<UserState, UserState> = {
       dispatch('servers/notifyNoServerUsed', {
         root: true
       });
+
       return;
     }
 

--- a/utils/playbackProfiles/helpers/audioFormats.ts
+++ b/utils/playbackProfiles/helpers/audioFormats.ts
@@ -22,6 +22,7 @@ export function getSupportedAudioCodecs(format: string): boolean {
   } else if (format === 'opus') {
     if (!browserDetector.isWebOS()) {
       typeString = 'audio/ogg; codecs="opus"';
+
       return !!document
         .createElement('audio')
         .canPlayType(typeString)

--- a/utils/playbackProfiles/helpers/codecProfiles.ts
+++ b/utils/playbackProfiles/helpers/codecProfiles.ts
@@ -14,11 +14,13 @@ import { browserDetector } from '~/plugins/browserDetection';
  */
 function getGlobalMaxVideoBitrate(): number | null {
   let isTizenFhd = false;
+
   if (browserDetector.isTizen()) {
     try {
       // @ts-expect-error - Non-standard functions doesn't have typings
       // eslint-disable-next-line no-undef
       const isTizenUhd = webapis?.productinfo?.isUdPanelSupported();
+
       isTizenFhd = !isTizenUhd;
 
       // eslint-disable-next-line no-console
@@ -35,12 +37,15 @@ function getGlobalMaxVideoBitrate(): number | null {
   if (browserDetector.isPs4()) {
     return 8000000;
   }
+
   if (browserDetector.isXbox()) {
     return 12000000;
   }
+
   if (browserDetector.isTizen() && isTizenFhd) {
     return 20000000;
   }
+
   return null;
 }
 

--- a/utils/playbackUtils.ts
+++ b/utils/playbackUtils.ts
@@ -21,8 +21,10 @@ export async function translateItemsForPlayback(
   }
 
   let translatedItems: BaseItemDto[] = [];
+
   for (const item of items) {
     let responseItems;
+
     if (item.Type === 'Program' && item.ChannelId) {
       responseItems =
         (
@@ -111,5 +113,6 @@ export async function translateItemsForPlayback(
       }
     }
   }
+
   return uniqBy(translatedItems, 'Id');
 }


### PR DESCRIPTION
This forces some spacing in the code, to improve readability.

Each sub-rule is documented and the errors generated were fixed automatically by ESLint.

Essentially, we want spaces around variable declaration blocks, import blocks, export blocks, conditions, directives and before return statements.