### PR TITLE
feat(login): focus forms on login pages automatically

### DIFF
--- a/src/components/Forms/AddServerForm.vue
+++ b/src/components/Forms/AddServerForm.vue
@@ -10,6 +10,7 @@
           <v-text-field
             v-model="serverUrl"
             outlined
+            autofocus
             :label="$t('login.serverAddress')"
             type="url"
             :error-messages="errors"

--- a/src/components/Forms/LoginForm.vue
+++ b/src/components/Forms/LoginForm.vue
@@ -12,6 +12,7 @@
             v-model="login.username"
             outlined
             hide-details
+            autofocus
             autocomplete="username"
             :label="$t('username')"
             :error-messages="errors"


### PR DESCRIPTION
It's annoying the need to go and click the field manually. ith this, we're mimicking all other login forms that do this (i.e Google, Amazon, etc...)