### PR TITLE
fix(ui): margin and layout changes for audio controls

### DIFF
--- a/client/components/Item/ItemMenu.vue
+++ b/client/components/Item/ItemMenu.vue
@@ -10,7 +10,6 @@
       <template #activator="{ on, attrs }">
         <v-btn
           icon
-          small
           :outlined="outlined"
           :dark="dark"
           v-bind="attrs"

--- a/client/components/Layout/AudioControls.vue
+++ b/client/components/Layout/AudioControls.vue
@@ -11,7 +11,7 @@
       <v-container v-if="isFullScreenPlayer" fluid>
         <time-slider />
       </v-container>
-      <v-container class="pb-s" fluid>
+      <v-container fluid>
         <v-row class="ma-0">
           <v-col cols="9" md="3" class="d-flex flex-row pa-0">
             <nuxt-link :to="'/fullscreen/playback'">
@@ -25,37 +25,29 @@
                 <blurhash-image :item="getCurrentItem" />
               </v-avatar>
             </nuxt-link>
-            <v-col class="d-flex flex-column justify-center ml-4 py-0 mt-1">
-              <v-row class="pa-0">
+            <v-col class="d-flex flex-column justify-center ml-4">
+              <v-row class="align-end">
                 <nuxt-link
                   tag="span"
-                  class="text-truncate link mt-2 height-fit-content"
+                  class="text-truncate link height-fit-content"
                   :to="getItemDetailsLink(getCurrentItem)"
                 >
                   {{ getCurrentItem.Name }}
                 </nuxt-link>
               </v-row>
-              <v-row v-if="getCurrentItem.ArtistItems" class="pa-0">
+              <v-row v-if="getCurrentItem.ArtistItems" class="align-start">
                 <span
-                  v-for="(artist, index) in getCurrentItem.ArtistItems"
+                  v-for="artist in getCurrentItem.ArtistItems"
                   :key="`artist-${artist.Id}`"
                   :to="getItemDetailsLink(artist, 'MusicArtist')"
-                  class="ma-0"
                 >
-                  <p class="mb-0">
+                  <p class="mb-0 mr-2">
                     <nuxt-link
                       tag="span"
                       class="text--secondary text-caption text-truncate link"
                       :to="getItemDetailsLink(artist, 'MusicArtist')"
                       >{{ artist.Name }}</nuxt-link
                     >
-                    <!-- Handles whitespaces -->
-                    <!-- eslint-disable vue/no-v-html -->
-                    <span
-                      v-if="index !== getCurrentItem.ArtistItems.length - 1"
-                      v-html="'&nbsp;'"
-                    />
-                    <!-- eslint-enable vue/no-v-html -->
                   </p>
                 </span>
               </v-row>
@@ -68,7 +60,6 @@
                   icon
                   fab
                   small
-                  :elevation="isShuffling ? '3' : '0'"
                   class="mx-1 active-button"
                   :color="isShuffling ? 'primary' : undefined"
                   @click="toggleShuffle"
@@ -110,7 +101,6 @@
                   icon
                   fab
                   small
-                  :elevation="isRepeating ? '3' : '0'"
                   class="mx-1 active-button"
                   :color="isRepeating ? 'primary' : undefined"
                   @click="toggleRepeatMode"
@@ -127,11 +117,12 @@
             <div class="hidden-lg-and-down">
               <volume-slider />
             </div>
+            <item-menu :item="getCurrentItem" />
             <v-fade-transition>
               <v-tooltip v-if="!isFullScreenPlayer" top>
                 <template #activator="{ on, attrs }">
                   <nuxt-link tag="span" :to="'/fullscreen/playback'">
-                    <v-btn icon class="ml-2" v-bind="attrs" v-on="on">
+                    <v-btn icon v-bind="attrs" v-on="on">
                       <v-icon>mdi-fullscreen</v-icon>
                     </v-btn>
                   </nuxt-link>
@@ -139,7 +130,6 @@
                 <span>{{ $t('fullScreen') }}</span>
               </v-tooltip>
             </v-fade-transition>
-            <item-menu :item="getCurrentItem" />
           </v-col>
           <v-col
             cols="3"


### PR DESCRIPTION
- item menu button was likely made small for TrackList but doesn't match any other situations with normal sized icons
- album art in AudioControls had no bottom padding and the Name - Artist labels next to it had odd vertical alignment
- explicitly setting elevation to zero will cause a strange border on Firefox and should be avoided
- moved the fullscreen button to the end since this is where most people would expect a fullscreen button
- removed left padding on fullscreen button

<img src="https://user-images.githubusercontent.com/21353219/112922008-b415d500-9146-11eb-8add-918b8f163926.png" height="120px"> <img src="https://user-images.githubusercontent.com/21353219/112922010-b5470200-9146-11eb-8863-b360c613b070.png" height="120px">

<img src="https://user-images.githubusercontent.com/21353219/112921872-7c0e9200-9146-11eb-9d33-3e098c43634e.png" height="120px"> <img src="https://user-images.githubusercontent.com/21353219/112921874-7ca72880-9146-11eb-8016-efa23f527b31.png" height="120px">

<img src="https://user-images.githubusercontent.com/21353219/112922065-cd1e8600-9146-11eb-8a75-a11bf5c89e83.png" height="80px"> <img src="https://user-images.githubusercontent.com/21353219/112922069-cdb71c80-9146-11eb-806a-37e66dee03a4.png" height="80px">