### PR TITLE
chore: bump @jellyfin/client-axios to 10.7.4

### DIFF
--- a/client/components/Item/Metadata/MetadataEditor.vue
+++ b/client/components/Item/Metadata/MetadataEditor.vue
@@ -359,7 +359,7 @@ export default Vue.extend({
         this.loading = true;
         await this.$api.itemUpdate.updateItem({
           itemId: this.metadata.Id as string,
-          baseItemDto: item
+          uNKNOWNBASETYPE: item
         });
         this.$emit('save');
         this.loading = false;

--- a/client/components/Players/AudioPlayer.vue
+++ b/client/components/Players/AudioPlayer.vue
@@ -161,7 +161,7 @@ export default Vue.extend({
           await this.$api.mediaInfo.getPostedPlaybackInfo({
             itemId: this.getCurrentItem?.Id || '',
             userId: this.$auth.user?.Id,
-            playbackInfoDto: { DeviceProfile: this.$playbackProfile }
+            uNKNOWNBASETYPE: { DeviceProfile: this.$playbackProfile }
           })
         ).data;
 

--- a/client/components/Players/PlayerManager.vue
+++ b/client/components/Players/PlayerManager.vue
@@ -224,7 +224,7 @@ export default Vue.extend({
           ) {
             this.$api.playState.reportPlaybackStopped(
               {
-                playbackStopInfo: {
+                uNKNOWNBASETYPE: {
                   ItemId: this.getPreviousItem.Id,
                   PlaySessionId: state.playbackManager.playSessionId,
                   PositionTicks: this.msToTicks(
@@ -240,7 +240,7 @@ export default Vue.extend({
           if (this.getCurrentItem?.Id) {
             this.$api.playState.reportPlaybackStart(
               {
-                playbackStartInfo: {
+                uNKNOWNBASETYPE: {
                   CanSeek: true,
                   ItemId: this.getCurrentItem.Id,
                   PlaySessionId: state.playbackManager.playSessionId,
@@ -270,7 +270,7 @@ export default Vue.extend({
             ) {
               this.$api.playState.reportPlaybackProgress(
                 {
-                  playbackProgressInfo: {
+                  uNKNOWNBASETYPE: {
                     ItemId: this.getCurrentItem.Id,
                     PlaySessionId: state.playbackManager.playSessionId,
                     IsPaused: false,
@@ -292,7 +292,7 @@ export default Vue.extend({
           if (state.playbackManager.currentTime !== null) {
             this.$api.playState.reportPlaybackStopped(
               {
-                playbackStopInfo: {
+                uNKNOWNBASETYPE: {
                   ItemId: this.getPreviousItem.Id,
                   PlaySessionId: state.playbackManager.playSessionId,
                   PositionTicks: this.msToTicks(
@@ -315,7 +315,7 @@ export default Vue.extend({
           if (state.playbackManager.currentTime !== null) {
             this.$api.playState.reportPlaybackProgress(
               {
-                playbackProgressInfo: {
+                uNKNOWNBASETYPE: {
                   ItemId: this.getCurrentItem.Id,
                   PlaySessionId: state.playbackManager.playSessionId,
                   IsPaused: true,

--- a/client/components/Players/TrackList.vue
+++ b/client/components/Players/TrackList.vue
@@ -75,7 +75,11 @@
 import Vue from 'vue';
 import { mapActions, mapGetters } from 'vuex';
 import groupBy from 'lodash/groupBy';
-import { BaseItemDto, BaseItemDtoQueryResult } from '@jellyfin/client-axios';
+import {
+  BaseItemDto,
+  BaseItemDtoQueryResult,
+  SortOrder
+} from '@jellyfin/client-axios';
 import timeUtils from '~/mixins/timeUtils';
 import itemHelper from '~/mixins/itemHelper';
 
@@ -97,8 +101,8 @@ export default Vue.extend({
       await this.$api.items.getItems({
         userId: this.$auth.user?.Id,
         parentId: this.item.Id,
-        sortBy: 'SortName',
-        sortOrder: 'Ascending'
+        sortBy: ['SortName'],
+        sortOrder: [SortOrder.Ascending]
       })
     ).data;
   },

--- a/client/components/Players/VideoPlayer.vue
+++ b/client/components/Players/VideoPlayer.vue
@@ -159,7 +159,7 @@ export default Vue.extend({
           await this.$api.mediaInfo.getPostedPlaybackInfo({
             itemId: this.getCurrentItem?.Id || '',
             userId: this.$auth.user?.Id,
-            playbackInfoDto: { DeviceProfile: this.$playbackProfile }
+            uNKNOWNBASETYPE: { DeviceProfile: this.$playbackProfile }
           })
         ).data;
 

--- a/client/components/Wizard/WizardAdminAccount.vue
+++ b/client/components/Wizard/WizardAdminAccount.vue
@@ -88,7 +88,7 @@ export default Vue.extend({
         this.$auth.ctx.app.$axios.setHeader('X-Emby-Authorization', token);
 
         await this.$api.startup.updateStartupUser({
-          startupUserDto: this.admin
+          uNKNOWNBASETYPE: this.admin
         });
 
         this.$emit('step-complete', { step: 2 });

--- a/client/components/Wizard/WizardLanguage.vue
+++ b/client/components/Wizard/WizardLanguage.vue
@@ -62,7 +62,7 @@ export default Vue.extend({
       try {
         this.$i18n.setLocale(this.UICulture);
         await this.$api.startup.updateInitialConfiguration({
-          startupConfigurationDto: {
+          uNKNOWNBASETYPE: {
             ...this.initialConfig,
             UICulture: this.UICulture
           }

--- a/client/components/Wizard/WizardMetadata.vue
+++ b/client/components/Wizard/WizardMetadata.vue
@@ -65,7 +65,7 @@ export default Vue.extend({
 
       try {
         await this.$api.startup.updateInitialConfiguration({
-          startupConfigurationDto: {
+          uNKNOWNBASETYPE: {
             ...this.initialConfig,
             MetadataCountryCode: this.metadataLanguage,
             PreferredMetadataLanguage: this.metadataCountry

--- a/client/components/Wizard/WizardRemoteAccess.vue
+++ b/client/components/Wizard/WizardRemoteAccess.vue
@@ -33,7 +33,7 @@ export default Vue.extend({
 
       try {
         await this.$api.startup.setRemoteAccess({
-          startupRemoteAccessDto: {
+          uNKNOWNBASETYPE: {
             EnableRemoteAccess: this.allowRemoteAccess,
             EnableAutomaticPortMapping: this.enableUPNP
           }

--- a/client/pages/artist/_itemId/index.vue
+++ b/client/pages/artist/_itemId/index.vue
@@ -116,7 +116,7 @@
 <script lang="ts">
 import Vue from 'vue';
 import { mapActions, mapGetters, mapState } from 'vuex';
-import { BaseItemDto, ImageType } from '@jellyfin/client-axios';
+import { BaseItemDto, ImageType, SortOrder } from '@jellyfin/client-axios';
 import { Context } from '@nuxt/types';
 import htmlHelper from '~/mixins/htmlHelper';
 import imageHelper from '~/mixins/imageHelper';
@@ -138,8 +138,8 @@ export default Vue.extend({
 
     const appearanceIds = await $items.getItems({
       albumArtistIds: [itemId],
-      sortBy: 'PremiereDate,ProductionYear,SortName',
-      sortOrder: 'Descending',
+      sortBy: ['PremiereDate', 'ProductionYear', 'SortName'],
+      sortOrder: [SortOrder.Descending],
       recursive: true,
       includeItemTypes: ['MusicAlbum']
     });

--- a/client/schemes/jellyfinScheme.ts
+++ b/client/schemes/jellyfinScheme.ts
@@ -76,7 +76,7 @@ export default class JellyfinScheme {
       // Login using the Axios client
       const authenticateResponse = await this.$auth.ctx.app.$api.user.authenticateUserByName(
         {
-          authenticateUserByName: {
+          uNKNOWNBASETYPE: {
             Username: username,
             Pw: password
           }

--- a/client/store/plugins/preferencesSyncPlugin.ts
+++ b/client/store/plugins/preferencesSyncPlugin.ts
@@ -98,7 +98,7 @@ export const preferencesSync: Plugin<AppState> = (store) => {
             displayPreferencesId: subModule,
             userId: store.$auth.user?.Id,
             client: 'vue',
-            displayPreferencesDto: displayPrefs as DisplayPreferencesDto
+            uNKNOWNBASETYPE: displayPrefs as DisplayPreferencesDto
           }
         );
 

--- a/client/utils/playbackUtils.ts
+++ b/client/utils/playbackUtils.ts
@@ -49,7 +49,7 @@ export async function translateItemsForPlayback(
             artistIds: [item.Id],
             filters: [ItemFilter.IsNotFolder],
             recursive: true,
-            sortBy: 'SortName',
+            sortBy: ['SortName'],
             mediaTypes: ['Audio']
           })
         ).data.Items || [];
@@ -61,7 +61,7 @@ export async function translateItemsForPlayback(
             genreIds: [item.Id],
             filters: [ItemFilter.IsNotFolder],
             recursive: true,
-            sortBy: 'SortName',
+            sortBy: ['SortName'],
             mediaTypes: ['Audio']
           })
         ).data.Items || [];
@@ -74,7 +74,7 @@ export async function translateItemsForPlayback(
             filters: [ItemFilter.IsNotFolder],
             recursive: true,
             sortBy: !['BoxSet'].includes(item.Type || '')
-              ? 'SortName'
+              ? ['SortName']
               : undefined,
             mediaTypes: ['Audio', 'Video']
           })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1638,11 +1638,11 @@
       "dev": true
     },
     "@jellyfin/client-axios": {
-      "version": "10.7.0",
-      "resolved": "https://registry.npmjs.org/@jellyfin/client-axios/-/client-axios-10.7.0.tgz",
-      "integrity": "sha512-XS/77cY3MJ/ITFf/BppGTtrncB3Bsf+fQq4MsVgwlMo98rTfLm0sXJXxIgZHDd1P2Cb/iSOVsqPGuYr+OSW/qA==",
+      "version": "10.7.4",
+      "resolved": "https://registry.npmjs.org/@jellyfin/client-axios/-/client-axios-10.7.4.tgz",
+      "integrity": "sha512-MXYllr2RURq3q0e3Eljo5i828EBP1b4N3Mfag3MaPMJKeKS6QhzLt3fyhygzmMJbqywKVvAO4B2RYlaKf2zHew==",
       "requires": {
-        "axios": "^0.19.2"
+        "axios": "^0.21.1"
       }
     },
     "@jest/console": {
@@ -4776,11 +4776,18 @@
       "dev": true
     },
     "axios": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
       "requires": {
-        "follow-redirects": "1.5.10"
+        "follow-redirects": "^1.10.0"
+      },
+      "dependencies": {
+        "follow-redirects": {
+          "version": "1.13.3",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.3.tgz",
+          "integrity": "sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA=="
+        }
       }
     },
     "axios-retry": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@fontsource/noto-sans-kr": "^4.2.2",
     "@fontsource/noto-sans-sc": "^4.2.2",
     "@fontsource/noto-sans-tc": "^4.2.2",
-    "@jellyfin/client-axios": "^10.7.0",
+    "@jellyfin/client-axios": "^10.7.4",
     "@nuxtjs/auth": "^4.9.1",
     "@nuxtjs/axios": "^5.13.1",
     "@nuxtjs/pwa": "^3.3.5",


### PR DESCRIPTION
I fixed the useSingleParameter option [upstream](https://github.com/jellyfin/jellyfin-client-axios/pull/12). Fixed package is up in NPM and GitHub Packages with version 10.7.4 (not yet tagged as latest due to a permission issue in CI)

However, there are some fields in the parameters that are like ``uNKNOWNBASETYPE`` for some reason. I wonder if it's a generator bug because we're fully ES6 now or something in server that's not compliant with OpenAPI spec.

This update also reduces the bundle size by quite a lot :) (master is 4.3 MB)
![image](https://user-images.githubusercontent.com/10274099/114761051-539ab080-9d60-11eb-8a77-a392db7da752.png)
