### PR TITLE
fix(arm): revert #1136 to fix arm builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ This is an experimental web client for Jellyfin based on Vue.js. We welcome all 
 
 ## Dependencies
 
-- [Node.js LTS](https://nodejs.org/en/download) `>=16.13.0 <17.0.0`
-- npm `>=8.1.0` (included in Node.js)
+- [Node.js LTS](https://nodejs.org/en/download) `>=16.13.1 <17.0.0`
+- npm `>=8.1.2` (included in Node.js)
 - Jellyfin Server `>=10.7.0`
 
 ## Getting Started

--- a/package.json
+++ b/package.json
@@ -131,10 +131,5 @@
     "node": ">=16.13.1 <17.0.0",
     "npm": ">=8.1.2",
     "yarn": "Yarn is not supported. Please use NPM."
-  },
-  "fork-ts-checker": {
-    "typescript": {
-      "memoryLimit": 4096
-    }
   }
 }

--- a/src/nuxt.config.ts
+++ b/src/nuxt.config.ts
@@ -374,12 +374,6 @@ const config: NuxtConfig = {
       }
     },
     optimizeCSS: true,
-    optimization: {
-      splitChunks: {
-        chunks: 'all',
-        maxSize: 800000
-      }
-    },
     extractCSS: {
       ignoreOrder: true
     },


### PR DESCRIPTION
NodeJS GC fails on ARM architectures when running ``fork-ts-checker``. Reverting the change until a better solution is found.

Also fixed an small typo in readme.