### PR TITLE
Cleanup playback profiles

### DIFF
--- a/client/plugins/playbackProfiles/directPlayProfile.ts
+++ b/client/plugins/playbackProfiles/directPlayProfile.ts
@@ -5,6 +5,7 @@ import { getSupportedMP4AudioCodecs } from './helpers/mp4AudioFormats';
 import { hasMkvSupport } from './helpers/transcodingFormats';
 import { getSupportedWebMAudioCodecs } from './helpers/webmAudioFormats';
 import { getSupportedWebMVideoCodecs } from './helpers/webmVideoFormats';
+import { getSupportedAudioCodecs } from './helpers/audioFormats';
 
 /**
  * Returns a valid DirectPlayProfile for the current platform.
@@ -17,7 +18,7 @@ export function getDirectPlayProfiles(
   context: Context,
   videoTestElement: HTMLVideoElement
 ): Array<DirectPlayProfile> {
-  const DirectPlayProfiles = [] as DirectPlayProfile[];
+  const DirectPlayProfiles: DirectPlayProfile[] = [];
 
   const webmVideoCodecs = getSupportedWebMVideoCodecs(
     context,
@@ -72,30 +73,32 @@ export function getDirectPlayProfiles(
     'oga'
   ];
 
-  for (const audioFormat of supportedAudio) {
-    if (audioFormat === 'mp2') {
+  for (const audioFormat of supportedAudio.filter((format) =>
+    getSupportedAudioCodecs(context, format)
+  )) {
+    DirectPlayProfiles.push({
+      Container: audioFormat,
+      Type: DlnaProfileType.Audio
+    });
+
+    if (audioFormat === 'opus' || audioFormat === 'webma') {
       DirectPlayProfiles.push({
-        Container: 'mp2,mp3',
+        Container: 'webm',
         Type: DlnaProfileType.Audio,
         AudioCodec: audioFormat
-      });
-    } else if (audioFormat === 'mp3') {
-      DirectPlayProfiles.push({
-        Container: audioFormat,
-        Type: DlnaProfileType.Audio,
-        AudioCodec: audioFormat
-      });
-    } else {
-      DirectPlayProfiles.push({
-        Container: audioFormat === 'webma' ? 'webma,webm' : audioFormat,
-        Type: DlnaProfileType.Audio
       });
     }
 
     // aac also appears in the m4a and m4b container
     if (audioFormat === 'aac' || audioFormat === 'alac') {
       DirectPlayProfiles.push({
-        Container: 'm4a,m4b',
+        Container: 'm4a',
+        AudioCodec: audioFormat,
+        Type: DlnaProfileType.Audio
+      });
+
+      DirectPlayProfiles.push({
+        Container: 'm4b',
         AudioCodec: audioFormat,
         Type: DlnaProfileType.Audio
       });

--- a/client/plugins/playbackProfiles/helpers/fmp4VideoFormats.ts
+++ b/client/plugins/playbackProfiles/helpers/fmp4VideoFormats.ts
@@ -22,15 +22,16 @@ export function getSupportedFmp4VideoCodecs(
     codecs.push('hevc');
   }
 
-  if (hasH264Support(videoTestElement)) {
-    if (
+  if (
+    hasH264Support(videoTestElement) &&
+    (context.$browser.isChrome() ||
+      context.$browser.isFirefox() ||
       context.$browser.isApple() ||
       context.$browser.isEdge() ||
       context.$browser.isTizen() ||
-      context.$browser.isWebOS()
-    ) {
-      codecs.push('h264');
-    }
+      context.$browser.isWebOS())
+  ) {
+    codecs.push('h264');
   }
 
   return codecs;

--- a/client/plugins/playbackProfiles/helpers/tsAudioFormats.ts
+++ b/client/plugins/playbackProfiles/helpers/tsAudioFormats.ts
@@ -1,5 +1,4 @@
 import { Context } from '@nuxt/types';
-import { getSupportedAudioCodecs } from './audioFormats';
 import {
   hasAacSupport,
   hasAc3InHlsSupport,
@@ -35,10 +34,6 @@ export function getSupportedTsAudioCodecs(
         codecs.push('eac3');
       }
     }
-  }
-
-  if (getSupportedAudioCodecs(context, 'opus')) {
-    codecs.push('opus');
   }
 
   return codecs;

--- a/client/plugins/playbackProfiles/subtitleProfile.ts
+++ b/client/plugins/playbackProfiles/subtitleProfile.ts
@@ -16,5 +16,30 @@ export function getSubtitleProfiles(): Array<SubtitleProfile> {
     Method: SubtitleDeliveryMethod.External
   });
 
+  SubtitleProfiles.push({
+    Format: 'ttml',
+    Method: SubtitleDeliveryMethod.External
+  });
+
+  SubtitleProfiles.push({
+    Format: 'srt',
+    Methood: SubtitleDeliveryMethod.External
+  });
+
+  SubtitleProfiles.push({
+    Format: 'ass',
+    Methood: SubtitleDeliveryMethod.External
+  });
+
+  SubtitleProfiles.push({
+    Format: 'ssa',
+    Methood: SubtitleDeliveryMethod.External
+  });
+
+  SubtitleProfiles.push({
+    Format: 'subviewer',
+    Methood: SubtitleDeliveryMethod.External
+  });
+
   return SubtitleProfiles;
 }

--- a/client/plugins/playbackProfiles/subtitleProfile.ts
+++ b/client/plugins/playbackProfiles/subtitleProfile.ts
@@ -1,7 +1,4 @@
-import {
-  SubtitleDeliveryMethod,
-  SubtitleProfile
-} from '@jellyfin/client-axios';
+import { SubtitleProfile } from '@jellyfin/client-axios';
 
 /**
  * Returns a valid SubtitleProfile for the current platform.
@@ -9,7 +6,14 @@ import {
  * @returns {Array<SubtitleProfile>} An array of subtitle profiles for the current platform.
  */
 export function getSubtitleProfiles(): Array<SubtitleProfile> {
-  const SubtitleProfiles = [];
+  // TODO: Uncomment when proper subtitle support is added
+  const SubtitleProfiles: Array<SubtitleProfile> = [];
+
+  /*
+  SubtitleProfiles.push({
+    Format: 'ttml',
+    Method: SubtitleDeliveryMethod.External
+  });
 
   SubtitleProfiles.push({
     Format: 'vtt',
@@ -17,29 +21,25 @@ export function getSubtitleProfiles(): Array<SubtitleProfile> {
   });
 
   SubtitleProfiles.push({
-    Format: 'ttml',
+    Format: 'subrip',
     Method: SubtitleDeliveryMethod.External
   });
 
   SubtitleProfiles.push({
-    Format: 'srt',
-    Methood: SubtitleDeliveryMethod.External
-  });
-
-  SubtitleProfiles.push({
     Format: 'ass',
-    Methood: SubtitleDeliveryMethod.External
+    Method: SubtitleDeliveryMethod.External
   });
 
   SubtitleProfiles.push({
     Format: 'ssa',
-    Methood: SubtitleDeliveryMethod.External
+    Method: SubtitleDeliveryMethod.External
   });
 
   SubtitleProfiles.push({
     Format: 'subviewer',
-    Methood: SubtitleDeliveryMethod.External
+    Method: SubtitleDeliveryMethod.External
   });
+  */
 
   return SubtitleProfiles;
 }

