### PR TITLE
fix(layout): exclude fullscreen-playback from the pages kept alive

### DIFF
--- a/client/layouts/default.vue
+++ b/client/layouts/default.vue
@@ -100,7 +100,10 @@
     </v-app-bar>
     <v-main>
       <div class="pa-s">
-        <nuxt keep-alive :keep-alive-props="{ max: 10 }" />
+        <nuxt
+          keep-alive
+          :keep-alive-props="{ max: 10, exclude: ['fullscreen-playback'] }"
+        />
       </div>
     </v-main>
     <audio-controls />


### PR DESCRIPTION
Fixes #976 (at least it should)