### PR TITLE
feat(video): support fmp4

### DIFF
--- a/src/plugins/playbackProfiles/transcodingProfile.ts
+++ b/src/plugins/playbackProfiles/transcodingProfile.ts
@@ -5,6 +5,8 @@ import {
 } from '@jellyfin/client-axios';
 import { Context } from '@nuxt/types';
 import { getSupportedAudioCodecs } from './helpers/audioFormats';
+import { getSupportedFmp4AudioCodecs } from './helpers/fmp4AudioFormats';
+import { getSupportedFmp4VideoCodecs } from './helpers/fmp4VideoFormats';
 import { getSupportedMP4AudioCodecs } from './helpers/mp4AudioFormats';
 import {
   getSupportedMP4VideoCodecs,
@@ -75,17 +77,6 @@ export function getTranscodingProfiles(
       });
     });
 
-  // TODO
-  // See below
-  // const hlsInFmp4VideoCodecs = getSupportedFmp4VideoCodecs(
-  //   context,
-  //   videoTestElement
-  // );
-  // const hlsInFmp4AudioCodecs = getSupportedFmp4AudioCodecs(
-  //   context,
-  //   videoTestElement
-  // );
-
   const hlsInTsVideoCodecs = getSupportedTsVideoCodecs(videoTestElement);
   const hlsInTsAudioCodecs = getSupportedTsAudioCodecs(
     context,
@@ -93,32 +84,28 @@ export function getTranscodingProfiles(
   );
 
   if (canPlayHls) {
-    // TODO
-    // Disabled for now as HLS.js has troubles seeking in it
-    // We should enable it for platforms supporting it natively
+    const hlsInFmp4VideoCodecs = getSupportedFmp4VideoCodecs(
+      context,
+      videoTestElement
+    );
+    const hlsInFmp4AudioCodecs = getSupportedFmp4AudioCodecs(
+      context,
+      videoTestElement
+    );
 
-    // const hlsInFmp4VideoCodecs = getSupportedFmp4VideoCodecs(
-    //   context,
-    //   videoTestElement
-    // );
-    // const hlsInFmp4AudioCodecs = getSupportedFmp4AudioCodecs(
-    //   context,
-    //   videoTestElement
-    // );
-
-    // if (hlsInFmp4VideoCodecs.length && hlsInFmp4AudioCodecs.length) {
-    //   TranscodingProfiles.push({
-    //     Container: 'mp4',
-    //     Type: DlnaProfileType.Video,
-    //     AudioCodec: hlsInFmp4AudioCodecs.join(','),
-    //     VideoCodec: hlsInFmp4VideoCodecs.join(','),
-    //     Context: EncodingContext.Streaming,
-    //     Protocol: 'hls',
-    //     MaxAudioChannels: physicalAudioChannels.toString(),
-    //     MinSegments: context.$browser.isApple() ? 2 : 1,
-    //     BreakOnNonKeyFrames: hlsBreakOnNonKeyFrames
-    //   });
-    // }
+    if (hlsInFmp4VideoCodecs.length && hlsInFmp4AudioCodecs.length) {
+      TranscodingProfiles.push({
+        Container: 'mp4',
+        Type: DlnaProfileType.Video,
+        AudioCodec: hlsInFmp4AudioCodecs.join(','),
+        VideoCodec: hlsInFmp4VideoCodecs.join(','),
+        Context: EncodingContext.Streaming,
+        Protocol: 'hls',
+        MaxAudioChannels: physicalAudioChannels.toString(),
+        MinSegments: context.$browser.isApple() ? 2 : 1,
+        BreakOnNonKeyFrames: hlsBreakOnNonKeyFrames
+      });
+    }
 
     if (hlsInTsVideoCodecs.length && hlsInTsAudioCodecs.length) {
       TranscodingProfiles.push({


### PR DESCRIPTION
Put back fMP4 support as the seeking bug was due to HLS.js >v1 and we're not using this version cause it affects TS containers too

This also has for result HEVC support on the compatible browsers