### PR TITLE
fix(ui): "Soft" back arrow can be clicked when hidden

### DIFF
--- a/src/plugins/directives/hide.ts
+++ b/src/plugins/directives/hide.ts
@@ -3,9 +3,9 @@ import Vue from 'vue';
 Vue.directive('hide', (el, binding) => {
   if (el) {
     if (binding.value === true) {
-      el.style.opacity = '0';
+      el.style.display = 'none';
     } else {
-      el.style.opacity = '1';
+      el.style.display = 'initial';
     }
   }
 });

--- a/src/plugins/directives/hide.ts
+++ b/src/plugins/directives/hide.ts
@@ -3,9 +3,9 @@ import Vue from 'vue';
 Vue.directive('hide', (el, binding) => {
   if (el) {
     if (binding.value === true) {
-      el.style.display = 'none';
+      el.style.visibility = 'hidden';
     } else {
-      el.style.display = 'initial';
+      el.style.visibility = 'visible';
     }
   }
 });


### PR DESCRIPTION
From the issue #1365 : The back arrow on the top bar is hidden on the homepage but can be clicked.

So I change the hide directive logic from using CSS opacity to the display property.