--- a/client/plugins/playbackProfiles/transcodingProfile.ts
+++ b/client/plugins/playbackProfiles/transcodingProfile.ts
@@ -86,6 +86,9 @@ export function getTranscodingProfiles(
     videoTestElement
   );
 
+  console.dir(hlsInFmp4VideoCodecs);
+  console.dir(hlsInFmp4AudioCodecs);
+
   const hlsInTsVideoCodecs = getSupportedTsVideoCodecs(videoTestElement);
   const hlsInTsAudioCodecs = getSupportedTsAudioCodecs(
     context,

--- a/client/plugins/playbackProfiles/transcodingProfile.ts
+++ b/client/plugins/playbackProfiles/transcodingProfile.ts
@@ -31,7 +31,7 @@ export function getTranscodingProfiles(
   context: Context,
   videoTestElement: HTMLVideoElement
 ): Array<TranscodingProfile> {
-  const TranscodingProfiles = [] as TranscodingProfile[];
+  const TranscodingProfiles: TranscodingProfile[] = [];
   const physicalAudioChannels = context.$browser.isTv() ? 6 : 2;
 
   const hlsBreakOnNonKeyFrames = !!(
@@ -86,9 +86,6 @@ export function getTranscodingProfiles(
     videoTestElement
   );
 
-  console.dir(hlsInFmp4VideoCodecs);
-  console.dir(hlsInFmp4AudioCodecs);
-
   const hlsInTsVideoCodecs = getSupportedTsVideoCodecs(videoTestElement);
   const hlsInTsAudioCodecs = getSupportedTsAudioCodecs(
     context,
@@ -96,6 +93,7 @@ export function getTranscodingProfiles(
   );
 
   if (canPlayHls) {
+    // Since we have Mux.js loaded, anything using Shaka Player should be able to play fMP4 just fine.
     if (hlsInFmp4VideoCodecs.length && hlsInFmp4AudioCodecs.length) {
       TranscodingProfiles.push({
         Container: 'mp4',

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -25,7 +25,8 @@
       "@nuxtjs/date-fns",
       "nuxt-i18n",
       "@types/wicg-mediasession",
-      "jest"
+      "jest",
+      "@types/tizen-tv-webapis"
     ]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4591,6 +4591,12 @@
         "@types/jest": "*"
       }
     },
+    "@types/tizen-tv-webapis": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/tizen-tv-webapis/-/tizen-tv-webapis-2.0.0.tgz",
+      "integrity": "sha512-gxA/vV0B/BJreKSsG3p+4Kh2o513Tlikq703y7Zps/PTrfpTYOs/MoSXq/mK40msaZ6qhQtWWBWCR4H+qbVv6Q==",
+      "dev": true
+    },
     "@types/trusted-types": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "@types/qs": "^6.9.7",
     "@types/simple-icons": "^5.0.1",
     "@types/swiper": "^5.4.3",
+    "@types/tizen-tv-webapis": "^2.0.0",
     "@types/uuid": "^8.3.1",
     "@types/wicg-mediasession": "^1.1.2",
     "@vue/test-utils": "^1.2.1",


### PR DESCRIPTION
* Adds typings for the Tizen Web APIs
* Simplifies the global video bitrate thing (Remove variables that are just aliases of the global video bitrate)
* Remove some casting (`as`) and properly declare variable types instead
* Use `createProfileCondition` to create profile conditions instead of doing it manually (It's already done in most of the profile creation, but some forward ports from jf-web didn't include them).
* Removed a bit of Tizen code that depends on NativeShell, since we don't support that
* Improved the HEVC profiles comments
* Enabled fMP4 by default for Chrome, Firefox, Safari (Desktop and mobile), Edge, WebOS and Tizen