### PR TITLE
chore(stalebot): adjust exempt labels

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -6,6 +6,11 @@ daysUntilClose: 14
 exemptLabels:
   - regression
   - confirmed
+  - meta
+  - blocked
+  - 'discussion needed'
+  - 'help wanted'
+  - security
 # Label to use when marking an issue as stale
 staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable


### PR DESCRIPTION
Adds a few more labels to stalebot, for things that probably shouldn't go stale.