### PR TITLE
Regex url fix

### DIFF
--- a/src/components/Forms/AddServerForm.vue
+++ b/src/components/Forms/AddServerForm.vue
@@ -48,7 +48,7 @@ import { mapActions, mapState } from 'vuex';
 export default Vue.extend({
   data() {
     return {
-      serverUrl: '',
+      serverUrl: '192.168.4.122',
       loading: false,
       rules: {
         serverUrl: {
@@ -75,6 +75,14 @@ export default Vue.extend({
     ...mapActions('servers', ['connectServer']),
     async connectToServer(): Promise<void> {
       this.loading = true;
+
+      if (!this.serverUrl.match(/^https?:\/\//)) {
+        this.serverUrl = 'http://' + this.serverUrl;
+      }
+
+      if (!this.serverUrl.match(/:[0-9]+$/)) {
+        this.serverUrl = this.serverUrl + ':8096';
+      }
 
       try {
         await this.connectServer(this.serverUrl);

--- a/src/components/Forms/AddServerForm.vue
+++ b/src/components/Forms/AddServerForm.vue
@@ -48,7 +48,7 @@ import { mapActions, mapState } from 'vuex';
 export default Vue.extend({
   data() {
     return {
-      serverUrl: '192.168.4.122',
+      serverUrl: '',
       loading: false,
       rules: {
         serverUrl: {

--- a/src/plugins/nuxt/veeValidate.ts
+++ b/src/plugins/nuxt/veeValidate.ts
@@ -6,7 +6,7 @@ import { required } from 'vee-validate/dist/rules';
 extend('required', required);
 
 extend('mustBeUrl', (value: string): boolean => {
-  return /^https?:\/\/.+/.test(value);
+  return /^(https?:\/\/)?[0-9.]+(:[0-9]+)?/.test(value);
 });
 
 extend('bothPasswordsSame', {


### PR DESCRIPTION
Add Server form now accepts URLs without protocol.

Modified the regex of the url validator to accept server URLs that do not have a port or an HTTP protocol.
The server form will now add a default port (8086) and protocol (http://) if none are present.

fix #1688