### PR TITLE
Swiper paginators

### DIFF
--- a/client/assets/styles/HomeHeader.scss
+++ b/client/assets/styles/HomeHeader.scss
@@ -38,9 +38,11 @@
   background-size: contain;
   background-repeat: no-repeat;
   box-sizing: border-box;
-  mask-image: linear-gradient(180deg,
-      rgba(37, 18, 18, 0.75) 0%,
-      rgba(0, 0, 0, 0) 100%);
+  mask-image: linear-gradient(
+    180deg,
+    rgba(37, 18, 18, 0.75) 0%,
+    rgba(0, 0, 0, 0) 100%
+  );
   z-index: 1;
 }
 
@@ -61,7 +63,8 @@
     margin-right: 0;
     padding-bottom: (9 / 16) * 80%;
     background-position: right center;
-    mask-image: linear-gradient(to right,
+    mask-image: linear-gradient(
+        to right,
         hsla(0, 0%, 0%, 0) 0%,
         hsla(0, 0%, 0%, 0.182) 5.6%,
         hsla(0, 0%, 0%, 0.34) 9.9%,
@@ -77,8 +80,10 @@
         hsla(0, 0%, 0%, 0.989) 54.3%,
         hsla(0, 0%, 0%, 0.996) 66.6%,
         hsla(0, 0%, 0%, 0.999) 81.7%,
-        hsl(0, 0%, 0%) 100%),
-      linear-gradient(to top,
+        hsl(0, 0%, 0%) 100%
+      ),
+      linear-gradient(
+        to top,
         hsla(0, 0%, 0%, 0) 0%,
         hsla(0, 0%, 0%, 0.182) 5.6%,
         hsla(0, 0%, 0%, 0.34) 9.9%,
@@ -94,12 +99,14 @@
         hsla(0, 0%, 0%, 0.989) 54.3%,
         hsla(0, 0%, 0%, 0.996) 66.6%,
         hsla(0, 0%, 0%, 0.999) 81.7%,
-        hsl(0, 0%, 0%) 100%);
+        hsl(0, 0%, 0%) 100%
+      );
     mask-composite: intersect;
   }
 
   .swiper {
     margin-top: -64px;
+    margin-bottom: 64px;
   }
 
   .slide-content {
@@ -107,6 +114,7 @@
   }
 
   .progress-bar {
+    position: relative !important;
     top: initial;
     margin-top: initial;
   }

