### PR TITLE
fix(audiocontrols): re-add span tag on fullscreen button

### DIFF
--- a/client/components/Layout/AudioControls.vue
+++ b/client/components/Layout/AudioControls.vue
@@ -117,7 +117,11 @@
               <volume-slider />
             </div>
             <item-menu :item="getCurrentItem" />
-            <nuxt-link v-if="!isFullScreenPlayer" :to="'/fullscreen/playback'">
+            <nuxt-link
+              v-if="!isFullScreenPlayer"
+              tag="span"
+              :to="'/fullscreen/playback'"
+            >
               <v-btn icon>
                 <v-icon>mdi-fullscreen</v-icon>
               </v-btn>

--- a/client/components/Layout/AudioControls.vue
+++ b/client/components/Layout/AudioControls.vue
@@ -117,16 +117,15 @@
               <volume-slider />
             </div>
             <item-menu :item="getCurrentItem" />
-            <nuxt-link
-              v-if="!isFullScreenPlayer"
-              tag="span"
-              :to="'/fullscreen/playback'"
+            <v-btn
+              v-show="!isFullScreenPlayer"
+              icon
+              nuxt
+              to="/fullscreen/playback"
             >
-              <v-btn icon>
-                <v-icon>mdi-fullscreen</v-icon>
-              </v-btn>
-            </nuxt-link>
-            <v-btn v-else icon @click="$router.back()">
+              <v-icon>mdi-fullscreen</v-icon>
+            </v-btn>
+            <v-btn v-show="isFullScreenPlayer" icon @click="$router.back()">
               <v-icon>mdi-fullscreen-exit</v-icon>
             </v-btn>
           </v-col>


### PR DESCRIPTION
Should fix the fullscreen button having an underline since #1025 was merged.