### PR TITLE
refactor(home-header): use functional components for item titles

### DIFF
--- a/src/components/Layout/HomeHeader/HomeHeaderAlbumTitle.vue
+++ b/src/components/Layout/HomeHeader/HomeHeaderAlbumTitle.vue
@@ -1,66 +1,59 @@
-<template>
+<template functional>
   <div>
-    <nuxt-link
-      v-if="imageTag"
-      :to="
-        item.AlbumArtists.length > 0
-          ? getItemDetailsLink(item.AlbumArtists[0], 'MusicArtist')
-          : null
-      "
-    >
+    <nuxt-link v-if="props.logo.tag" :to="props.parentLink">
       <v-img
         max-width="50%"
         max-height="5.5em"
         contain
         position="left center"
         data-swiper-parallax="-300"
-        :alt="item.Name"
-        :src="logo"
+        :alt="props.item.Name"
+        :src="props.logo.url"
       />
     </nuxt-link>
     <nuxt-link
       v-else
       data-swiper-parallax="-300"
       class="link d-block text-h5 text-sm-h4 text-truncate mb-n1 mb-sm-n2 mt-n3"
-      :to="
-        item.AlbumArtists.length > 0
-          ? getItemDetailsLink(item.AlbumArtists[0], 'MusicArtist')
-          : null
-      "
+      :to="props.parentLink"
     >
-      {{ item.AlbumArtist }}
+      {{ props.item.AlbumArtist }}
     </nuxt-link>
     <nuxt-link
       data-swiper-parallax="-200"
       class="link d-block text-h4 text-sm-h3 text-truncate"
-      :to="getItemDetailsLink(item)"
+      :to="props.link"
     >
-      {{ item.Name }}
+      {{ props.item.Name }}
     </nuxt-link>
   </div>
 </template>
 
 <script lang="ts">
 import Vue from 'vue';
