### PR TITLE
feat(robots): disallow all crawling

### DIFF
--- a/client/static/robots.txt
+++ b/client/static/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
As reported by Lighthouse, we don't have a robots.txt:
![image](https://user-images.githubusercontent.com/19396809/114169021-5432e180-9931-11eb-86e4-0f08333254c6.png)

The one in this disallows all crawling, as a default. It is easily changeable if, for whatever reason, someone wants to make their server public and searchable through Google or something (Though there is no auto-login for a public user at this point in time).