### PR TITLE
feat(blurhash-image): use web assembly version of the blurhash decoder

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,3 +5,5 @@ dist
 .vscode
 .devcontainer
 sw.*
+client/.nuxt
+client/dist

--- a/client/components/Item/Card/Card.vue
+++ b/client/components/Item/Card/Card.vue
@@ -208,8 +208,8 @@ export default Vue.extend({
       }
     },
     getImageType(): ImageType {
-      if (this.shape === 'thumb-card' && this.item.Type === 'Movie') {
-        return ImageType.Backdrop;
+      if (this.shape === 'thumb-card') {
+        return ImageType.Thumb;
       } else {
         return ImageType.Primary;
       }

--- a/client/components/Item/Metadata/ImageEditor.vue
+++ b/client/components/Item/Metadata/ImageEditor.vue
@@ -117,7 +117,7 @@ export default Vue.extend({
     },
     imageFormat(imageInfo: ImageInfo): string | undefined {
       if (imageInfo.ImageType && imageInfo.ImageTag) {
-        return this.getImageUrl(this.metadata, {
+        return this.getImageInfo(this.metadata, {
           preferThumb: imageInfo.ImageType === ImageType.Thumb,
           preferBanner: imageInfo.ImageType === ImageType.Banner,
           preferLogo: imageInfo.ImageType === ImageType.Logo,

--- a/client/components/Item/Metadata/ImageEditor.vue
+++ b/client/components/Item/Metadata/ImageEditor.vue
@@ -117,10 +117,13 @@ export default Vue.extend({
     },
     imageFormat(imageInfo: ImageInfo): string | undefined {
       if (imageInfo.ImageType && imageInfo.ImageTag) {
-        return this.getImageUrlForElement(imageInfo.ImageType, {
-          itemId: this.metadata.Id,
+        return this.getImageUrl(this.metadata, {
+          preferThumb: imageInfo.ImageType === ImageType.Thumb,
+          preferBanner: imageInfo.ImageType === ImageType.Banner,
+          preferLogo: imageInfo.ImageType === ImageType.Logo,
+          preferBackdrop: imageInfo.ImageType === ImageType.Backdrop,
           tag: imageInfo.ImageTag
-        });
+        }).url;
       }
     },
     handleSearch(): void {

--- a/client/components/Item/PersonList.vue
+++ b/client/components/Item/PersonList.vue
@@ -11,7 +11,7 @@
           <v-img
             v-if="item.PrimaryImageTag"
             ref="personImg"
-            :src="getImageUrl(item.Id)"
+            :src="getPersonImage(item).url"
           />
           <v-icon v-else class="grey darken-3">mdi-account</v-icon>
         </v-list-item-avatar>
@@ -37,8 +37,8 @@
 
 <script lang="ts">
 import Vue from 'vue';
-import { BaseItemPerson, ImageType } from '@jellyfin/client-axios';
-import imageHelper from '~/mixins/imageHelper';
+import { BaseItemDto, BaseItemPerson } from '@jellyfin/client-axios';
+import imageHelper, { ImageUrlInfo } from '~/mixins/imageHelper';
 import itemHelper from '~/mixins/itemHelper';
 
 export default Vue.extend({
@@ -56,13 +56,14 @@ export default Vue.extend({
     }
   },
   methods: {
-    getImageUrl(itemId: string): string | undefined {
+    getPersonImage(item: BaseItemDto): ImageUrlInfo {
       const element = this.$refs.personImg as HTMLElement;
 
-      return this.getImageUrlForElement(ImageType.Primary, {
-        itemId,
-        element
+      const image = this.getImageUrl(item, {
+        width: element?.clientWidth
       });
+
+      return image;
     }
   }
 });

--- a/client/components/Item/PersonList.vue
+++ b/client/components/Item/PersonList.vue
@@ -8,12 +8,13 @@
         :to="getItemDetailsLink(item, 'Person')"
       >
         <v-list-item-avatar>
-          <v-img
-            v-if="item.PrimaryImageTag"
-            ref="personImg"
-            :src="getPersonImage(item).url"
-          />
-          <v-icon v-else class="grey darken-3">mdi-account</v-icon>
+          <v-avatar color="card">
+            <blurhash-image :item="item">
+              <template #placeholder>
+                <v-icon size="16">mdi-account</v-icon>
+              </template>
+            </blurhash-image>
+          </v-avatar>
         </v-list-item-avatar>
         <v-list-item-content>
           <v-list-item-title>{{ item.Name }}</v-list-item-title>
@@ -37,8 +38,8 @@
 
 <script lang="ts">
 import Vue from 'vue';
-import { BaseItemDto, BaseItemPerson } from '@jellyfin/client-axios';
-import imageHelper, { ImageUrlInfo } from '~/mixins/imageHelper';
+import { BaseItemPerson } from '@jellyfin/client-axios';
+import imageHelper from '~/mixins/imageHelper';
 import itemHelper from '~/mixins/itemHelper';
 
 export default Vue.extend({
@@ -53,17 +54,6 @@ export default Vue.extend({
     skeletonLength: {
       type: Number,
       default: 0
-    }
-  },
-  methods: {
-    getPersonImage(item: BaseItemDto): ImageUrlInfo {
-      const element = this.$refs.personImg as HTMLElement;
-
-      const image = this.getImageUrl(item, {
-        width: element?.clientWidth
-      });
-
-      return image;
     }
   }
 });

--- a/client/components/Item/RelatedItems.vue
+++ b/client/components/Item/RelatedItems.vue
@@ -25,7 +25,9 @@
             :to="getItemDetailsLink(relatedItem)"
           >
             <v-list-item-avatar>
-              <blurhash-image :item="relatedItem" />
+              <v-avatar color="card">
+                <blurhash-image :item="relatedItem" icon-size="16" />
+              </v-avatar>
             </v-list-item-avatar>
             <v-list-item-content>
               <v-list-item-title>{{ relatedItem.Name }}</v-list-item-title>

--- a/client/components/Layout/AudioControls.vue
+++ b/client/components/Layout/AudioControls.vue
@@ -196,7 +196,7 @@
 </template>
 
 <script lang="ts">
-import { BaseItemDto, ImageType, RepeatMode } from '@jellyfin/client-axios';
+import { RepeatMode } from '@jellyfin/client-axios';
 import Vue from 'vue';
 import { mapActions, mapGetters, mapState } from 'vuex';
 import timeUtils from '~/mixins/timeUtils';
@@ -246,18 +246,7 @@ export default Vue.extend({
       'toggleShuffle',
       'toggleRepeatMode',
       'playPause'
-    ]),
-    getImageUrl(item: BaseItemDto): string | undefined {
-      const imageUrl = this.getImageUrlForElement(ImageType.Primary, { item });
-
-      if (imageUrl) {
-        return imageUrl;
-      }
-
-      return this.getImageUrlForElement(ImageType.Primary, {
-        itemId: item.AlbumId
-      });
-    }
+    ])
   }
 });
 </script>

--- a/client/components/Layout/HomeHeader/HomeHeader.vue
+++ b/client/components/Layout/HomeHeader/HomeHeader.vue
@@ -44,7 +44,7 @@ export default Vue.extend({
       await this.$api.userLibrary.getLatestMedia({
         userId: this.$auth.user?.Id,
         limit: this.pages,
-        fields: [ItemFields.Overview],
+        fields: [ItemFields.Overview, ItemFields.PrimaryImageAspectRatio],
         enableImageTypes: [ImageType.Backdrop, ImageType.Logo],
         imageTypeLimit: 1
       })

--- a/client/components/Layout/HomeHeader/HomeHeaderItems.vue
+++ b/client/components/Layout/HomeHeader/HomeHeaderItems.vue
@@ -165,7 +165,7 @@ export default Vue.extend({
       }
     },
     getLogo(item: BaseItemDto): string | undefined {
-      return this.getImageUrl(item, { preferLogo: true }).url;
+      return this.getImageInfo(item, { preferLogo: true }).url;
     },
     // HACK: Swiper seems to have a bug where the components inside of duplicated slides (when loop is enabled,
     // swiper creates a duplicate of the first one, so visually it looks like you started all over before repositioning all the DOM)

--- a/client/components/Layout/HomeHeader/HomeHeaderItems.vue
+++ b/client/components/Layout/HomeHeader/HomeHeaderItems.vue
@@ -13,7 +13,7 @@
           <div class="default-icon" />
           <blurhash-image
             :key="`${item.Id}-image`"
-            :item="getRelatedItem(item)"
+            :item="item"
             :type="'Backdrop'"
             :icon-size="$vuetify.breakpoint.mdAndUp ? '256' : '128'"
           />
@@ -165,11 +165,7 @@ export default Vue.extend({
       }
     },
     getLogo(item: BaseItemDto): string | undefined {
-      const relatedItem = this.getRelatedItem(item);
-
-      return this.getImageUrlForElement(ImageType.Logo, {
-        itemId: relatedItem.Id
-      });
+      return this.getImageUrl(item, { preferLogo: true }).url;
     },
     // HACK: Swiper seems to have a bug where the components inside of duplicated slides (when loop is enabled,
     // swiper creates a duplicate of the first one, so visually it looks like you started all over before repositioning all the DOM)

--- a/client/components/Layout/Images/BlurhashImage.vue
+++ b/client/components/Layout/Images/BlurhashImage.vue
@@ -1,6 +1,6 @@
 <template>
   <div ref="imageElement">
-    <div v-if="!error" ref="img" class="absolute">
+    <div v-if="!error" ref="img">
       <v-fade-transition>
         <blurhash-canvas
           v-if="hash"
@@ -23,17 +23,11 @@
         />
       </v-fade-transition>
     </div>
-    <div v-if="!$slots.placeholder" class="absolute icon img">
-      <v-icon
-        class="absolute text--disabled"
-        :size="iconSize"
-        color="white"
-        dark
-      >
+    <slot v-else name="placeholder">
+      <v-icon class="absolute text--disabled" :size="iconSize">
         {{ getItemIcon(item) }}
       </v-icon>
-    </div>
-    <slot v-else name="placeholder" />
+    </slot>
   </div>
 </template>
 
@@ -179,9 +173,5 @@ export default Vue.extend({
 .img {
   color: transparent;
   object-fit: cover;
-}
-
-.icon {
-  z-index: -5;
 }
 </style>

--- a/client/components/Layout/Images/BlurhashImage.vue
+++ b/client/components/Layout/Images/BlurhashImage.vue
@@ -120,7 +120,7 @@ export default Vue.extend({
       this.$nextTick(() => {
         const element = this.$refs.imageElement as HTMLImageElement;
 
-        const imageInfo = this.getImageUrl(this.item, {
+        const imageInfo = this.getImageInfo(this.item, {
           preferThumb: this.type === ImageType.Thumb,
           preferBanner: this.type === ImageType.Banner,
           preferLogo: this.type === ImageType.Logo,

--- a/client/components/Layout/Images/BlurhashImage.vue
+++ b/client/components/Layout/Images/BlurhashImage.vue
@@ -1,19 +1,19 @@
 <template>
-  <div class="absolute">
+  <div ref="imageElement">
     <div v-if="!error" ref="img" class="absolute">
-      <blurhash-canvas
-        v-if="hash"
-        key="canvas"
-        :hash="hash"
-        :width="width"
-        :height="height"
-        :punch="punch"
-        class="absolute"
-      />
+      <v-fade-transition>
+        <blurhash-canvas
+          v-if="hash"
+          :hash="hash"
+          :width="width"
+          :height="height"
+          :punch="punch"
+          class="absolute"
+        />
+      </v-fade-transition>
       <v-fade-transition>
         <img
           v-show="!loading"
-          :key="`blurhashimage-${item.Id}`"
           class="absolute img"
           :src="image"
           v-bind="$attrs"
@@ -79,6 +79,7 @@ export default Vue.extend({
   data() {
     return {
       image: '' as string | undefined,
+      tag: '' as string,
       loading: true,
       error: false,
       resetting: false
@@ -122,16 +123,25 @@ export default Vue.extend({
       this.error = true;
     },
     getImage(): void {
-      const img = this.$refs.img as HTMLElement;
+      this.$nextTick(() => {
+        const element = this.$refs.imageElement as HTMLImageElement;
 
-      this.image = this.getImageUrlForElement(this.type, {
-        item: this.item,
-        element: img
+        const imageInfo = this.getImageUrl(this.item, {
+          preferThumb: this.type === ImageType.Thumb,
+          preferBanner: this.type === ImageType.Banner,
+          preferLogo: this.type === ImageType.Logo,
+          preferBackdrop: this.type === ImageType.Backdrop,
+          width: element?.clientWidth,
+          ratio: window.devicePixelRatio || 1
+        });
+
+        this.image = imageInfo.url;
+        this.tag = imageInfo.tag ? imageInfo.tag : 'no-image-tag';
+
+        if (!this.image) {
+          this.onError();
+        }
       });
-
-      if (!this.image) {
-        this.onError();
-      }
     },
     resetImage(hideImage = true): void {
       const previousUrl = this.image;

--- a/client/components/Layout/SwiperSection.vue
+++ b/client/components/Layout/SwiperSection.vue
@@ -32,6 +32,7 @@ import Vue from 'vue';
 import { SwiperOptions } from 'swiper';
 import { v4 as uuidv4 } from 'uuid';
 import { BaseItemDto } from '@jellyfin/client-axios';
+import { getShapeFromItemType } from '~/utils/items';
 
 export default Vue.extend({
   props: {
@@ -54,7 +55,7 @@ export default Vue.extend({
     shape: {
       type: String,
       default(): string {
-        return '';
+        return getShapeFromItemType(this.items?.[0]?.Type);
       }
     }
   },

--- a/client/components/Players/PlayerManager.vue
+++ b/client/components/Players/PlayerManager.vue
@@ -157,7 +157,6 @@
 </template>
 
 <script lang="ts">
-import { ImageType } from '@jellyfin/client-axios';
 import Vue from 'vue';
 import { mapActions, mapGetters, mapState } from 'vuex';
 import imageHelper from '~/mixins/imageHelper';
@@ -523,50 +522,44 @@ export default Vue.extend({
           artwork: [
             {
               src:
-                this.getImageUrlForElement(ImageType.Primary, {
-                  item: this.getCurrentItem,
-                  maxWidth: 96
-                }) || '',
+                this.getImageUrl(this.getCurrentItem, {
+                  width: 96
+                }).url || '',
               sizes: '96x96'
             },
             {
               src:
-                this.getImageUrlForElement(ImageType.Primary, {
-                  item: this.getCurrentItem,
-                  maxWidth: 128
-                }) || '',
+                this.getImageUrl(this.getCurrentItem, {
+                  width: 128
+                }).url || '',
               sizes: '128x128'
             },
             {
               src:
-                this.getImageUrlForElement(ImageType.Primary, {
-                  item: this.getCurrentItem,
-                  maxWidth: 192
-                }) || '',
+                this.getImageUrl(this.getCurrentItem, {
+                  width: 192
+                }).url || '',
               sizes: '192x192'
             },
             {
               src:
-                this.getImageUrlForElement(ImageType.Primary, {
-                  item: this.getCurrentItem,
-                  maxWidth: 256
-                }) || '',
+                this.getImageUrl(this.getCurrentItem, {
+                  width: 256
+                }).url || '',
               sizes: '256x256'
             },
             {
               src:
-                this.getImageUrlForElement(ImageType.Primary, {
-                  item: this.getCurrentItem,
-                  maxWidth: 384
-                }) || '',
+                this.getImageUrl(this.getCurrentItem, {
+                  width: 384
+                }).url || '',
               sizes: '384x384'
             },
             {
               src:
-                this.getImageUrlForElement(ImageType.Primary, {
-                  item: this.getCurrentItem,
-                  maxWidth: 512
-                }) || '',
+                this.getImageUrl(this.getCurrentItem, {
+                  width: 512
+                }).url || '',
               sizes: '512x512'
             }
           ]

--- a/client/components/Players/PlayerManager.vue
+++ b/client/components/Players/PlayerManager.vue
@@ -522,42 +522,42 @@ export default Vue.extend({
           artwork: [
             {
               src:
-                this.getImageUrl(this.getCurrentItem, {
+                this.getImageInfo(this.getCurrentItem, {
                   width: 96
                 }).url || '',
               sizes: '96x96'
             },
             {
               src:
-                this.getImageUrl(this.getCurrentItem, {
+                this.getImageInfo(this.getCurrentItem, {
                   width: 128
                 }).url || '',
               sizes: '128x128'
             },
             {
               src:
-                this.getImageUrl(this.getCurrentItem, {
+                this.getImageInfo(this.getCurrentItem, {
                   width: 192
                 }).url || '',
               sizes: '192x192'
             },
             {
               src:
-                this.getImageUrl(this.getCurrentItem, {
+                this.getImageInfo(this.getCurrentItem, {
                   width: 256
                 }).url || '',
               sizes: '256x256'
             },
             {
               src:
-                this.getImageUrl(this.getCurrentItem, {
+                this.getImageInfo(this.getCurrentItem, {
                   width: 384
                 }).url || '',
               sizes: '384x384'
             },
             {
               src:
-                this.getImageUrl(this.getCurrentItem, {
+                this.getImageInfo(this.getCurrentItem, {
                   width: 512
                 }).url || '',
               sizes: '512x512'

--- a/client/components/Players/VideoPlayer.vue
+++ b/client/components/Players/VideoPlayer.vue
@@ -51,7 +51,7 @@ export default Vue.extend({
     ...mapState('deviceProfile', ['deviceId']),
     ...mapState('user', ['accessToken']),
     poster(): ImageUrlInfo {
-      return this.getImageUrl(this.getCurrentItem, { preferBackdrop: true });
+      return this.getImageInfo(this.getCurrentItem, { preferBackdrop: true });
     }
   },
   watch: {

--- a/client/components/Players/VideoPlayer.vue
+++ b/client/components/Players/VideoPlayer.vue
@@ -2,7 +2,7 @@
   <v-container fill-height fluid class="pa-0 justify-center">
     <video
       ref="videoPlayer"
-      :poster="poster"
+      :poster="poster.url"
       autoplay
       @timeupdate="onVideoProgressThrottled"
       @pause="onVideoPause"
@@ -19,14 +19,10 @@ import throttle from 'lodash/throttle';
 // @ts-expect-error - This module doesn't have typings
 import muxjs from 'mux.js';
 import { mapActions, mapGetters, mapState } from 'vuex';
-import {
-  ImageType,
-  PlaybackInfoResponse,
-  RepeatMode
-} from '@jellyfin/client-axios';
+import { PlaybackInfoResponse, RepeatMode } from '@jellyfin/client-axios';
 import { AppState } from '~/store';
 import timeUtils from '~/mixins/timeUtils';
-import imageHelper from '~/mixins/imageHelper';
+import imageHelper, { ImageUrlInfo } from '~/mixins/imageHelper';
 
 declare global {
   interface Window {
@@ -54,13 +50,8 @@ export default Vue.extend({
     ...mapState('playbackManager', ['currentTime', 'lastProgressUpdate']),
     ...mapState('deviceProfile', ['deviceId']),
     ...mapState('user', ['accessToken']),
-    poster(): string | undefined {
-      return this.getImageUrlForElement(ImageType.Backdrop, {
-        itemId:
-          this.getCurrentItem?.ParentBackdropItemId ||
-          this.getCurrentItem?.SeriesId ||
-          this.getCurrentItem?.Id
-      });
+    poster(): ImageUrlInfo {
+      return this.getImageUrl(this.getCurrentItem, { preferBackdrop: true });
     }
   },
   watch: {

--- a/client/mixins/imageHelper.ts
+++ b/client/mixins/imageHelper.ts
@@ -29,7 +29,7 @@ declare module '@nuxt/types' {
       index?: number,
       checkParent?: boolean
     ): string | undefined;
-    getImageUrl(
+    getImageInfo(
       item: BaseItemDto,
       options?: {
         shape?: CardShapes;
@@ -60,7 +60,7 @@ declare module '@nuxt/types' {
       index?: number,
       checkParent?: boolean
     ): string | undefined;
-    getImageUrl(
+    getImageInfo(
       item: BaseItemDto,
       options?: {
         shape?: CardShapes;
@@ -93,7 +93,7 @@ declare module 'vue/types/vue' {
       index?: number,
       checkParent?: boolean
     ): string | undefined;
-    getImageUrl(
+    getImageInfo(
       item: BaseItemDto,
       options?: {
         shape?: CardShapes;
@@ -269,7 +269,7 @@ const imageHelper = Vue.extend({
 
       return aspectRatio;
     },
-    getImageUrl(
+    getImageInfo(
       item: BaseItemDto | BaseItemPerson,
       {
         shape = getShapeFromItemType(item.Type),

--- a/client/mixins/imageHelper.ts
+++ b/client/mixins/imageHelper.ts
@@ -6,7 +6,7 @@
 import Vue from 'vue';
 import { stringify } from 'qs';
 import { BaseItemDto, BaseItemPerson, ImageType } from '@jellyfin/client-axios';
-import { getShapeFromItemType, CardShapes } from '~/utils/items';
+import { getShapeFromItemType, CardShapes, isPerson } from '~/utils/items';
 
 export interface ImageUrlInfo {
   url: string | undefined;
@@ -109,16 +109,6 @@ declare module 'vue/types/vue' {
       }
     ): ImageUrlInfo;
   }
-}
-
-/**
- * Checks if the passed object is BaseItemDto or BaseItemPerson
- *
- * @param {BaseItemDto|BaseItemPerson} obj - The object to check
- * @returns {boolean} Returns true if the object is a person, false otherwise.
- */
-function isPerson(obj: BaseItemDto | BaseItemPerson): obj is BaseItemPerson {
-  return (obj as BaseItemPerson)?.Role !== undefined;
 }
 
 const excludedBlurhashTypes = [ImageType.Logo];

--- a/client/pages/artist/_itemId/index.vue
+++ b/client/pages/artist/_itemId/index.vue
@@ -86,7 +86,7 @@
                     <v-img
                       cover
                       aspect-ratio="1.7778"
-                      :src="getImageUrl(item, { preferBackdrop: true }).url"
+                      :src="getImageInfo(item, { preferBackdrop: true }).url"
                     />
                     <div v-if="item.Overview">
                       <h2 class="text-h6 mt-2">

--- a/client/pages/artist/_itemId/index.vue
+++ b/client/pages/artist/_itemId/index.vue
@@ -3,13 +3,20 @@
     <template #left>
       <v-row justify="center" justify-sm="start">
         <v-col cols="6" sm="3" class="d-flex flex-row">
-          <v-img
-            v-if="item.ImageTags && item.ImageTags.Primary"
-            class="person-image elevation-2"
-            cover
-            aspect-ratio="1"
-            :src="getImageUrl(item.Id, 'Primary')"
-          />
+          <v-responsive aspect-ratio="1">
+            <v-avatar
+              color="card"
+              width="100%"
+              height="100%"
+              class="elevation-2"
+            >
+              <blurhash-image
+                v-if="item.ImageTags && item.ImageTags.Primary"
+                :item="item"
+              />
+              <v-icon v-else size="128" dark>mdi-account</v-icon>
+            </v-avatar>
+          </v-responsive>
         </v-col>
         <v-col cols="12" sm="7">
           <v-row justify="space-between">
@@ -83,7 +90,7 @@
                     <v-img
                       cover
                       aspect-ratio="1.7778"
-                      :src="getImageUrl(item.Id, 'Backdrop')"
+                      :src="getImageUrl(item, { preferBackdrop: true }).url"
                     />
                     <div v-if="item.Overview">
                       <h2 class="text-h6 mt-2">
@@ -120,8 +127,10 @@ import imageHelper from '~/mixins/imageHelper';
 import timeUtils from '~/mixins/timeUtils';
 import itemHelper from '~/mixins/itemHelper';
 import { isValidMD5 } from '~/utils/items';
+import BlurhashImage from '~/components/Layout/Images/BlurhashImage.vue';
 
 export default Vue.extend({
+  components: { BlurhashImage },
   mixins: [htmlHelper, imageHelper, timeUtils, itemHelper],
   validate(ctx: Context) {
     return isValidMD5(ctx.route.params.itemId);
@@ -194,14 +203,7 @@ export default Vue.extend({
   },
   methods: {
     ...mapActions('page', ['setPageTitle', 'setAppBarOpacity']),
-    ...mapActions('backdrop', ['setBackdrop', 'clearBackdrop']),
-    getImageUrl(itemId: string | undefined, type: string): string | undefined {
-      if (itemId) {
-        return this.getImageUrlForElement(type as ImageType, { itemId });
-      } else {
-        return '';
-      }
-    }
+    ...mapActions('backdrop', ['setBackdrop', 'clearBackdrop'])
   }
 });
 </script>

--- a/client/pages/artist/_itemId/index.vue
+++ b/client/pages/artist/_itemId/index.vue
@@ -3,18 +3,18 @@
     <template #left>
       <v-row justify="center" justify-sm="start">
         <v-col cols="6" sm="3" class="d-flex flex-row">
-          <v-responsive aspect-ratio="1">
+          <v-responsive aspect-ratio="1" class="overflow-visible">
             <v-avatar
               color="card"
               width="100%"
               height="100%"
               class="elevation-2"
             >
-              <blurhash-image
-                v-if="item.ImageTags && item.ImageTags.Primary"
-                :item="item"
-              />
-              <v-icon v-else size="128" dark>mdi-account</v-icon>
+              <blurhash-image :item="item">
+                <template #placeholder>
+                  <v-icon size="128">mdi-account</v-icon>
+                </template>
+              </blurhash-image>
             </v-avatar>
           </v-responsive>
         </v-col>
@@ -127,10 +127,8 @@ import imageHelper from '~/mixins/imageHelper';
 import timeUtils from '~/mixins/timeUtils';
 import itemHelper from '~/mixins/itemHelper';
 import { isValidMD5 } from '~/utils/items';
-import BlurhashImage from '~/components/Layout/Images/BlurhashImage.vue';
 
 export default Vue.extend({
-  components: { BlurhashImage },
   mixins: [htmlHelper, imageHelper, timeUtils, itemHelper],
   validate(ctx: Context) {
     return isValidMD5(ctx.route.params.itemId);

--- a/client/pages/artist/_itemId/index.vue
+++ b/client/pages/artist/_itemId/index.vue
@@ -10,11 +10,7 @@
               height="100%"
               class="elevation-2"
             >
-              <blurhash-image :item="item">
-                <template #placeholder>
-                  <v-icon size="128">mdi-account</v-icon>
-                </template>
-              </blurhash-image>
+              <blurhash-image :item="item" />
             </v-avatar>
           </v-responsive>
         </v-col>

--- a/client/pages/person/_itemId/index.vue
+++ b/client/pages/person/_itemId/index.vue
@@ -11,11 +11,7 @@
                 height="100%"
                 class="elevation-2"
               >
-                <blurhash-image :item="item">
-                  <template #placeholder>
-                    <v-icon size="128">mdi-account</v-icon>
-                  </template>
-                </blurhash-image>
+                <blurhash-image :item="item" />
               </v-avatar>
             </v-responsive>
           </v-col>

--- a/client/pages/person/_itemId/index.vue
+++ b/client/pages/person/_itemId/index.vue
@@ -4,14 +4,20 @@
       <v-col cols="12">
         <v-row>
           <v-col cols="2">
-            <v-img
-              v-if="item.Id"
-              ref="personImg"
-              class="person-image elevation-2 ml-2"
-              cover
-              aspect-ratio="1"
-              :src="getImageUrl(item.Id)"
-            />
+            <v-responsive aspect-ratio="1">
+              <v-avatar
+                color="card"
+                width="100%"
+                height="100%"
+                class="elevation-2"
+              >
+                <blurhash-image
+                  v-if="item.ImageTags && item.ImageTags.Primary"
+                  :item="item"
+                />
+                <v-icon v-else size="128" dark>mdi-account</v-icon>
+              </v-avatar>
+            </v-responsive>
           </v-col>
           <v-col cols="7">
             <div
@@ -43,7 +49,7 @@
             </v-row>
             <v-row v-if="birthPlace">
               <v-col cols="3" class="text--secondary">
-                {{ $t('item.person.birthplace') }}
+                {{ $t('item.person.birthPlace') }}
               </v-col>
               <v-col cols="9">
                 {{ birthPlace }}
@@ -180,19 +186,7 @@ export default Vue.extend({
   },
   methods: {
     ...mapActions('page', ['setPageTitle', 'setAppBarOpacity']),
-    ...mapActions('backdrop', ['setBackdrop', 'clearBackdrop']),
-    getImageUrl(itemId: string | undefined): string | undefined {
-      const element = this.$refs.personImg as HTMLElement;
-
-      if (itemId) {
-        return this.getImageUrlForElement(ImageType.Primary, {
-          itemId,
-          element
-        });
-      } else {
-        return '';
-      }
-    }
+    ...mapActions('backdrop', ['setBackdrop', 'clearBackdrop'])
   }
 });
 </script>

--- a/client/pages/person/_itemId/index.vue
+++ b/client/pages/person/_itemId/index.vue
@@ -11,11 +11,11 @@
                 height="100%"
                 class="elevation-2"
               >
-                <blurhash-image
-                  v-if="item.ImageTags && item.ImageTags.Primary"
-                  :item="item"
-                />
-                <v-icon v-else size="128" dark>mdi-account</v-icon>
+                <blurhash-image :item="item">
+                  <template #placeholder>
+                    <v-icon size="128">mdi-account</v-icon>
+                  </template>
+                </blurhash-image>
               </v-avatar>
             </v-responsive>
           </v-col>

--- a/client/store/tvShows.ts
+++ b/client/store/tvShows.ts
@@ -135,7 +135,7 @@ export const actions: ActionTree<TvShowsState, TvShowsState> = {
       const { data } = await this.$api.items.getItems({
         userId: this.$auth.user?.Id,
         parentId: season.Id,
-        fields: [ItemFields.Overview]
+        fields: [ItemFields.Overview, ItemFields.PrimaryImageAspectRatio]
       });
 
       dispatch('getTvShowsSeasonEpisodesSuccess', {

--- a/client/utils/__tests__/items.spec.ts
+++ b/client/utils/__tests__/items.spec.ts
@@ -34,8 +34,8 @@ describe('getShapeFromCollectionType', () => {
     expect(getShapeFromCollectionType('folders')).toEqual('square-card');
     expect(getShapeFromCollectionType('playlists')).toEqual('square-card');
     expect(getShapeFromCollectionType('music')).toEqual('square-card');
-    expect(getShapeFromCollectionType(undefined)).toEqual('square-card');
-    expect(getShapeFromCollectionType(null)).toEqual('square-card');
+    expect(getShapeFromCollectionType(undefined)).toEqual('portrait-card');
+    expect(getShapeFromCollectionType(null)).toEqual('portrait-card');
   });
 });
 

--- a/client/utils/items.ts
+++ b/client/utils/items.ts
@@ -1,3 +1,5 @@
+import { BaseItemPerson } from '@jellyfin/client-axios';
+
 /**
  * A list of valid collections that should be treated as folders.
  */
@@ -8,6 +10,26 @@ export const validLibraryTypes = [
   'playlists',
   'PhotoAlbum'
 ];
+
+export type CardShapes =
+  | 'portrait-card'
+  | 'thumb-card'
+  | 'square-card'
+  | 'banner-card';
+
+/**
+ * Determines if the item is a person
+ *
+ * @param {*} item - The item to be checked.
+ * @returns {boolean} Whether the provided item is of type BaseItemPerson.
+ */
+export function isPerson(item: unknown): item is BaseItemPerson {
+  if ((item as BaseItemPerson).Role) {
+    return true;
+  }
+
+  return false;
+}
 
 /**
  * Checks if the string is a valid MD5 hash.
@@ -61,7 +83,7 @@ export function getLibraryIcon(libraryType: string | undefined | null): string {
  */
 export function getShapeFromCollectionType(
   collectionType: string | null | undefined
-): string {
+): CardShapes {
   switch (collectionType?.toLowerCase()) {
     case 'boxsets':
     case 'movies':
@@ -69,6 +91,7 @@ export function getShapeFromCollectionType(
     case 'books':
       return 'portrait-card';
     case 'livetv':
+    case 'musicvideos':
       return 'thumb-card';
     case 'folders':
     case 'playlists':
@@ -86,7 +109,7 @@ export function getShapeFromCollectionType(
  */
 export function getShapeFromItemType(
   itemType: string | null | undefined
-): string {
+): CardShapes {
   switch (itemType?.toLowerCase()) {
     case 'audio':
     case 'folder':
@@ -98,6 +121,7 @@ export function getShapeFromItemType(
     case 'video':
       return 'square-card';
     case 'episode':
+    case 'musicvideo':
     case 'studio':
       return 'thumb-card';
     case 'book':

--- a/client/utils/items.ts
+++ b/client/utils/items.ts
@@ -111,6 +111,7 @@ export function getShapeFromCollectionType(
 export function getShapeFromItemType(
   itemType: string | null | undefined
 ): CardShapes {
+  // TODO: Refactor to take a BaseItemDto or BaseItemPerson instead
   switch (itemType?.toLowerCase()) {
     case 'audio':
     case 'folder':

--- a/client/utils/items.ts
+++ b/client/utils/items.ts
@@ -1,4 +1,4 @@
-import { BaseItemPerson } from '@jellyfin/client-axios';
+import { BaseItemDto, BaseItemPerson } from '@jellyfin/client-axios';
 
 /**
  * A list of valid collections that should be treated as folders.
@@ -9,6 +9,17 @@ export const validLibraryTypes = [
   'UserView',
   'playlists',
   'PhotoAlbum'
+];
+
+export const validPersonTypes = [
+  'Actor',
+  'Director',
+  'Composer',
+  'Writer',
+  'GuestStar',
+  'Producer',
+  'Conductor',
+  'Lyricist'
 ];
 
 export type CardShapes =
@@ -23,8 +34,13 @@ export type CardShapes =
  * @param {*} item - The item to be checked.
  * @returns {boolean} Whether the provided item is of type BaseItemPerson.
  */
-export function isPerson(item: unknown): item is BaseItemPerson {
-  if ((item as BaseItemPerson).Role) {
+export function isPerson(
+  item: BaseItemDto | BaseItemPerson
+): item is BaseItemPerson {
+  if (
+    'Role' in (item as BaseItemPerson) ||
+    (item.Type && validPersonTypes.includes(item.Type))
+  ) {
     return true;
   }
 

--- a/client/utils/items.ts
+++ b/client/utils/items.ts
@@ -96,8 +96,9 @@ export function getShapeFromCollectionType(
     case 'folders':
     case 'playlists':
     case 'music':
-    default:
       return 'square-card';
+    default:
+      return 'portrait-card';
   }
 }
 

--- a/client/utils/playbackUtils.ts
+++ b/client/utils/playbackUtils.ts
@@ -92,7 +92,7 @@ export async function translateItemsForPlayback(
               userId: (window.$nuxt.$auth.user as UserDto).Id,
               seriesId: item.SeriesId,
               isMissing: false,
-              fields: [ItemFields.Chapters],
+              fields: [ItemFields.Chapters, ItemFields.PrimaryImageAspectRatio],
               startItemId: item.Id
             })
           ).data.Items || item;


### PR DESCRIPTION
For speed and glory, this replaces the web worker decoding with the (way faster) Rust-based one.

The import is a bit janky, but we have to force a split in the Webpack bundles by using a dynamic import, hence this madness.