### PR TITLE
Remove Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,6 @@
 
 This is an experimental web client for Jellyfin based on Vue.js. We welcome all contributions and pull requests! If you have a larger feature in mind please open an issue so we can discuss the implementation before you start.
 
-<p align="center">
-    <a href="https://jellyfin-vue.pages.dev/">View demo</a>
-</p>
-
 ## Requirements
 
 This project requires [Node 14](https://nodejs.org/en/) and uses **npm** as a package manager.


### PR DESCRIPTION
As a temporary measure until the domain is transferred, removing the link from the readme.