### PR TITLE
chore: replace GH_TOKEN with JF_BOT_TOKEN

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GH_TOKEN }}
+          password: ${{ secrets.JF_BOT_TOKEN }}
 
       - name: Build and push stable SSR images
         if: github.event.action == 'released'
@@ -139,7 +139,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GH_TOKEN }}
+          password: ${{ secrets.JF_BOT_TOKEN }}
 
       - name: Build and push stable static images
         if: github.event.action == 'released'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -63,7 +63,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GH_TOKEN }}
+          password: ${{ secrets.JF_BOT_TOKEN }}
 
       - name: Build images and push
         uses: docker/build-push-action@v2.4.0
@@ -137,7 +137,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GH_TOKEN }}
+          password: ${{ secrets.JF_BOT_TOKEN }}
 
       - name: Build images and push
         uses: docker/build-push-action@v2.4.0

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -9,4 +9,4 @@ jobs:
       - uses: actions/labeler@v3
         continue-on-error: true
         with:
-          repo-token: '${{ secrets.GH_TOKEN }}'
+          repo-token: '${{ secrets.JF_BOT_TOKEN }}'

--- a/.github/workflows/merge-conflicts.yml
+++ b/.github/workflows/merge-conflicts.yml
@@ -14,4 +14,4 @@ jobs:
       - uses: eps1lon/actions-label-merge-conflict@v2.0.1
         with:
           dirtyLabel: 'merge conflict'
-          repoToken: ${{ secrets.GH_TOKEN }}
+          repoToken: ${{ secrets.JF_BOT_TOKEN }}

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -1,4 +1,4 @@
-name: Move new pull request to "Ongoing development" project
+name: Automation
 
 on:
   pull_request:
@@ -6,7 +6,7 @@ on:
       - opened
 
 jobs:
-  automate-project-columns:
+  project:
     runs-on: ubuntu-latest
     steps:
       - uses: alex-page/github-project-automation-plus@v0.7.1
@@ -14,4 +14,4 @@ jobs:
         with:
           project: Ongoing development
           column: In progress
-          repo-token: ${{ secrets.GH_TOKEN }}
+          repo-token: ${{ secrets.JF_BOT_TOKEN }}

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -11,15 +11,15 @@ jobs:
       - name: Notify as seen
         uses: peter-evans/create-or-update-comment@v1.4.5
         with:
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.JF_BOT_TOKEN }}
           comment-id: ${{ github.event.comment.id }}
           reactions: '+1'
       - name: Checkout the latest code
         uses: actions/checkout@v2.3.4
         with:
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.JF_BOT_TOKEN }}
           fetch-depth: 0
       - name: Automatic Rebase
         uses: cirrus-actions/rebase@1.4
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.JF_BOT_TOKEN }}


### PR DESCRIPTION
``GH_TOKEN`` seems to be used internally by GitHub and it's making some actions we're using in some repos fail ([Source](https://github.com/alex-page/github-project-automation-plus/issues/39))

*(PRs made from users of the org are always successful, but PRs that aren't don't work, like Dependabot PRs. This can be checked by looking at the history of server repos and Jellyfin Vue)*

The org-wide secret should be renamed to something else to avoid confusion and further replacements or messes in GH's side. This PR replaces ``GH_TOKEN`` with ``JF_BOT_TOKEN``, which should be pretty generic.