### PR TITLE
feat(shaka-player): add audio gain support to player

### DIFF
--- a/client/components/Layout/VolumeSlider.vue
+++ b/client/components/Layout/VolumeSlider.vue
@@ -7,7 +7,7 @@
       class="volume-slider"
       hide-details
       thumb-label
-      max="125"
+      max="100"
       :value="currentVolume"
       validate-on-blur
       @input="onVolumeChange"

--- a/client/components/Layout/VolumeSlider.vue
+++ b/client/components/Layout/VolumeSlider.vue
@@ -7,7 +7,7 @@
       class="volume-slider"
       hide-details
       thumb-label
-      max="100"
+      max="125"
       :value="currentVolume"
       validate-on-blur
       @input="onVolumeChange"

--- a/client/components/Players/ShakaPlayer.vue
+++ b/client/components/Players/ShakaPlayer.vue
@@ -4,6 +4,7 @@
     ref="shakaPlayer"
     :poster="poster.url"
     autoplay
+    crossorigin="anonymous"
     :playsinline="$browser.isMobile() && $browser.isApple()"
     @timeupdate="onProgressThrottled"
     @pause="onPause"
@@ -41,7 +42,10 @@ export default Vue.extend({
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       player: null as any,
       // eslint-disable-next-line @typescript-eslint/no-empty-function
-      unsubscribe(): void {}
+      unsubscribe(): void {},
+      audioContext: null as AudioContext | null,
+      audioSource: null as MediaElementAudioSourceNode | null,
+      gainNode: null as GainNode | null
     };
   },
   computed: {
@@ -110,6 +114,17 @@ export default Vue.extend({
         window.player = new shaka.Player(this.$refs.shakaPlayer);
         this.player = window.player;
 
+        // Create WebAudio context and nodes for added processing
+        this.audioContext = new AudioContext();
+        this.audioSource = this.audioContext.createMediaElementSource(
+          this.$refs.shakaPlayer as HTMLMediaElement
+        );
+        this.gainNode = this.audioContext.createGain();
+        this.gainNode.gain.value = 1;
+        this.audioSource.connect(this.gainNode);
+
+        this.gainNode.connect(this.audioContext.destination);
+
         // Register player events
         this.player.addEventListener('error', this.onPlayerError);
         // Subscribe to Vuex actions
@@ -140,9 +155,8 @@ export default Vue.extend({
                 break;
 
               case 'playbackManager/SET_VOLUME':
-                if (this.$refs.shakaPlayer) {
-                  (this.$refs.shakaPlayer as HTMLAudioElement).volume =
-                    this.currentVolume / 100;
+                if (this.$refs.shakaPlayer && this.gainNode) {
+                  this.gainNode.gain.value = this.currentVolume / 100;
                 }
 
                 break;
@@ -178,6 +192,10 @@ export default Vue.extend({
       this.player.removeEventListener('error', this.onPlayerError);
       this.player.unload();
       this.player.destroy();
+
+      if (this.audioContext) {
+        this.audioContext.close();
+      }
     }
 
     this.unsubscribe();

--- a/client/store/playbackManager.ts
+++ b/client/store/playbackManager.ts
@@ -1,5 +1,4 @@
 import { ActionTree, GetterTree, MutationTree } from 'vuex';
-import clamp from 'lodash/clamp';
 import shuffle from 'lodash/shuffle';
 import {
   BaseItemDto,
@@ -279,7 +278,7 @@ export const mutations: MutationTree<PlaybackManagerState> = {
     state.lastProgressUpdate = progress;
   },
   SET_VOLUME(state: PlaybackManagerState, { volume }: VolumeMutationPayload) {
-    state.currentVolume = clamp(volume, 0, 100);
+    state.currentVolume = volume;
   },
   SET_MINIMIZE(
     state: PlaybackManagerState,


### PR DESCRIPTION
Hooks up the player's audio output to a Web Audio context, in order to add a GainNode to it.

This allows us to control the gain of the audio, here in order to mimic VLC's "125% audio volume" feature, allowing the user to boost the audio level of their content if it's too low.

**Warning: increasing the gain past 100% can lead to clipping. It's not really an issue, but it's worth knowing.**