### PR TITLE
fix(ui): span entire queue with hover background and standardize divider size

### DIFF
--- a/client/components/Buttons/QueueButton.vue
+++ b/client/components/Buttons/QueueButton.vue
@@ -50,7 +50,6 @@
         </v-list-item>
       </v-list>
       <v-divider />
-      <v-divider />
       <v-list class="overflow">
         <!-- We set an special property to destroy the element so it doesn't take resources while it's not being used.
         Specially useful for really huge queues -->

--- a/client/components/Players/DraggableQueue.vue
+++ b/client/components/Players/DraggableQueue.vue
@@ -1,13 +1,12 @@
 <template>
-  <v-list-item-group>
-    <draggable v-model="queue" v-bind="dragOptions" class="list-group">
+  <v-list-item-group class="list-group">
+    <draggable v-model="queue" v-bind="dragOptions" class="list-draggable">
       <v-hover
         v-for="(item, index) in queue"
         :key="`${item.Id}-${getUuid()}`"
         v-slot="{ hover }"
-        class="pa-0 ma-0"
       >
-        <v-list-item ripple class="pa-0 ma-0" @click="onClick(index)">
+        <v-list-item ripple @click="onClick(index)">
           <v-list-item-action
             v-if="!hover"
             class="list-group-item d-flex justify-center d-flex text-caption"
@@ -108,19 +107,15 @@ export default Vue.extend({
 </script>
 
 <style lang="scss" scoped>
-.flip-list-move {
-  transition: transform 0.5s;
-}
-
-.no-move {
-  transition: transform 0s;
+.list-group {
+  margin: 0 !important;
 }
 
 .ghost {
   opacity: 0;
 }
 
-.list-group {
+.list-draggable {
   user-select: none;
   min-height: 20px;
 }


### PR DESCRIPTION
- the hover background was getting cut off on the left side
- all other divider instances only use a single divider so this one looked unusually thick

<img src="https://user-images.githubusercontent.com/21353219/112923219-dad50b00-9148-11eb-9212-1c520ed00df0.png" height="200px"> <img src="https://user-images.githubusercontent.com/21353219/112923224-dc063800-9148-11eb-8693-1fe485ce70f1.png" height="200px">