### PR TITLE
style(eslint): add no-restrict-globals with confusing-browser-globals

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,6 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires -- The ESLint config expects Node modules
+var restrictedGlobals = require('confusing-browser-globals');
+
 module.exports = {
   root: true,
   env: {
@@ -17,6 +20,7 @@ module.exports = {
   ],
   plugins: ['prettier', 'promise', 'import', 'jsdoc', 'lodash'],
   rules: {
+    'no-restricted-globals': ['error'].concat(restrictedGlobals),
     'import/newline-after-import': 'error',
     'import/order': 'error',
     'jsdoc/require-hyphen-before-param-description': 'error',

--- a/package-lock.json
+++ b/package-lock.json
@@ -6773,6 +6773,12 @@
         "proto-list": "~1.2.1"
       }
     },
+    "confusing-browser-globals": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.10.tgz",
+      "integrity": "sha512-gNld/3lySHwuhaVluJUKLePYirM3QNCKzVxqAdhJII9/WXKVX5PURzMVJspS1jTslSqjeuG4KMVTSouit5YPHA==",
+      "dev": true
+    },
     "connect": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/connect/-/connect-3.7.0.tgz",
@@ -19846,7 +19852,7 @@
           "dependencies": {
             "acorn": {
               "version": "3.3.0",
-              "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+              "resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
               "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
             }
           }
