### PR TITLE
feat: reduce chunk size to speed up slow HTTP/2 connections

### DIFF
--- a/client/nuxt.config.ts
+++ b/client/nuxt.config.ts
@@ -367,6 +367,12 @@ const config: NuxtConfig = {
       }
     },
     optimizeCSS: true,
+    optimization: {
+      splitChunks: {
+        chunks: 'all',
+        maxSize: 800000
+      }
+    },
     extractCSS: {
       ignoreOrder: true
     },

--- a/package.json
+++ b/package.json
@@ -3,6 +3,11 @@
   "author": "Jellyfin Team",
   "version": "0.0.0",
   "private": true,
+  "fork-ts-checker": {
+    "typescript": {
+      "memoryLimit": 4096 
+    }
+  },
   "scripts": {
     "dev": "NUXT_SSR=1 nuxt client",
     "dev:static": "nuxt client",


### PR DESCRIPTION
We have some chunks in our building output which are roughly 3 MB, which poses a problem for slow connections. Cloudflare Pages is a good example of that: I don't know why, but their servers seems to be extremely slow for serving the pages.

While the chunks are loading, some parts of the pages are not available or incomplete (like the Home and its header or item details), which makes content jump until the specific chunk of that section of the page is fully loaded.

The problem will still exist on single-thread slow HTTP connections, but the situation should be much better on HTTP2 (which is the case of Cloudflare for example and Jellyfin server, once it's able to serve this client) as smaller chunks will be downloaded in parallel.

With this changes, 380 chunks are created as of today, with the bigger one being 369 KB.

The downsides of this change is that it will increase memory consumption (until ``jellyfin/client-axios`` is fully ES6) and builds will take longer to complete.