### PR TITLE
fix(card): fix pogress bar position

### DIFF
--- a/client/components/Item/Card/Card.vue
+++ b/client/components/Item/Card/Card.vue
@@ -51,7 +51,7 @@
             "
             v-model="progress"
             color="primary accent-4"
-            class="align-self-end"
+            class="card-progress"
           />
         </div>
         <div
@@ -322,6 +322,13 @@ export default Vue.extend({
   position: absolute;
   top: 1em;
   right: 1em;
+}
+
+.card-progress {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
 }
 
 .card-overlay {


### PR DESCRIPTION
The progress bar was positioned next to the image using flexbox.

This changes its positioning to be absolute and aligns it to the bottom of the card, taking the full width and fixing the image size issue that resulted from it taking half of the card space.

Before
![image](https://user-images.githubusercontent.com/19396809/114242648-8b35e100-998b-11eb-9025-9a9f16af53ea.png)
After
![image](https://user-images.githubusercontent.com/19396809/114242585-70636c80-998b-11eb-9ee2-3ed85d5b4aaa.png)
