### PR TITLE
feat(volume): use a x³ curve for media volume

### DIFF
--- a/src/components/Players/ShakaPlayer.vue
+++ b/src/components/Players/ShakaPlayer.vue
@@ -157,7 +157,10 @@ export default Vue.extend({
 
               case 'playbackManager/SET_VOLUME':
                 if (this.$refs.shakaPlayer && this.gainNode) {
-                  this.gainNode.gain.value = this.currentVolume / 100;
+                  this.gainNode.gain.value = Math.pow(
+                    this.currentVolume / 100,
+                    3
+                  );
                 }
 
                 break;


### PR DESCRIPTION
This provides a more natural input for the volume slider, since the volume will now be exponential instead of linear.

x³ is the same curve used by VLC and MPV, so we're aiming to match familiarity here.