### PR TITLE
fix(series-item): removed original title if it is the same as the name

### DIFF
--- a/client/pages/series/_itemId/index.vue
+++ b/client/pages/series/_itemId/index.vue
@@ -13,7 +13,7 @@
             {{ item.Name }}
           </h1>
           <h2
-            v-if="item.OriginalTitle"
+            v-if="item.OriginalTitle && item.OriginalTitle !== item.Name"
             class="text-subtitle-1"
             :class="{ 'text-center': !$vuetify.breakpoint.mdAndUp }"
           >


### PR DESCRIPTION
#890 -> was only for a film
This not also fixes this Issue on a series.

see https://github.com/jellyfin/jellyfin-vue/issues/836#issuecomment-804008091