--- a/client/assets/styles/HomeHeader.scss
+++ b/client/assets/styles/HomeHeader.scss
@@ -106,7 +106,6 @@
 
   .swiper {
     margin-top: -64px;
-    margin-bottom: 64px;
   }
 
   .slide-content {

--- a/client/components/Layout/HomeHeader/HomeHeader.vue
+++ b/client/components/Layout/HomeHeader/HomeHeader.vue
@@ -7,6 +7,8 @@
       @animationend="onNoItemsTransitionEnd"
     >
       <home-header-welcome :extra-text="extraText" />
+      <!-- This acts as a placeholder for the progressbar space -->
+      <div class="px-2 px-sm-4 progress-bar progress-bar-container" />
     </div>
     <home-header-items
       v-else-if="show"
@@ -108,6 +110,16 @@ export default Vue.extend({
 </script>
 
 <style lang="scss" scoped>
+@import '~/assets/styles/HomeHeader.scss';
+.progress-bar-container {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+  padding: 10px 0;
+  height: 10px;
+}
+
 .no-items {
   overflow: hidden;
   animation-name: slideUp;

--- a/client/components/Layout/HomeHeader/HomeHeaderItems.vue
+++ b/client/components/Layout/HomeHeader/HomeHeaderItems.vue
@@ -76,6 +76,7 @@
       :duration="slideDuration"
       :paused="isPaused"
       class="px-2 px-sm-4 progress-bar"
+      hoverable
       @on-animation-end="onAnimationEnd"
       @on-progress-clicked="onProgressClicked"
     />

--- a/client/components/Layout/HomeHeader/SwiperProgressBar.vue
+++ b/client/components/Layout/HomeHeader/SwiperProgressBar.vue
@@ -1,12 +1,17 @@
 <template>
-  <div class="progress-container">
+  <div class="progress-bar-container">
     <div
       v-for="i in pages"
       :key="`progress-key-${i}`"
       ref="progress"
-      class="progress"
-      @click.self="onProgressClicked"
-    />
+      class="progress d-flex align-center justify-center"
+      :class="expand ? 'expand' : undefined"
+      @click="onProgressClicked(i)"
+    >
+      <v-chip v-if="expand" class="pager" color="primary">
+        {{ i }}
+      </v-chip>
+    </div>
   </div>
 </template>
 
@@ -31,12 +36,22 @@ export default Vue.extend({
       type: Boolean,
       required: true,
       default: false
+    },
+    hoverable: {
+      type: Boolean,
+      required: false,
+      default: false
     }
   },
   data() {
     return {
       bars: [] as HTMLElement[]
     };
+  },
+  computed: {
+    expand(): boolean {
+      return this.hoverable && !this.$vuetify.breakpoint.mobile;
+    }
   },
   watch: {
     currentIndex(): void {
@@ -93,10 +108,8 @@ export default Vue.extend({
     onAnimationEnd(): void {
       this.$emit('on-animation-end');
     },
-    onProgressClicked(event: MouseEvent): void {
-      const target = event.target as HTMLElement;
-
-      this.$emit('on-progress-clicked', this.bars.indexOf(target) as number);
+    onProgressClicked(index: number): void {
+      this.$emit('on-progress-clicked', index - 1);
     },
     togglePause(): void {
       if (this.paused) {
@@ -117,17 +130,34 @@ export default Vue.extend({
 </script>
 
 <style lang="scss" scoped>
-.progress-container {
+.progress-bar-container {
   box-sizing: border-box;
   display: flex;
   flex-direction: row;
   width: 100%;
   padding: 10px 0;
+  height: 10px;
+}
+
+.pager {
+  opacity: 0;
+  cursor: pointer;
+}
+
+.progress-bar-container:hover .expand {
+  height: 7px !important;
+  transition: height 0.25s;
+}
+
+.progress-bar-container:hover .pager {
+  opacity: 1;
+  transition: opacity 0.25s;
 }
 
 .progress {
   cursor: pointer;
   height: 2px;
+  transition: height 0.25s;
   flex-grow: 1;
   border-radius: 4px;
   margin: 0 3px;

--- a/client/components/Layout/HomeHeader/SwiperProgressBar.vue
+++ b/client/components/Layout/HomeHeader/SwiperProgressBar.vue
@@ -3,14 +3,14 @@
     <div
       v-for="i in pages"
       :key="`progress-key-${i}`"
-      ref="progress"
-      class="progress d-flex align-center justify-center"
-      :class="expand ? 'expand' : undefined"
-      @click="onProgressClicked(i)"
+      class="progress-bar"
+      @click.capture="onProgressClicked(i)"
     >
-      <v-chip v-if="expand" class="pager" color="primary">
-        {{ i }}
-      </v-chip>
+      <div
+        ref="progress"
+        class="progress d-flex align-center justify-center"
+        :class="expand ? 'expand' : undefined"
+      />
     </div>
   </div>
 </template>
@@ -135,27 +135,27 @@ export default Vue.extend({
   display: flex;
   flex-direction: row;
   width: 100%;
-  padding: 10px 0;
-  height: 10px;
+  padding: 0;
+  margin: 10px 0;
+  overflow: hidden;
+  justify-content: center;
 }
 
-.pager {
-  opacity: 0;
-  cursor: pointer;
+.progress-bar {
+  cursor: pointer !important;
+  height: 30px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-grow: 1;
 }
 
-.progress-bar-container:hover .expand {
-  height: 7px !important;
+.progress-bar:hover .expand.progress {
+  height: 10px !important;
   transition: height 0.25s;
 }
 
-.progress-bar-container:hover .pager {
-  opacity: 1;
-  transition: opacity 0.25s;
-}
-
 .progress {
-  cursor: pointer;
   height: 2px;
   transition: height 0.25s;
   flex-grow: 1;

--- a/client/components/Layout/HomeHeader/SwiperProgressBar.vue
+++ b/client/components/Layout/HomeHeader/SwiperProgressBar.vue
@@ -153,6 +153,7 @@ export default Vue.extend({
 .progress-bar:hover .expand.progress {
   height: 10px !important;
   transition: height 0.25s;
+  border-radius: 2px;
 }
 
 .progress {

--- a/client/layouts/default.vue
+++ b/client/layouts/default.vue
@@ -161,6 +161,14 @@ export default Vue.extend({
       } else if (!this.$store.state.page.showNavDrawer) {
         this.showNavDrawer({ showNavDrawer: true });
       }
+    },
+    '$vuetify.breakpoint.mobile': {
+      immediate: true,
+      handler(newVal: boolean): void {
+        if (newVal === true) {
+          this.drawer = false;
+        }
+      }
     }
   },
   beforeMount() {


### PR DESCRIPTION
* Added pagination indicators on hover in the progress bar (desktop only):

![image](https://user-images.githubusercontent.com/10274099/112564189-1be0be80-8ddb-11eb-9c3d-60bfb4f273a9.png)

Closes #864 

* Hide drawer when entering into the ``mobile`` breakpoint
* Fix margin issues with the swiper.