### PR TITLE
fix(ui): remove side margins from filter panel

### DIFF
--- a/client/assets/variables.scss
+++ b/client/assets/variables.scss
@@ -11,6 +11,7 @@ $body-font-family: $heading-font-family;
 $font-size-root: 14px;
 $input-font-size: 14px;
 $btn-font-weight: 500;
+$expansion-panel-content-padding: 0;
 
 $material-light: (
   'background': #f2f2f2,


### PR DESCRIPTION
The side margins don't look like they were intentional, and it definitely looks better without them. Chromium has a weird white box in the bottom right corner that I didn't bother looking into since Firefox works fine.

<img src="https://user-images.githubusercontent.com/21353219/112780575-16f26800-9084-11eb-8a98-f31d5f57ca1b.png" height="300px"> <img src="https://user-images.githubusercontent.com/21353219/112780577-18239500-9084-11eb-9b6a-09c06a36f0ba.png" height="300px">