### PR TITLE
Load fonts in nuxt.config instead of CSS and treeshake SimpleIcons library

### DIFF
--- a/client/assets/global.scss
+++ b/client/assets/global.scss
@@ -1,11 +1,3 @@
-@import '~vuetify/src/styles/styles.sass';
-@import '@fontsource/noto-sans/index.css';
-@import '@fontsource/noto-sans-jp/index.css';
-@import '@fontsource/noto-sans-sc/index.css';
-@import '@fontsource/noto-sans-kr/index.css';
-@import '@fontsource/noto-sans-tc/index.css';
-@import '@fontsource/noto-sans-hk/index.css';
-
 body {
   background-color: var(--v-background-base);
 }

--- a/client/nuxt.config.ts
+++ b/client/nuxt.config.ts
@@ -1,7 +1,8 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import { NuxtRouteConfig } from '@nuxt/types/config/router';
 import type { NuxtConfig } from '@nuxt/types';
-import simpleIcons from 'simple-icons';
+// @ts-expect-error - Individual icons doesn't have typings
+import jellyfinIcon from 'simple-icons/icons/jellyfin';
 
 const config: NuxtConfig = {
   /*
@@ -363,7 +364,7 @@ const config: NuxtConfig = {
     icons: {
       iconfont: 'mdi',
       values: {
-        jellyfin: simpleIcons.get('jellyfin').path
+        jellyfin: jellyfinIcon.path
       }
     }
   },

--- a/client/nuxt.config.ts
+++ b/client/nuxt.config.ts
@@ -70,7 +70,17 @@ const config: NuxtConfig = {
   /*
    ** Global CSS
    */
-  css: ['~/assets/global.scss', '@mdi/font/css/materialdesignicons.css'],
+  css: [
+    '~/assets/global.scss',
+    '@mdi/font/css/materialdesignicons.css',
+    'vuetify/src/styles/styles.sass',
+    '@fontsource/noto-sans/index.css',
+    '@fontsource/noto-sans-jp/index.css',
+    '@fontsource/noto-sans-sc/index.css',
+    '@fontsource/noto-sans-kr/index.css',
+    '@fontsource/noto-sans-tc/index.css',
+    '@fontsource/noto-sans-hk/index.css'
+  ],
   /*
    ** Plugins to load before mounting the App
    ** https://nuxtjs.org/guide/plugins

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     }
   },
   "scripts": {
+    "analyze": "NUXT_SSR=1 nuxt build --analyze client",
+    "analyze:static": "nuxt build --analyze client",
     "dev": "NUXT_SSR=1 nuxt client",
     "dev:static": "nuxt client",
     "build": "NUXT_SSR=1 nuxt build client",


### PR DESCRIPTION
Additionally, added nuxt analyze commands to package.json to ease the bundle analysis later on.