### PR TITLE
fix(itemsplugin): fetch all fields of an item when calling getItems

### DIFF
--- a/client/plugins/itemsPlugin.ts
+++ b/client/plugins/itemsPlugin.ts
@@ -1,4 +1,4 @@
-import { ItemsApiGetItemsRequest } from '@jellyfin/client-axios';
+import { ItemsApiGetItemsRequest, ItemFields } from '@jellyfin/client-axios';
 import { Plugin } from '@nuxt/types/app';
 
 type GetItemsParams = Omit<ItemsApiGetItemsRequest, 'userId'>;
@@ -40,7 +40,11 @@ const itemsPlugin: Plugin = ({ $api, $auth, store }, inject) => {
      */
     getItems: async (params: GetItemsParams): Promise<string[]> => {
       const result = (
-        await $api.items.getItems({ ...params, userId: $auth.user?.Id })
+        await $api.items.getItems({
+          ...params,
+          userId: $auth.user?.Id,
+          fields: Object.values(ItemFields)
+        })
       ).data.Items;
 
       if (!result) {

--- a/client/plugins/userLibraryPlugin.ts
+++ b/client/plugins/userLibraryPlugin.ts
@@ -1,4 +1,7 @@
-import { UserLibraryApiGetLatestMediaRequest } from '@jellyfin/client-axios';
+import {
+  UserLibraryApiGetLatestMediaRequest,
+  ItemFields
+} from '@jellyfin/client-axios';
 import { Plugin } from '@nuxt/types/app';
 
 type GetLatestMediaParams = Omit<UserLibraryApiGetLatestMediaRequest, 'userId'>;
@@ -59,7 +62,8 @@ const userLibraryPlugin: Plugin = ({ $api, $auth, store }, inject) => {
       const result = (
         await $api.userLibrary.getLatestMedia({
           ...params,
-          userId: $auth.user?.Id
+          userId: $auth.user?.Id,
+          fields: Object.values(ItemFields)
         })
       ).data;
 


### PR DESCRIPTION
When fetching an array of items for a person/genre/artist, get all the fields of items.

fix #1059