### PR TITLE
fix(library): fixed mixed library item fetching

### DIFF
--- a/client/pages/library/_viewId.vue
+++ b/client/pages/library/_viewId.vue
@@ -290,12 +290,16 @@ export default Vue.extend({
                 includeItemTypes: this.viewType,
                 sortBy:
                   this.collectionInfo.CollectionType === 'homevideos' ||
-                  this.collectionInfo.Type === 'Folder'
+                  this.collectionInfo.Type === 'Folder' ||
+                  (this.collectionInfo.Type === 'CollectionFolder' &&
+                    !('CollectionType' in this.collectionInfo))
                     ? 'IsFolder,SortName'
                     : this.sortBy,
                 recursive:
                   this.collectionInfo.CollectionType === 'homevideos' ||
-                  this.collectionInfo.Type === 'Folder'
+                  this.collectionInfo.Type === 'Folder' ||
+                  (this.collectionInfo.Type === 'CollectionFolder' &&
+                    !('CollectionType' in this.collectionInfo))
                     ? undefined
                     : true,
                 sortOrder: 'Ascending',


### PR DESCRIPTION
Fixes item listing in mixed libraries.

It was fetching recursively before, when it shouldn't have been.