### PR TITLE
Pin lockfile in .npmrc

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,7 @@ updates:
       prefix: fix
       prefix-development: chore
       include: scope
+    versioning-strategy: increase
   # Fetch and updated latest `npm` packages for Docker SSR
   - package-ecosystem: npm
     directory: '/.docker'

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 fund=false
+lockfile-version=3

--- a/package.json
+++ b/package.json
@@ -133,8 +133,8 @@
     "vue-jest": "^3.0.7"
   },
   "engines": {
-    "node": ">=16.13.0 <17.0.0",
-    "npm": ">=8.1.0",
+    "node": ">=16.13.1 <17.0.0",
+    "npm": ">=8.1.2",
     "yarn": "Yarn is not supported. Please use NPM."
   },
   "fork-ts-checker": {


### PR DESCRIPTION
This is an attempt to fix dependabot updates messing with the lockfile version 3.

Right now, npm 8 will generate an v2 lockfile if an user wants to regen their lockfile or issues an ``npm i --package-lock-only``. In order to match this repo's v3, the ``--lockfile-version 3`` argument must be used. This PR adds that config to ``.npmrc`` file, essentially fixing this for everybody transparently, without the need to add any additional CLI arguments.

Also, I bumped the minimum ``npm`` and ``nodejs`` version, as npm ``8.1.0`` had [an issue](https://github.com/npm/cli/pull/3949) where numbers where treated as strings, which was fixed in ``npm 8.1.2`` (which is included in  ``nodejs 16.13.1``)