### PR TITLE
feat(audio): gapless playback

### DIFF
--- a/client/components/Players/PlayerManager.vue
+++ b/client/components/Players/PlayerManager.vue
@@ -290,7 +290,10 @@ export default Vue.extend({
           break;
         }
         case 'playbackManager/STOP_PLAYBACK':
-          if (state.playbackManager.currentTime !== null) {
+          if (
+            state.playbackManager.currentTime !== null &&
+            this.getPreviousItem?.Id
+          ) {
             this.$api.playState.reportPlaybackStopped(
               {
                 playbackStopInfo: {
@@ -313,7 +316,10 @@ export default Vue.extend({
 
           break;
         case 'playbackManager/PAUSE_PLAYBACK':
-          if (state.playbackManager.currentTime !== null) {
+          if (
+            state.playbackManager.currentTime !== null &&
+            this.getCurrentItem?.Id
+          ) {
             this.$api.playState.reportPlaybackProgress(
               {
                 playbackProgressInfo: {


### PR DESCRIPTION
Marking as draft as I didn't have the chance to test proper gapless tracks, but I checked some tracks that start rightaway and it's absolutely seamless. Once I test with gapless files I will label as ready.

* Loads 3 audio players to prefetch next tracks (easily changeable in the future) and switches seamlessly between them.
* Disables progress bar when fetching playback info (loading them into Shaka doesn't show any progress either)

The multiple audio player approach is not only helpful for prefetching but also for crossfade features once that's worked on as well.