### PR TITLE
chore(ci): replace with actions-label-merge-conflict

### DIFF
--- a/.github/workflows/merge-conflicts.yml
+++ b/.github/workflows/merge-conflicts.yml
@@ -4,15 +4,14 @@ on:
   push:
     branches:
       - master
-  pull_request:
+  pull_request_target:
     types:
       - synchronize
 jobs:
   triage:
     runs-on: ubuntu-latest
-    if: github.repository == 'jellyfin/jellyfin-vue'
     steps:
-      - uses: mschilde/auto-label-merge-conflicts@v2.0
+      - uses: eps1lon/actions-label-merge-conflict@v2.0.0
         with:
-          CONFLICT_LABEL_NAME: 'merge conflict'
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          dirtyLabel: 'merge conflict'
+          repoToken: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
I tested the query this action performs in GraphQL explorer and checked the source code and it should fit all our needs. It will label PRs with conflicts only, without paying attention to the rest of the conditions (reviews, rebase, etc).