### PR TITLE
feat: remove keep-alive

### DIFF
--- a/src/components/Buttons/LikeButton.vue
+++ b/src/components/Buttons/LikeButton.vue
@@ -36,7 +36,7 @@ export default Vue.extend({
       }
     }
   },
-  activated() {
+  mounted() {
     this.unsubscribe = this.$store.subscribe((mutation) => {
       if (
         mutation?.type === 'SOCKET_ONMESSAGE' &&
@@ -54,7 +54,7 @@ export default Vue.extend({
       }
     });
   },
-  deactivated() {
+  destroyed() {
     this.unsubscribe();
   },
   methods: {

--- a/src/components/Forms/AddServerForm.vue
+++ b/src/components/Forms/AddServerForm.vue
@@ -61,7 +61,7 @@ export default Vue.extend({
   computed: {
     ...mapState('servers', ['serverList'])
   },
-  activated() {
+  mounted() {
     /**
      * Instead of mapping the current state from the store, we use the number of servers that are present
      * during the initialization of the component. That way, we can do the redirection to the correct page

--- a/src/components/Item/Card/Card.vue
+++ b/src/components/Item/Card/Card.vue
@@ -248,7 +248,7 @@ export default Vue.extend({
       }
     }
   },
-  activated() {
+  mounted() {
     this.unsubscribe = this.$store.subscribe((mutation, state) => {
       if (
         mutation.type === 'SOCKET_ONMESSAGE' &&
@@ -259,7 +259,7 @@ export default Vue.extend({
       }
     });
   },
-  deactivated() {
+  destroyed() {
     this.unsubscribe();
   },
   methods: {

--- a/src/components/Layout/HomeHeader/HomeHeaderItems.vue
+++ b/src/components/Layout/HomeHeader/HomeHeaderItems.vue
@@ -156,11 +156,9 @@ export default Vue.extend({
     const hash = this.getBlurhash(this.items[0], ImageType.Backdrop);
 
     this.setBackdrop({ hash });
-  },
-  activated() {
     this.onSlideChange();
   },
-  deactivated() {
+  destroyed() {
     this.clearBackdrop();
   },
   methods: {

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -105,7 +105,7 @@
     </v-app-bar>
     <v-main>
       <div class="pa-s">
-        <nuxt keep-alive :keep-alive-props="keepAliveOptions" />
+        <nuxt />
       </div>
     </v-main>
     <audio-controls />
@@ -132,17 +132,6 @@ interface LayoutButton {
 
 export default Vue.extend({
   mixins: [settingsHelper],
-  props: {
-    keepAliveOptions: {
-      type: Object as () => Record<string, unknown>,
-      default: (): Record<string, unknown> => {
-        return {
-          max: 10,
-          exclude: ['fullscreen-playback']
-        };
-      }
-    }
-  },
   data() {
     return {
       isScrolled: false,
@@ -218,10 +207,10 @@ export default Vue.extend({
 
     this.$connect(socketUrl);
   },
-  activated() {
+  mounted() {
     window.addEventListener('scroll', this.setIsScrolled, { passive: true });
   },
-  deactivated() {
+  destroyed() {
     window.removeEventListener('scroll', this.setIsScrolled);
   },
   methods: {

--- a/src/pages/artist/_itemId/index.vue
+++ b/src/pages/artist/_itemId/index.vue
@@ -248,10 +248,10 @@ export default Vue.extend({
       deep: true
     }
   },
-  activated() {
+  mounted() {
     this.setAppBarOpacity({ opaqueAppBar: false });
   },
-  deactivated() {
+  destroyed() {
     this.setAppBarOpacity({ opaqueAppBar: true });
     this.clearBackdrop();
   },

--- a/src/pages/fullscreen/playback/index.vue
+++ b/src/pages/fullscreen/playback/index.vue
@@ -95,15 +95,13 @@ export default Vue.extend({
       this.setBackdrop({ hash: this.backdropHash });
     });
   },
-  activated() {
+  mounted() {
     this.setAppBarOpacity({ opaqueAppBar: false });
     this.setBackdropOpacity({ newOpacity: 0.5 });
     this.setMinimized({ minimized: false });
-  },
-  mounted() {
     this.swiper = (this.$refs.playbackSwiper as Vue).$swiper as Swiper;
   },
-  deactivated() {
+  destroyed() {
     this.clearBackdrop();
     this.resetBackdropOpacity();
     this.setMinimized({ minimized: true });

--- a/src/pages/fullscreen/playback/index.vue
+++ b/src/pages/fullscreen/playback/index.vue
@@ -96,10 +96,10 @@ export default Vue.extend({
     });
   },
   mounted() {
+    this.swiper = (this.$refs.playbackSwiper as Vue).$swiper as Swiper;
     this.setAppBarOpacity({ opaqueAppBar: false });
     this.setBackdropOpacity({ newOpacity: 0.5 });
     this.setMinimized({ minimized: false });
-    this.swiper = (this.$refs.playbackSwiper as Vue).$swiper as Swiper;
   },
   destroyed() {
     this.clearBackdrop();

--- a/src/pages/genre/_itemId/index.vue
+++ b/src/pages/genre/_itemId/index.vue
@@ -96,13 +96,13 @@ export default Vue.extend({
       return this.getItems(this.itemIds);
     }
   },
-  activated() {
+  mounted() {
     this.setAppBarOpacity({ opaqueAppBar: true });
     this.setPageTitle({
       title: this.genre.Name
     });
   },
-  deactivated() {
+  destroyed() {
     this.setAppBarOpacity({ opaqueAppBar: false });
   },
   methods: {

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -148,7 +148,7 @@ export default Vue.extend({
     ...mapState('clientSettings', ['CustomPrefs']),
     ...mapState('userViews', ['views'])
   },
-  activated() {
+  mounted() {
     if (this.$fetchState.timestamp <= Date.now() - 30000) {
       this.$fetch();
     }
@@ -156,7 +156,7 @@ export default Vue.extend({
     this.setPageTitle({ title: this.$t('home') });
     this.setAppBarOpacity({ opaqueAppBar: false });
   },
-  deactivated() {
+  destroyed() {
     this.setAppBarOpacity({ opaqueAppBar: true });
   },
   methods: {

--- a/src/pages/item/_itemId/index.vue
+++ b/src/pages/item/_itemId/index.vue
@@ -379,14 +379,14 @@ export default Vue.extend({
       deep: true
     }
   },
-  activated() {
+  mounted() {
     this.setAppBarOpacity({ opaqueAppBar: false });
 
     if (this.item.MediaSources && this.item.MediaSources.length > 0) {
       this.currentSource = this.item.MediaSources[0];
     }
   },
-  deactivated() {
+  destroyed() {
     this.setAppBarOpacity({ opaqueAppBar: true });
     this.clearBackdrop();
   },

--- a/src/pages/library/_viewId.vue
+++ b/src/pages/library/_viewId.vue
@@ -137,7 +137,7 @@ export default Vue.extend({
       await this.refreshItems();
     }
   },
-  async activated() {
+  async mounted() {
     this.setAppBarOpacity({ opaqueAppBar: true });
     this.$nextTick(() => {
       this.$nuxt.$loading.start();
@@ -177,7 +177,7 @@ export default Vue.extend({
       });
     }
   },
-  deactivated() {
+  destroyed() {
     this.setAppBarOpacity({ opaqueAppBar: false });
   },
   methods: {

--- a/src/pages/musicalbum/_itemId/index.vue
+++ b/src/pages/musicalbum/_itemId/index.vue
@@ -138,10 +138,10 @@ export default Vue.extend({
       deep: true
     }
   },
-  activated() {
+  mounted() {
     this.setAppBarOpacity({ opaqueAppBar: false });
   },
-  deactivated() {
+  destroyed() {
     this.setAppBarOpacity({ opaqueAppBar: true });
     this.clearBackdrop();
   },

--- a/src/pages/person/_itemId/index.vue
+++ b/src/pages/person/_itemId/index.vue
@@ -285,10 +285,10 @@ export default Vue.extend({
       deep: true
     }
   },
-  activated() {
+  mounted() {
     this.setAppBarOpacity({ opaqueAppBar: false });
   },
-  deactivated() {
+  destroyed() {
     this.setAppBarOpacity({ opaqueAppBar: true });
     this.clearBackdrop();
   },

--- a/src/pages/series/_itemId/index.vue
+++ b/src/pages/series/_itemId/index.vue
@@ -249,10 +249,10 @@ export default Vue.extend({
       deep: true
     }
   },
-  activated() {
+  mounted() {
     this.setAppBarOpacity({ opaqueAppBar: false });
   },
-  deactivated() {
+  destroyed() {
     this.setAppBarOpacity({ opaqueAppBar: true });
     this.clearBackdrop();
   },

--- a/src/pages/server/add.vue
+++ b/src/pages/server/add.vue
@@ -26,7 +26,7 @@ export default Vue.extend({
   computed: {
     ...mapState('page', ['title'])
   },
-  activated() {
+  mounted() {
     this.setPageTitle({ title: this.$t('login.addServer') });
   },
   methods: {

--- a/src/pages/server/login.vue
+++ b/src/pages/server/login.vue
@@ -90,7 +90,7 @@ export default Vue.extend({
   computed: {
     ...mapState('page', ['title'])
   },
-  activated() {
+  mounted() {
     this.setPageTitle({ title: this.$t('login.login') });
   },
   methods: {

--- a/src/pages/server/select.vue
+++ b/src/pages/server/select.vue
@@ -55,7 +55,7 @@ export default Vue.extend({
       }
     }
   },
-  activated() {
+  mounted() {
     this.setPageTitle({ title: this.$t('login.selectServer') });
   },
   methods: {

--- a/src/pages/settings/index.vue
+++ b/src/pages/settings/index.vue
@@ -227,7 +227,7 @@ export default Vue.extend({
       ]
     };
   },
-  activated() {
+  mounted() {
     this.setAppBarOpacity({ opaqueAppBar: true });
     this.setPageTitle({ title: this.$t('settings.settings') });
   },

--- a/src/pages/settings/logsAndActivity.vue
+++ b/src/pages/settings/logsAndActivity.vue
@@ -157,7 +157,7 @@ export default Vue.extend({
     ...mapState('page', ['title']),
     ...mapState('user', ['accessToken'])
   },
-  activated() {
+  mounted() {
     this.setPageTitle({ title: this.$t('settingsSections.logs.name') });
   },
   methods: {

--- a/src/pages/wizard.vue
+++ b/src/pages/wizard.vue
@@ -114,7 +114,7 @@ export default Vue.extend({
       return '';
     }
   },
-  activated() {
+  mounted() {
     this.setPageTitle({ title: this.$t('wizard.setupWizard') });
     this.setDeviceProfile();
   },


### PR DESCRIPTION
Keep alive introduces lots of complexities to the state management of the app and it consumes a lot of memory. It's true that removing it introduces some loading time, but what we need is proper item caching instead and we're still not production ready, so this is a minor annoyance.

It never worked properly when switching pages when a promise is running (can be seen easily by going to a library page from the home page while it's loading).