### PR TITLE
chore(ci): fix tags only referencing a single arch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,14 +10,6 @@ jobs:
   docker:
     name: Build Docker images 💿💻
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        platform:
-          - 'linux/amd64'
-          - 'linux/arm64'
-          - 'linux/arm'
-          - 'linux/arm/v6'
 
     steps:
       - name: Checkout ⬇️
@@ -48,7 +40,7 @@ jobs:
         with:
           context: .
           push: true
-          platforms: ${{ matrix.platform }}
+          platforms: linux/amd64,linux/arm64,linux/arm,linux/arm/v6
           build-args: |
             IS_STABLE=1
           tags: |
@@ -65,7 +57,7 @@ jobs:
         with:
           context: .
           push: true
-          platforms: ${{ matrix.platform }}
+          platforms: linux/amd64,linux/arm64,linux/arm,linux/arm/v6
           build-args: |
             IS_STABLE=1
           tags: |

--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -9,14 +9,6 @@ jobs:
   docker:
     name: Build Docker images 💿💻
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        platform:
-          - 'linux/amd64'
-          - 'linux/arm64'
-          - 'linux/arm'
-          - 'linux/arm/v6'
 
     steps:
       - name: Checkout ⬇️
@@ -54,7 +46,7 @@ jobs:
         with:
           context: .
           push: true
-          platforms: ${{ matrix.platform }}
+          platforms: linux/amd64,linux/arm64,linux/arm,linux/arm/v6
           tags: |
             jellyfin/jellyfin-vue:unstable
             jellyfin/jellyfin-vue:unstable.${{ steps.date.outputs.date }}.${{ steps.sha.outputs.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,6 @@
 ## This dockerfile builds the client entirely in a Docker context
 
 FROM node:16-alpine AS build
-# Set labels
-LABEL maintainer="Jellyfin Packaging Team - packaging@jellyfin.org"
-LABEL org.opencontainers.image.source="https://github.com/jellyfin/jellyfin-vue"
 # Set environment variables
 ARG IS_STABLE=0
 ENV NUXT_ENV_COMMIT=""
@@ -29,5 +26,8 @@ RUN npm run build
 # Deploy built distribution to nginx
 FROM nginx:alpine
 COPY --from=build /app/src/dist/ /usr/share/nginx/html/
-
 EXPOSE 80
+
+# Set labels
+LABEL maintainer="Jellyfin Packaging Team - packaging@jellyfin.org"
+LABEL org.opencontainers.image.source="https://github.com/jellyfin/jellyfin-vue"


### PR DESCRIPTION
After merging #1645, the Docker tags that were pushed and available to registries were the ones that got pushed later, overwriting the other arches.

Disabled parallelization in the workflows that actually push to registries, leaving it only for the ``pull_request`` workflow, where no push happens and where more speedy checks are actually needed.