### PR TITLE
feat(playback): add track selection to details pages

### DIFF
--- a/client/components/Buttons/PlayButton.vue
+++ b/client/components/Buttons/PlayButton.vue
@@ -51,6 +51,18 @@ export default Vue.extend({
     },
     shuffle: {
       type: Boolean
+    },
+    videoTrackIndex: {
+      type: Number,
+      default: undefined
+    },
+    audioTrackIndex: {
+      type: Number,
+      default: undefined
+    },
+    subtitleTrackIndex: {
+      type: Number,
+      default: undefined
     }
   },
   data() {
@@ -76,6 +88,9 @@ export default Vue.extend({
       if (this.item && this.canResume(this.item)) {
         this.play({
           item: this.item,
+          audioTrackIndex: this.audioTrackIndex,
+          subtitleTrackIndex: this.subtitleTrackIndex || -1,
+          videoTrackIndex: this.videoTrackIndex,
           startFromTime:
             this.ticksToMs(this.item.UserData?.PlaybackPositionTicks) / 1000
         });
@@ -83,11 +98,17 @@ export default Vue.extend({
         // We force playback from the start when shuffling, since you wouldn't resume AND shuffle at the same time
         this.play({
           item: this.item,
+          audioTrackIndex: this.audioTrackIndex,
+          subtitleTrackIndex: this.subtitleTrackIndex || -1,
+          videoTrackIndex: this.videoTrackIndex,
           startShuffled: true
         });
       } else {
         this.play({
-          item: this.item
+          item: this.item,
+          audioTrackIndex: this.audioTrackIndex,
+          subtitleTrackIndex: this.subtitleTrackIndex || -1,
+          videoTrackIndex: this.videoTrackIndex
         });
       }
     }

--- a/client/components/Item/TrackSelector.vue
+++ b/client/components/Item/TrackSelector.vue
@@ -11,7 +11,7 @@
     :items="selectItems"
     :placeholder="placeholder"
     :disabled="disabled"
-    :clearable="clearable"
+    clearable
   >
     <template slot="selection" slot-scope="{ item: i }">
       {{ getTrackSelection(i.text) }}
@@ -75,7 +75,7 @@ export default Vue.extend({
     }
   },
   data() {
-    return { trackIndex: undefined as number | undefined };
+    return { trackIndex: -1 as number };
   },
   computed: {
     mediaSourceItem: {
@@ -163,28 +163,12 @@ export default Vue.extend({
         return this.$t('noTracksAvailable');
       }
     },
-    clearable: {
-      /**
-       * @returns {boolean} Whether the v-select is clearable
-       */
-      get(): boolean {
-        return this.type === 'Subtitle';
-      }
-    },
     /**
      * @returns {number|undefined} Default index to use (undefined if empty by default)
      */
     defaultIndex: {
-      get(): number | undefined {
-        const defaultTrack = this.tracks.findIndex((track) => track.IsDefault);
-
-        if (defaultTrack !== -1) {
-          return defaultTrack;
-        } else if (this.type === 'Subtitle') {
-          return undefined;
-        }
-
-        return 0;
+      get(): number {
+        return this.tracks.findIndex((track) => track.IsDefault);
       }
     }
   },
@@ -192,8 +176,15 @@ export default Vue.extend({
     /**
      * @param {number} newVal - New index value choosen in the v-select
      */
-    trackIndex(newVal: number): void {
-      this.$emit('input', newVal);
+    trackIndex: {
+      immediate: true,
+      handler(newVal: number): void {
+        if (this.tracks?.[newVal]?.Index) {
+          this.$emit('input', this.tracks?.[newVal]?.Index);
+        } else {
+          this.$emit('input', -1);
+        }
+      }
     },
     /**
      * When the media source index is changed by the parent, we reset the selected track as it has changed

--- a/client/components/Players/ShakaPlayer.vue
+++ b/client/components/Players/ShakaPlayer.vue
@@ -52,7 +52,11 @@ export default Vue.extend({
     ...mapState('playbackManager', [
       'lastProgressUpdate',
       'currentTime',
-      'currentVolume'
+      'currentVolume',
+      'currentMediaSource',
+      'currentVideoStreamIndex',
+      'currentAudioStreamIndex',
+      'currentSubtitleStreamIndex'
     ]),
     ...mapState('deviceProfile', ['deviceId']),
     ...mapState('user', ['accessToken']),
@@ -196,7 +200,13 @@ export default Vue.extend({
             {
               itemId: this.getCurrentItem?.Id || '',
               userId: this.$auth.user?.Id,
-              playbackInfoDto: { DeviceProfile: this.$playbackProfile }
+              autoOpenLiveStream: true,
+              playbackInfoDto: { DeviceProfile: this.$playbackProfile },
+              mediaSourceId: this.currentMediaSource?.Id
+                ? this.currentMediaSource.Id
+                : undefined,
+              audioStreamIndex: this.currentAudioStreamIndex,
+              subtitleStreamIndex: this.currentSubtitleStreamIndex
             },
             { progress: false }
           )

--- a/client/pages/item/_itemId/index.vue
+++ b/client/pages/item/_itemId/index.vue
@@ -32,7 +32,13 @@
               'ml-0': $vuetify.breakpoint.mdAndUp
             }"
           >
-            <play-button class="mr-2" :item="item" />
+            <play-button
+              class="mr-2"
+              :item="item"
+              :video-track-index="currentVideoTrack"
+              :audio-track-index="currentAudioTrack"
+              :subtitle-track-index="currentSubtitleTrack"
+            />
             <like-button :item="item" class="mr-2" />
             <mark-played-button :item="item" class="mr-2" />
             <item-menu :item="item" />

--- a/client/store/playbackManager.ts
+++ b/client/store/playbackManager.ts
@@ -144,7 +144,7 @@ export const getters: GetterTree<PlaybackManagerState, RootState> = {
   getCurrentVideoTrack: (state) => {
     if (
       state.currentMediaSource !== null &&
-      state.currentVideoStreamIndex !== null
+      state.currentVideoStreamIndex !== undefined
     ) {
       return state.currentMediaSource.MediaStreams?.filter((stream) => {
         return stream.Type === 'Video';
@@ -156,7 +156,7 @@ export const getters: GetterTree<PlaybackManagerState, RootState> = {
   getCurrentAudioTrack: (state) => {
     if (
       state.currentMediaSource !== null &&
-      state.currentAudioStreamIndex !== null
+      state.currentAudioStreamIndex !== undefined
     ) {
       return state.currentMediaSource.MediaStreams?.filter((stream) => {
         return stream.Type === 'Audio';
@@ -168,7 +168,7 @@ export const getters: GetterTree<PlaybackManagerState, RootState> = {
   getCurrentSubtitleTrack: (state) => {
     if (
       state.currentMediaSource !== null &&
-      state.currentSubtitleStreamIndex !== null
+      state.currentSubtitleStreamIndex !== undefined
     ) {
       return state.currentMediaSource.MediaStreams?.filter((stream) => {
         return stream.Type === 'Subtitle';

--- a/client/store/playbackManager.ts
+++ b/client/store/playbackManager.ts
@@ -33,9 +33,9 @@ export interface PlaybackManagerState {
   lastItemIndex: number | null;
   currentItemIndex: number | null;
   currentMediaSource: MediaSourceInfo | null;
-  currentVideoStreamIndex: number | null;
-  currentAudioStreamIndex: number | null;
-  currentSubtitleStreamIndex: number | null;
+  currentVideoStreamIndex: number | undefined;
+  currentAudioStreamIndex: number | undefined;
+  currentSubtitleStreamIndex: number | undefined;
   currentItemChapters: ChapterInfo[] | null;
   currentTime: number | null;
   lastProgressUpdate: number;
@@ -57,9 +57,9 @@ export const defaultState = (): PlaybackManagerState => ({
   lastItemIndex: null,
   currentItemIndex: null,
   currentMediaSource: null,
-  currentVideoStreamIndex: 0,
-  currentAudioStreamIndex: 0,
-  currentSubtitleStreamIndex: 0,
+  currentVideoStreamIndex: undefined,
+  currentAudioStreamIndex: undefined,
+  currentSubtitleStreamIndex: undefined,
   currentItemChapters: null,
   currentTime: null,
   lastProgressUpdate: 0,
@@ -220,6 +220,24 @@ export const mutations: MutationTree<PlaybackManagerState> = {
   ) {
     state.currentMediaSource = mediaSource;
   },
+  SET_CURRENT_VIDEO_TRACK_INDEX(
+    state: PlaybackManagerState,
+    { videoStreamIndex }: { videoStreamIndex: number }
+  ) {
+    state.currentVideoStreamIndex = videoStreamIndex;
+  },
+  SET_CURRENT_AUDIO_TRACK_INDEX(
+    state: PlaybackManagerState,
+    { audioStreamIndex }: { audioStreamIndex: number }
+  ) {
+    state.currentAudioStreamIndex = audioStreamIndex;
+  },
+  SET_CURRENT_SUBTITLE_TRACK_INDEX(
+    state: PlaybackManagerState,
+    { subtitleStreamIndex }: { subtitleStreamIndex: number }
+  ) {
+    state.currentSubtitleStreamIndex = subtitleStreamIndex;
+  },
   INCREASE_QUEUE_INDEX(state: PlaybackManagerState) {
     if (state.currentItemIndex !== null) {
       state.lastItemIndex = state.currentItemIndex;
@@ -328,12 +346,18 @@ export const actions: ActionTree<PlaybackManagerState, RootState> = {
     { commit, state },
     {
       item,
+      audioTrackIndex,
+      subtitleTrackIndex,
+      videoTrackIndex,
       startFromIndex = 0,
       startFromTime = 0,
       initiator,
       startShuffled = false
     }: {
       item: BaseItemDto;
+      audioTrackIndex?: number;
+      subtitleTrackIndex?: number;
+      videoTrackIndex?: number;
       startFromIndex?: number;
       startFromTime?: number;
       initiator?: BaseItemDto;
@@ -356,6 +380,25 @@ export const actions: ActionTree<PlaybackManagerState, RootState> = {
     }
 
     commit('SET_QUEUE', { queue: translatedItems });
+
+    if (videoTrackIndex !== undefined) {
+      commit('SET_CURRENT_VIDEO_TRACK_INDEX', {
+        videoStreamIndex: videoTrackIndex
+      });
+    }
+
+    if (audioTrackIndex !== undefined) {
+      commit('SET_CURRENT_AUDIO_TRACK_INDEX', {
+        audioStreamIndex: audioTrackIndex
+      });
+    }
+
+    if (subtitleTrackIndex !== undefined) {
+      commit('SET_CURRENT_SUBTITLE_TRACK_INDEX', {
+        subtitleStreamIndex: subtitleTrackIndex
+      });
+    }
+
     commit('SET_CURRENT_ITEM_INDEX', { currentItemIndex: startFromIndex });
     commit('SET_CURRENT_TIME', { time: startFromTime });
 


### PR DESCRIPTION
Adds pre-playback stream selection.

TrackSelector needs a refactor for this to be a bit cleaner, as I currently have to work around it to fit what Jellyfin expects to get (This PR already has some changes, but it's only workarounds... The whole "clearing" part doesn't work for this, passing it an entire item and a type doesn't work (filtering should be done above), etc.

Supersedes #640