@@ -20750,7 +20756,7 @@
         },
         "browserify-aes": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
           "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
           "requires": {
             "buffer-xor": "^1.0.3",
@@ -20784,7 +20790,7 @@
         },
         "browserify-rsa": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
           "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
           "requires": {
             "bn.js": "^4.1.0",
@@ -20815,7 +20821,7 @@
         },
         "buffer": {
           "version": "4.9.1",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+          "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
           "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
           "requires": {
             "base64-js": "^1.0.2",
@@ -20951,7 +20957,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -21198,7 +21204,7 @@
         },
         "create-hash": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
           "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
           "requires": {
             "cipher-base": "^1.0.1",
@@ -21210,7 +21216,7 @@
         },
         "create-hmac": {
           "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+          "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
           "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
           "requires": {
             "cipher-base": "^1.0.3",
@@ -21417,7 +21423,7 @@
         },
         "diffie-hellman": {
           "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+          "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
           "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
           "requires": {
             "bn.js": "^4.1.0",
@@ -21493,7 +21499,7 @@
           "dependencies": {
             "debug": {
               "version": "2.3.3",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+              "resolved": "http://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
               "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
               "requires": {
                 "ms": "0.7.2"
@@ -21532,7 +21538,7 @@
             },
             "debug": {
               "version": "2.3.3",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+              "resolved": "http://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
               "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
               "requires": {
                 "ms": "0.7.2"
@@ -22983,7 +22989,7 @@
         },
         "http-errors": {
           "version": "1.6.3",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+          "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
           "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
           "requires": {
             "depd": "~1.1.2",
@@ -23469,7 +23475,7 @@
           "dependencies": {
             "lodash": {
               "version": "3.10.1",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+              "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
               "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
             }
           }
@@ -23505,7 +23511,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
             }
           }
@@ -23536,7 +23542,7 @@
         },
         "karma-webpack": {
           "version": "2.0.13",
-          "resolved": "https://registry.npmjs.org/karma-webpack/-/karma-webpack-2.0.13.tgz",
+          "resolved": "http://registry.npmjs.org/karma-webpack/-/karma-webpack-2.0.13.tgz",
           "integrity": "sha512-2cyII34jfrAabbI2+4Rk4j95Nazl98FvZQhgSiqKUDarT317rxfv/EdzZ60CyATN4PQxJdO5ucR5bOOXkEVrXw==",
           "requires": {
             "async": "^2.0.0",
@@ -23700,7 +23706,7 @@
         },
         "log4js": {
           "version": "0.6.38",
-          "resolved": "https://registry.npmjs.org/log4js/-/log4js-0.6.38.tgz",
+          "resolved": "http://registry.npmjs.org/log4js/-/log4js-0.6.38.tgz",
           "integrity": "sha1-LElBFmldb7JUgJQ9P8hy5mKlIv0=",
           "requires": {
             "readable-stream": "~1.0.2",
@@ -23714,7 +23720,7 @@
             },
             "readable-stream": {
               "version": "1.0.34",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+              "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
               "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
               "requires": {
                 "core-util-is": "~1.0.0",
@@ -23873,7 +23879,7 @@
             },
             "minimist": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
             },
             "path-exists": {
@@ -24000,7 +24006,7 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         },
         "mixin-deep": {
@@ -24024,7 +24030,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "requires": {
             "minimist": "0.0.8"
@@ -24051,7 +24057,7 @@
           "dependencies": {
             "commander": {
               "version": "2.9.0",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+              "resolved": "http://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
               "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
               "requires": {
                 "graceful-readlink": ">= 1.0.0"
@@ -24338,7 +24344,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
         },
         "optimist": {
@@ -24443,7 +24449,7 @@
         },
         "parse-asn1": {
           "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
+          "resolved": "http://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
           "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
           "requires": {
             "asn1.js": "^4.0.0",
@@ -24666,7 +24672,7 @@
         },
         "public-encrypt": {
           "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.2.tgz",
+          "resolved": "http://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.2.tgz",
           "integrity": "sha512-4kJ5Esocg8X3h8YgJsKAuoesBgB7mqH3eowiDzMUPKiRDDE7E/BqqZD1hnTByIaAFiwAw246YEltSq7tdrOH0Q==",
           "requires": {
             "bn.js": "^4.1.0",
@@ -24782,7 +24788,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -25095,7 +25101,7 @@
         },
         "sha.js": {
           "version": "2.4.11",
-          "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+          "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
           "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
           "requires": {
             "inherits": "^2.0.1",
@@ -25273,7 +25279,7 @@
           "dependencies": {
             "debug": {
               "version": "2.3.3",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+              "resolved": "http://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
               "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
               "requires": {
                 "ms": "0.7.2"
@@ -25302,7 +25308,7 @@
           "dependencies": {
             "debug": {
               "version": "2.3.3",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+              "resolved": "http://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
               "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
               "requires": {
                 "ms": "0.7.2"
@@ -25340,7 +25346,7 @@
             },
             "debug": {
               "version": "2.3.3",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+              "resolved": "http://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
               "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
               "requires": {
                 "ms": "0.7.2"
@@ -25366,7 +25372,7 @@
           "dependencies": {
             "debug": {
               "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "resolved": "http://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
               "requires": {
                 "ms": "0.7.1"
@@ -25561,7 +25567,7 @@
         },
         "table": {
           "version": "3.8.3",
-          "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
+          "resolved": "http://registry.npmjs.org/table/-/table-3.8.3.tgz",
           "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
           "requires": {
             "ajv": "^4.7.0",
@@ -25618,7 +25624,7 @@
         },
         "through": {
           "version": "2.3.8",
-          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+          "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
           "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
         },
         "time-stamp": {
@@ -25794,7 +25800,7 @@
             },
             "yargs": {
               "version": "3.10.0",
-              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+              "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
               "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
               "requires": {
                 "camelcase": "^1.0.2",
@@ -26436,7 +26442,7 @@
         },
         "wrap-ansi": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
           "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
           "requires": {
             "string-width": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "babel-eslint": "^10.1.0",
     "babel-jest": "^26.6.3",
     "comlink-loader": "^2.0.0",
+    "confusing-browser-globals": "^1.0.10",
     "core-js": "^3.11.0",
     "cz-conventional-changelog": "3.3.0",
     "eslint": "^7.24.0",


### PR DESCRIPTION
Adds the `no-restrict-globals`, with [confusing-browser-globals](https://www.npmjs.com/package/confusing-browser-globals) to prevent using potentially confusing globals without using `window` first.

The list of provided globals is here: https://github.com/facebook/create-react-app/blob/master/packages/confusing-browser-globals/index.js