### PR TITLE
fix(fullscreen-player-next-up): show empty space if it is the last item

### DIFF
--- a/client/components/Layout/AudioControls.vue
+++ b/client/components/Layout/AudioControls.vue
@@ -172,12 +172,17 @@
           </v-col>
         </v-row>
         <div
-          v-if="isFullScreenPlayer && getNextItem"
+          v-if="isFullScreenPlayer"
           class="d-flex justify-center align-center"
         >
           <div>
             <h4 class="text-overline font-italic">
-              {{ $t('upNextName', { upNextItemName: getNextItem.Name }) }}
+              {{
+                !!getNextItem
+                  ? $t('upNextName', { upNextItemName: getNextItem.Name })
+                  : ''
+              }}
+              <br />
             </h4>
           </div>
         </div>


### PR DESCRIPTION
Display an empty space at the location of the `UP NEXT` string to prevent the resizing of the toolbar.

#888