### PR TITLE
fix(watched-indicator): fix vuetify component treeshaking

### DIFF
--- a/src/components/Item/WatchedIndicator.vue
+++ b/src/components/Item/WatchedIndicator.vue
@@ -4,6 +4,18 @@
   </v-chip>
 </template>
 
+<script lang="ts">
+import Vue from 'vue';
+import { VChip, VIcon } from 'vuetify/lib';
+
+Vue.component('VChip', VChip);
+Vue.component('VIcon', VIcon);
+
+export default Vue.extend({
+  name: 'WatchedIndicator'
+});
+</script>
+
 <style lang="scss" scoped>
 .card-chip {
   position: absolute;


### PR DESCRIPTION
Declares VChip and VIcon locally, to avoid Vuetify treeshaking them out of WatchedIndicator due to it being functional.