### PR TITLE
ci: run merge conflict check on PR rebase

### DIFF
--- a/.github/workflows/merge-conflicts.yml
+++ b/.github/workflows/merge-conflicts.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    types:
+      - synchronize
 jobs:
   triage:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Runs the merge conflict check after a pull request is synchronized with the branch it's currently tracking.

This way, the label is removed after rebases in each PR and not only with commits on master.