### PR TITLE
chore(i18n): reword some translations for consistency and making translations easier

### DIFF
--- a/client/locales/en-US.json
+++ b/client/locales/en-US.json
@@ -17,9 +17,9 @@
   "buttons": {
     "ok": "Ok"
   },
-  "byArtist": "By",
+  "byArtist": "By {artist}",
   "cancel": "Cancel",
-  "castAndCrew": "Cast & Crew",
+  "castAndCrew": "Cast & crew",
   "collections": "Collections",
   "communityRating": "Community rating",
   "confirm": "Confirm",

--- a/client/pages/musicalbum/_itemId/index.vue
+++ b/client/pages/musicalbum/_itemId/index.vue
@@ -17,12 +17,11 @@
             class="text-subtitle-1 text-truncate mt-2"
             :class="{ 'text-center': !$vuetify.breakpoint.mdAndUp }"
           >
-            {{ $t('byArtist') }}
             <nuxt-link
               class="link"
               :to="getItemDetailsLink(item.AlbumArtists[0], 'MusicArtist')"
             >
-              {{ item.AlbumArtist }}
+              {{ $t('byArtist', { artist: item.AlbumArtist }) }}
             </nuxt-link>
           </h2>
           <div


### PR DESCRIPTION
* `Cast & Crew` -> `Cast & crew`
  Use a consistent capitalization with the rest of the client
* `By` -> `By {artist}`
  Add the artist to the string, to make it more understandable for translators and to allow changing the order of words if the language needs it.