### PR TITLE
fix(episode info): add season and episode index in 'Item' page with 3…

### DIFF
--- a/src/components/Item/MediaInfo.vue
+++ b/src/components/Item/MediaInfo.vue
@@ -1,5 +1,13 @@
 <template>
   <div class="text--secondary">
+    <span v-if="item.Type === 'Episode'">
+      {{
+        $t('seasonEpisodeAbbrev', {
+          seasonNumber: item.ParentIndexNumber,
+          episodeNumber: item.IndexNumber
+        })
+      }}
+    </span>
     <span v-if="item.ProductionYear && year">{{ item.ProductionYear }}</span>
     <span v-if="item.OfficialRating && rating">{{ item.OfficialRating }}</span>
     <span v-if="item.CommunityRating && rating">


### PR DESCRIPTION
## Micro fix

I add the season name and episode number in the episode detail.

![image](https://user-images.githubusercontent.com/61033694/148667530-846c4381-3120-4ccf-bc94-482421ca3870.png)


I check the type of the item and if it is an episode, I show the information: {SeasonName, IndexNumber} 
just before the year (in the line below title)

src/components/Item/MediaInfo.vue
```vue
    <span v-if="item.Type === 'Episode'">
      {{ item.SeasonName }} &#8226; {{ item.IndexNumber }}        
    </span>
```

------------------------------

Just for the record, I misread this old closed issue (#1442) and made this fix, but I still find it useful. :)