### PR TITLE
ci: remove unnecessary deps from Dockerfile and useless config from renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,46 +2,16 @@
   "packageRules": [
     {
       "matchDepTypes": ["devDependencies"],
-      "matchUpdateTypes": [
-        "major",
-        "minor",
-        "patch",
-        "bump",
-        "pin",
-        "digest",
-        "lockfileMaintenance",
-        "rollback"
-      ],
       "groupName": "development dependencies",
       "groupSlug": "dev-deps"
     },
     {
       "matchDepTypes": ["dependencies"],
-      "matchUpdateTypes": [
-        "major",
-        "minor",
-        "patch",
-        "bump",
-        "pin",
-        "digest",
-        "lockfileMaintenance",
-        "rollback"
-      ],
       "groupName": "dependencies",
       "groupSlug": "deps"
     },
     {
       "matchDepTypes": ["action"],
-      "matchUpdateTypes": [
-        "major",
-        "minor",
-        "patch",
-        "bump",
-        "pin",
-        "digest",
-        "lockfileMaintenance",
-        "rollback"
-      ],
       "groupName": "CI dependencies",
       "groupSlug": "ci-deps"
     }
@@ -49,7 +19,7 @@
   "dependencyDashboard": false,
   "ignoreDeps": ["npm", "swiper", "node", "hls.js"],
   "lockFileMaintenance": {
-    "enabled": false,
+    "enabled": true,
     "extends": ["schedule:monthly"]
   },
   "enabledManagers": ["npm", "github-actions"],

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG IS_STABLE=0
 ENV NUXT_ENV_COMMIT=""
 
 # Build dependencies required to build some node modules on ARM platforms. git is needed for fetching the latest commit
-RUN apk add --no-cache python3 make g++ git
+RUN apk add --no-cache git
 
 # Set workdir
 WORKDIR /app


### PR DESCRIPTION
Those dependencies were required for SSR. They are not needed by static (since we went away from imagemin as well).

I also took the opportunity to tidy up the renovate config after the feedback received on https://github.com/renovatebot/renovate/issues/13317