### PR TITLE
style(theme): use new color scheme

### DIFF
--- a/src/assets/variables.scss
+++ b/src/assets/variables.scss
@@ -28,13 +28,13 @@ $material-light: (
 // Lists use the ::before selector to apply hover backgrounds
 // This is not available on tables so it has to be manual
 $material-dark: (
-  'background': #121721,
-  'navigation-drawer': #1c2331,
-  'app-bar': #1c2331,
-  'dividers': #233543,
-  'cards': #1c2331,
-  'chips': #2b4355,
-  'menus': #252e41,
+  'background': #111827,
+  'navigation-drawer': #1f2937,
+  'app-bar': #1f2937,
+  'dividers': #374151,
+  'cards': #1f2937,
+  'chips': #4b5563,
+  'menus': #374151,
   'text': (
     'primary': #edf2f7
   ),

--- a/src/nuxt.config.ts
+++ b/src/nuxt.config.ts
@@ -327,7 +327,7 @@ const config: NuxtConfig = {
       disable: false,
       themes: {
         dark: {
-          primary: '#0086b3',
+          primary: '#9d37c2',
           secondary: '#2f3951',
           accent: '#FF4081',
           info: '#0099CC',
@@ -339,7 +339,7 @@ const config: NuxtConfig = {
           thumb: '#252e41'
         },
         light: {
-          primary: '#00A4DC',
+          primary: '#9d37c2',
           secondary: '#424242',
           accent: '#FF4081',
           info: '#33b5e5',


### PR DESCRIPTION
This changes the color scheme to the one used by `next.jellyfin.org`

![Screenshot 2021-08-28 at 11-22-00 Jellyfin](https://user-images.githubusercontent.com/19396809/131213208-7dde4181-4b4f-42ae-84bd-b023a2fc4079.png)
