### PR TITLE
ci(rebase): quote reaction

### DIFF
--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           token: ${{ secrets.GH_TOKEN }}
           comment-id: ${{ github.event.comment.id }}
-          reactions: +1
+          reactions: '+1'
       - name: Checkout the latest code
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Without the quote yaml interpreter takes it as an incomplete sum instead of a string