### PR TITLE
chore(packaging): replace contributors with author field

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,16 +11,7 @@
     "url": "https://github.com/jellyfin/jellyfin-vue/"
   },
   "license": "GPL-3.0-only",
-  "contributors": [
-    {
-      "name": "Julien Machiels",
-      "email": "iamtimscampi@gmail.com"
-    },
-    {
-      "name": "Thibault Nocchi",
-      "email": "thibaultnocchi@gmail.com"
-    }
-  ],
+  "author": "jellyfin-vue Contributors (https://github.com/jellyfin/jellyfin-vue/graphs/contributors)",
   "scripts": {
     "analyze": "NUXT_SSR=1 nuxt build --analyze src",
     "analyze:static": "nuxt build --analyze src",


### PR DESCRIPTION
Replaces the ``contributors`` array with the ``author`` field, pointing to the Contributors page in GitHub.

This way, contributors info is still displayed when using npm commands but we don't have to update each contributor name manually in the file and we take into account everyone.