-import { BaseItemDto, ImageType } from '@jellyfin/client-axios';
-import imageHelper from '~/mixins/imageHelper';
-import itemHelper from '~/mixins/itemHelper';
+import { VImg } from 'vuetify/lib';
+import { BaseItemDto } from '@jellyfin/client-axios';
+import { ImageUrlInfo } from '~/mixins/imageHelper';
+
+Vue.component('VImg', VImg);
 
 export default Vue.extend({
-  mixins: [imageHelper, itemHelper],
   props: {
     item: {
       type: Object as () => BaseItemDto,
       required: true
     },
-    logo: {
+    parentLink: {
       type: String,
-      default: ''
-    }
-  },
-  computed: {
-    imageTag(): string | undefined {
-      return this.getImageTag(this.item, ImageType.Logo);
+      required: true
+    },
+    link: {
+      type: String,
+      required: true
+    },
+    logo: {
+      type: Object as () => ImageUrlInfo,
+      default: undefined
     }
   }
 });

--- a/src/components/Layout/HomeHeader/HomeHeaderEpisodeTitle.vue
+++ b/src/components/Layout/HomeHeader/HomeHeaderEpisodeTitle.vue
@@ -1,71 +1,66 @@
-<template>
+<template functional>
   <div>
-    <nuxt-link
-      v-if="imageTag"
-      :to="
-        item.SeriesId
-          ? getItemDetailsLink({ Id: item.SeriesId }, 'Series')
-          : null
-      "
-    >
+    <nuxt-link v-if="props.logo.tag" :to="props.parentLink">
       <v-img
         class="mb-2"
-        :max-width="$vuetify.breakpoint.mdAndUp ? '50%' : '40%'"
-        :max-height="$vuetify.breakpoint.smAndUp ? '7.5em' : '4em'"
+        :max-width="parent.$vuetify.breakpoint.mdAndUp ? '50%' : '40%'"
+        :max-height="parent.$vuetify.breakpoint.smAndUp ? '7.5em' : '4em'"
         contain
         position="left center"
         data-swiper-parallax="-300"
-        :alt="item.Name"
-        :src="logo"
+        :alt="props.item.Name"
+        :src="props.logo.url"
       />
     </nuxt-link>
     <nuxt-link
       v-else
       data-swiper-parallax="-300"
       class="link d-block text-h4 text-sm-h2 text-truncate mt-n2 mb-n1"
-      :to="
-        item.SeriesId
-          ? getItemDetailsLink({ Id: item.SeriesId }, 'Series')
-          : null
-      "
+      :to="props.parentLink"
     >
-      {{ item.SeriesName }}
+      {{ props.item.SeriesName }}
     </nuxt-link>
     <p data-swiper-parallax="-200" class="mb-n1 text-truncate text-subtitle-2">
-      {{ item.SeasonName }}
-      {{ $t('episodeNumber', { episodeNumber: item.IndexNumber }) }}
+      {{ props.item.SeasonName }}
+      {{
+        parent.$t('episodeNumber', { episodeNumber: props.item.IndexNumber })
+      }}
     </p>
     <nuxt-link
       data-swiper-parallax="-200"
       class="link d-block text-h5 text-sm-h4 text-truncate"
-      :to="getItemDetailsLink(item)"
+      :to="props.link"
     >
-      {{ item.Name }}
+      {{ props.item.Name }}
     </nuxt-link>
   </div>
 </template>
 
 <script lang="ts">
 import Vue from 'vue';
-import { BaseItemDto, ImageType } from '@jellyfin/client-axios';
-import imageHelper from '~/mixins/imageHelper';
-import itemHelper from '~/mixins/itemHelper';
+import { VImg } from 'vuetify/lib';
+import { BaseItemDto } from '@jellyfin/client-axios';
+import { ImageUrlInfo } from '~/mixins/imageHelper';
+
+Vue.component('VImg', VImg);
 
 export default Vue.extend({
-  mixins: [imageHelper, itemHelper],
   props: {
     item: {
       type: Object as () => BaseItemDto,
       required: true
     },
-    logo: {
+    parentLink: {
       type: String,
-      default: ''
-    }
-  },
-  computed: {
-    imageTag(): string | undefined {
-      return this.getImageTag(this.item, ImageType.Logo);
+      required: true
+    },
+    link: {
+      type: String,
+      required: true
+    },
+    logo: {
+      type: Object as () => ImageUrlInfo,
+      default: undefined
     }
   }
 });

--- a/src/components/Layout/HomeHeader/HomeHeaderGenericTitle.vue
+++ b/src/components/Layout/HomeHeader/HomeHeaderGenericTitle.vue
@@ -1,56 +1,55 @@
-<template>
+<template functional>
   <div>
-    <nuxt-link v-if="imageTag" :to="getItemDetailsLink(item)">
+    <nuxt-link v-if="props.logo && props.logo.tag" :to="props.link">
       <v-img
         class="mb-2"
-        :max-width="$vuetify.breakpoint.mdAndUp ? '50%' : '40%'"
-        :max-height="$vuetify.breakpoint.smAndUp ? '7.5em' : '4em'"
+        :max-width="parent.$vuetify.breakpoint.mdAndUp ? '50%' : '40%'"
+        :max-height="parent.$vuetify.breakpoint.smAndUp ? '7.5em' : '4em'"
         contain
-        position="left center"
         data-swiper-parallax="-300"
-        :alt="item.Name"
-        :src="logo"
+        :alt="props.item.Name"
+        :src="props.logo.url"
       />
     </nuxt-link>
     <nuxt-link
       v-else
       data-swiper-parallax="-300"
       class="link d-block text-h4 text-sm-h3 text-sm-h2 text-truncate"
-      :to="getItemDetailsLink(item)"
+      :to="props.link"
     >
-      {{ item.Name }}
+      {{ props.item.Name }}
     </nuxt-link>
     <h2
-      v-if="item.Taglines && item.Taglines.length > 0"
+      v-if="props.item.Taglines && props.item.Taglines.length > 0"
       data-swiper-parallax="-200"
       class="text-truncate"
     >
-      {{ item.Taglines[0] }}
+      {{ props.item.Taglines[0] }}
     </h2>
   </div>
 </template>
 
 <script lang="ts">
 import Vue from 'vue';
-import { BaseItemDto, ImageType } from '@jellyfin/client-axios';
-import imageHelper from '~/mixins/imageHelper';
-import itemHelper from '~/mixins/itemHelper';
+import { VImg } from 'vuetify/lib';
+import { BaseItemDto } from '@jellyfin/client-axios';
+import { ImageUrlInfo } from '~/mixins/imageHelper';
+
+Vue.component('VImg', VImg);
 
 export default Vue.extend({
-  mixins: [imageHelper, itemHelper],
   props: {
     item: {
       type: Object as () => BaseItemDto,
       required: true
     },
-    logo: {
+    link: {
       type: String,
-      default: ''
-    }
-  },
-  computed: {
-    imageTag(): string | undefined {
-      return this.getImageTag(this.item, ImageType.Logo);
+      required: true
+    },
+    logo: {
+      type: Object as () => ImageUrlInfo,
+      default: undefined
     }
   }
 });

--- a/src/components/Layout/HomeHeader/HomeHeaderItems.vue
+++ b/src/components/Layout/HomeHeader/HomeHeaderItems.vue
@@ -37,16 +37,29 @@
                   v-if="item.Type === 'MusicAlbum'"
                   class="mb-sm-n1"
                   :item="item"
+                  :parent-link="
+                    item.AlbumArtists.length > 0
+                      ? getItemDetailsLink(item.AlbumArtists[0], 'MusicArtist')
+                      : null
+                  "
+                  :link="getItemDetailsLink(item)"
                   :logo="getLogo(item)"
                 />
                 <home-header-episode-title
                   v-else-if="item.Type === 'Episode'"
                   :item="item"
+                  :parent-link="
+                    item.SeriesId
+                      ? getItemDetailsLink({ Id: item.SeriesId }, 'Series')
+                      : null
+                  "
+                  :link="getItemDetailsLink(item)"
                   :logo="getLogo(item)"
                 />
                 <home-header-generic-title
                   v-else
                   :item="item"
+                  :link="getItemDetailsLink(item)"
                   :logo="getLogo(item)"
                 />
                 <media-info
@@ -168,9 +181,6 @@ export default Vue.extend({
       } else {
         return '';
       }
-    },
-    getLogo(item: BaseItemDto): string | undefined {
-      return this.getImageInfo(item, { preferLogo: true }).url;
     },
     // HACK: Swiper seems to have a bug where the components inside of duplicated slides (when loop is enabled,
     // swiper creates a duplicate of the first one, so visually it looks like you started all over before repositioning all the DOM)


### PR DESCRIPTION
Converts the home header title components to functional components, since reactivity isn't needed there.