### PR TITLE
Feat/episode serie link

### DIFF
--- a/client/components/Item/Card/Card.vue
+++ b/client/components/Item/Card/Card.vue
@@ -229,6 +229,8 @@ export default Vue.extend({
           this.item.AlbumArtists[0],
           'MusicArtist'
         );
+      } else if (this.item.Type === 'Episode') {
+        return this.getItemDetailsLink(this.item);
       }
 
       return undefined;

--- a/client/components/Item/Card/Card.vue
+++ b/client/components/Item/Card/Card.vue
@@ -78,10 +78,9 @@
       </nuxt-link>
       <!-- CARD SUBTITLE -->
       <nuxt-link
-        v-if="item.Type === 'MusicAlbum' && item.AlbumArtists.length > 0"
-        tag="div"
-        class="card-subtitle text--secondary text-truncate link"
-        :to="getItemDetailsLink(item.AlbumArtists[0], 'MusicArtist')"
+        v-if="cardSubtitleLink"
+        class="link d-block card-subtitle text--secondary text-truncate"
+        :to="cardSubtitleLink"
       >
         {{ cardSubtitle }}
       </nuxt-link>
@@ -216,6 +215,23 @@ export default Vue.extend({
       }
 
       return this.getItemDetailsLink(this.item);
+    },
+    /*
+     * @returns {string|undefined} A link to be applied to the subtitle
+     */
+    cardSubtitleLink(): string | undefined {
+      if (
+        this.item.Type === 'MusicAlbum' &&
+        this.item.AlbumArtists &&
+        this.item.AlbumArtists.length > 0
+      ) {
+        return this.getItemDetailsLink(
+          this.item.AlbumArtists[0],
+          'MusicArtist'
+        );
+      }
+
+      return undefined;
     },
     progress: {
       get(): number | false {

--- a/client/components/Item/Card/Card.vue
+++ b/client/components/Item/Card/Card.vue
@@ -1,7 +1,6 @@
 <template>
   <div :class="{ 'card-margin': margin, 'link-disabled': !link }">
     <nuxt-link
-      :event="link ? 'click' : null"
       :to="getItemDetailsLink(item)"
       :class="link ? null : 'link-disabled'"
       class="card-box nuxt-link"

--- a/client/components/Item/Card/Card.vue
+++ b/client/components/Item/Card/Card.vue
@@ -1,14 +1,12 @@
 <template>
-  <nuxt-link
-    :event="link ? 'click' : null"
-    :to="getItemDetailsLink(item)"
-    :class="link ? null : 'link-disabled'"
-    class="nuxt-link"
-  >
-    <div
-      class="card-box"
-      :class="{ 'card-margin': margin, 'link-disabled': !link }"
+  <div :class="{ 'card-margin': margin, 'link-disabled': !link }">
+    <nuxt-link
+      :event="link ? 'click' : null"
+      :to="getItemDetailsLink(item)"
+      :class="link ? null : 'link-disabled'"
+      class="card-box nuxt-link"
     >
+      <!-- CARD -->
       <div :class="shape || cardType" class="elevation-2">
         <div
           class="card-content card-content-button d-flex justify-center align-center darken-4"
@@ -69,22 +67,25 @@
           </div>
         </div>
       </div>
-      <div v-if="text" class="card-text">
-        <div class="card-title mt-1 text-truncate">{{ cardTitle }}</div>
-        <nuxt-link
-          v-if="item.Type === 'MusicAlbum' && item.AlbumArtists.length > 0"
-          tag="div"
-          class="card-subtitle text--secondary text-truncate link"
-          :to="getItemDetailsLink(item.AlbumArtists[0], 'MusicArtist')"
-        >
-          {{ cardSubtitle }}
-        </nuxt-link>
-        <div v-else class="card-subtitle text--secondary text-truncate">
-          {{ cardSubtitle }}
-        </div>
+    </nuxt-link>
+    <!-- CAPTIONS -->
+    <div v-if="text" class="card-text">
+      <!-- CARD TITLE -->
+      <div class="card-title mt-1 text-truncate">{{ cardTitle }}</div>
+      <!-- CARD SUBTITLE -->
+      <nuxt-link
+        v-if="item.Type === 'MusicAlbum' && item.AlbumArtists.length > 0"
+        tag="div"
+        class="card-subtitle text--secondary text-truncate link"
+        :to="getItemDetailsLink(item.AlbumArtists[0], 'MusicArtist')"
+      >
+        {{ cardSubtitle }}
+      </nuxt-link>
+      <div v-else class="card-subtitle text--secondary text-truncate">
+        {{ cardSubtitle }}
       </div>
     </div>
-  </nuxt-link>
+  </div>
 </template>
 
 <script lang="ts">

--- a/client/components/Item/Card/Card.vue
+++ b/client/components/Item/Card/Card.vue
@@ -1,9 +1,9 @@
 <template>
-  <div :class="{ 'card-margin': margin, 'link-disabled': !link }">
-    <nuxt-link
-      :to="getItemDetailsLink(item)"
-      :class="link ? null : 'link-disabled'"
-      class="card-box nuxt-link"
+  <div :class="{ 'card-margin': margin }">
+    <component
+      :is="link ? 'nuxt-link' : 'div'"
+      :to="link ? getItemDetailsLink(item) : null"
+      :class="{ 'card-box': link }"
     >
       <!-- CARD -->
       <div :class="shape || cardType" class="elevation-2">
@@ -66,7 +66,7 @@
           </div>
         </div>
       </div>
-    </nuxt-link>
+    </component>
     <!-- CAPTIONS -->
     <div v-if="text" class="card-text">
       <!-- CARD TITLE -->
@@ -277,16 +277,6 @@ export default Vue.extend({
 
 <style lang="scss" scoped>
 @import '~vuetify/src/styles/styles.sass';
-.nuxt-link {
-  text-decoration: none;
-  color: inherit;
-}
-
-.link-disabled {
-  user-select: none;
-  pointer-events: none !important;
-  cursor: initial !important;
-}
 
 .card-lower-buttons {
   position: absolute;

--- a/client/components/Item/Card/Card.vue
+++ b/client/components/Item/Card/Card.vue
@@ -70,7 +70,12 @@
     <!-- CAPTIONS -->
     <div v-if="text" class="card-text">
       <!-- CARD TITLE -->
-      <div class="card-title mt-1 text-truncate">{{ cardTitle }}</div>
+      <nuxt-link
+        class="link d-block card-title mt-1 text-truncate"
+        :to="cardTitleLink"
+      >
+        {{ cardTitle }}
+      </nuxt-link>
       <!-- CARD SUBTITLE -->
       <nuxt-link
         v-if="item.Type === 'MusicAlbum' && item.AlbumArtists.length > 0"
@@ -201,6 +206,16 @@ export default Vue.extend({
       }
 
       return '';
+    },
+    /**
+     * @returns {string} A link to be applied to the title
+     */
+    cardTitleLink(): string {
+      if (this.item.Type === 'Episode' && this.item.SeriesId) {
+        return this.getItemDetailsLink({ Id: this.item.SeriesId }, 'Series');
+      }
+
+      return this.getItemDetailsLink(this.item);
     },
     progress: {
       get(): number | false {

--- a/client/components/Item/Card/Card.vue
+++ b/client/components/Item/Card/Card.vue
@@ -218,9 +218,9 @@ export default Vue.extend({
     /**
      * Gets a link to be applied to the card subtitle
      *
-     * @returns {string|undefined} A router link to the parent item or a related item
+     * @returns {string|null} A router link to the parent item or a related item
      */
-    cardSubtitleLink(): string | undefined {
+    cardSubtitleLink(): string | null {
       if (
         this.item.Type === 'MusicAlbum' &&
         this.item.AlbumArtists &&
@@ -234,7 +234,7 @@ export default Vue.extend({
         return this.getItemDetailsLink(this.item);
       }
 
-      return undefined;
+      return null;
     },
     progress: {
       get(): number | false {

--- a/client/components/Item/Card/Card.vue
+++ b/client/components/Item/Card/Card.vue
@@ -67,16 +67,13 @@
         </div>
       </div>
     </component>
-    <!-- CAPTIONS -->
     <div v-if="text" class="card-text">
-      <!-- CARD TITLE -->
       <nuxt-link
         class="link d-block card-title mt-1 text-truncate"
         :to="cardTitleLink"
       >
         {{ cardTitle }}
       </nuxt-link>
-      <!-- CARD SUBTITLE -->
       <nuxt-link
         v-if="cardSubtitleLink"
         class="link d-block card-subtitle text--secondary text-truncate"

--- a/client/components/Item/Card/Card.vue
+++ b/client/components/Item/Card/Card.vue
@@ -204,7 +204,9 @@ export default Vue.extend({
       return '';
     },
     /**
-     * @returns {string} A link to be applied to the title
+     * Gets a link to be applied to the card title
+     *
+     * @returns {string} A router link to the item or a related item
      */
     cardTitleLink(): string {
       if (this.item.Type === 'Episode' && this.item.SeriesId) {
@@ -213,8 +215,10 @@ export default Vue.extend({
 
       return this.getItemDetailsLink(this.item);
     },
-    /*
-     * @returns {string|undefined} A link to be applied to the subtitle
+    /**
+     * Gets a link to be applied to the card subtitle
+     *
+     * @returns {string|undefined} A router link to the parent item or a related item
      */
     cardSubtitleLink(): string | undefined {
       if (


### PR DESCRIPTION
* Moved the surrounding nuxt-link tag to only the image part
* Moved the hover effect to only trigger when hovering the image part
* Removed the nuxt-link attribute "event" as it seems to work without (please tell me if it was needed @ferferga, I blamed you to find you :p)
* Added the same nuxt-link as the image to the title
* Moved the title and subtitle link logics to a computed method
* Added the subtitle link to the show under episodes
* Edited the current subtitle link to an <a> tag to get the browsers feature of the URL tooltip and URL copy
* Changed surrounding nuxt-link to a variable component: a nuxt-link or div whether `link` is true
* Removed ineffective classes 

You can review by commit to be easier, due to the first commit moving the surrounding nuxt-link inside and moving every tabulation around

Fixes #985