### PR TITLE
ci(github): use version and arch matrix to build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,8 +8,16 @@ on:
 
 jobs:
   ssr:
-    name: Build SSR
+    name: Build SSR (Node ${{ matrix.node }} - ${{ matrix.architecture }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node:
+          - 14
+          - 16
+        architecture:
+          - x64
 
     steps:
       - name: Checkout
@@ -18,7 +26,8 @@ jobs:
       - name: Setup node environment
         uses: actions/setup-node@v2.1.5
         with:
-          node-version: 14
+          node-version: ${{ matrix.node }}
+          architecture: ${{ matrix.architecture }}
 
       - name: Get npm cache directory path
         id: npm-cache-dir-path
@@ -28,10 +37,10 @@ jobs:
         uses: actions/cache@v2.1.5
         id: npm-cache
         with:
-          path: ${{ steps.npm-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
+          path: ~/.npm
+          key: ${{ runner.os }}-${{ matrix.architecture }}-node${{ matrix.node }}-npm-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-npm-
+            ${{ runner.os }}-${{ matrix.architecture }}-node${{ matrix.node }}-npm-
 
       - name: Install dependencies
         run: npm ci --no-audit
@@ -40,8 +49,16 @@ jobs:
         run: npm run build
 
   static:
-    name: Build static
+    name: Build static (Node ${{ matrix.node }} - ${{ matrix.architecture }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node:
+          - 14
+          - 16
+        architecture:
+          - x64
 
     steps:
       - name: Checkout
@@ -50,7 +67,8 @@ jobs:
       - name: Setup node environment
         uses: actions/setup-node@v2.1.5
         with:
-          node-version: 14
+          node-version: ${{ matrix.node }}
+          architecture: ${{ matrix.architecture }}
 
       - name: Get npm cache directory path
         id: npm-cache-dir-path
@@ -60,10 +78,10 @@ jobs:
         uses: actions/cache@v2.1.5
         id: npm-cache
         with:
-          path: ${{ steps.npm-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
+          path: ~/.npm
+          key: ${{ runner.os }}-${{ matrix.architecture }}-node${{ matrix.node }}-npm-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-npm-
+            ${{ runner.os }}-${{ matrix.architecture }}-node${{ matrix.node }}-npm-
 
       - name: Install dependencies
         run: npm ci --no-audit


### PR DESCRIPTION
**Edit: ARM seems busted, so it was removed**

To provide slightly better coverage of platforms and an easier upgrade path when a new Node LTS shows up, this adds matrices to both the architecture and Node versions.

We now build in CI:

* Node 14 on x64
* Node 14 on Armv7l
* Node 16 on x64
* Node 16 on Armv7l

This gives us an idea of how the client builds on both regular computers (x64) and on recent Raspberry Pi boards (armv7l), as well as warn us if a dependency fails with our next Node upgrade.

A change in requirements for CI passing will be done once this is merged:

* Node 14 on x64 and armv7l will become the required build jobs
* Node 16 jobs will be kept as optional, as it is expected they might fail in some cases

Once we move forward with Node versioning (Expected to happen next around June, when Node 16 becomes the current LTS), the matrix will change as follows:

* Node 14 -> Node 16
* Node 16 -> Node 17

So, essentially, the first entry is expected to track the current LTS, while the other will track the current stable.