### PR TITLE
feat: replace circle loader with Jellyfin-Vue logo

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,3 @@
-# editorconfig.org
 root = true
 
 [*]

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+/src/assets/loading.html
+node_modules
+.nuxt

--- a/src/assets/loading.html
+++ b/src/assets/loading.html
@@ -1,0 +1,26 @@
+<style>
+body, html, #<%= globals.id %> {
+  background: #111827;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: 0;
+  padding: 0;
+}
+
+.splashLogo {
+  width: 30%;
+  height: 30%;
+  /* This file is in the 'static' folder, so it will be placed at the root when the client is built */
+  background-image: url(/icon.png);
+  background-position: center center;
+  background-repeat: no-repeat;
+  background-size: contain;
+}
+</style>
+
+<div class="splashLogo">
+</div>
+

--- a/src/nuxt.config.ts
+++ b/src/nuxt.config.ts
@@ -357,9 +357,7 @@ const config: NuxtConfig = {
     }
   },
   loadingIndicator: {
-    name: 'circle',
-    color: '#0086b3',
-    background: '#14141F'
+    name: 'assets/loading.html'
   },
   /*
    ** Build configuration


### PR DESCRIPTION
Mimics jellyfin-web in that regard (but without the spinner, Nuxt 2's loading templates are really basic and doesn't let us detect the loading state properly to display an spinner when the loading is near to be finished.

https://user-images.githubusercontent.com/10274099/144721396-a1ea196b-ed6d-48ce-9d0c-8ed0ff0de993.mp4


