### PR TITLE
fix(playback): use new queue when setting the current item index

### DIFF
--- a/client/store/playbackManager.ts
+++ b/client/store/playbackManager.ts
@@ -345,8 +345,8 @@ export const actions: ActionTree<PlaybackManagerState, PlaybackManagerState> = {
       lastItem = state.queue[state.lastItemIndex];
     }
 
-    const newIndex = state.queue?.indexOf(item as BaseItemDto);
-    const lastItemNewIndex = state.queue?.indexOf(lastItem as BaseItemDto);
+    const newIndex = queue?.indexOf(item as BaseItemDto);
+    const lastItemNewIndex = queue?.indexOf(lastItem as BaseItemDto);
 
     commit('SET_QUEUE', { queue });
     commit('SET_CURRENT_ITEM_INDEX', {


### PR DESCRIPTION
The audio player will currently force playback for a different song when the currently playing song is moved to a new location.