### PR TITLE
Keyboard and Click player controls for better UX

### DIFF
--- a/frontend/components/Layout/VolumeSlider.vue
+++ b/frontend/components/Layout/VolumeSlider.vue
@@ -8,7 +8,7 @@
       hide-details
       thumb-label
       max="100"
-      :value="currentVolume"
+      :value="isMuted ? 0 : currentVolume"
       validate-on-blur
       @input="onVolumeChange"
     />
@@ -26,9 +26,11 @@ export default Vue.extend({
     };
   },
   computed: {
-    ...mapState('playbackManager', ['currentVolume']),
+    ...mapState('playbackManager', ['currentVolume', 'isMuted']),
     icon(): string {
-      if (this.currentVolume >= 80) {
+      if (this.isMuted) {
+        return 'mdi-volume-mute';
+      } else if (this.currentVolume >= 80) {
         return 'mdi-volume-high';
       } else if (this.currentVolume < 80 && this.currentVolume >= 25) {
         return 'mdi-volume-medium';

--- a/frontend/components/Layout/VolumeSlider.vue
+++ b/frontend/components/Layout/VolumeSlider.vue
@@ -40,17 +40,9 @@ export default Vue.extend({
     }
   },
   methods: {
-    ...mapActions('playbackManager', ['setVolume']),
+    ...mapActions('playbackManager', ['setVolume', 'toggleMute']),
     onVolumeChange(value: number): void {
       this.setVolume({ volume: value });
-    },
-    toggleMute(): void {
-      if (this.currentVolume !== 0) {
-        this.previousVolume = this.currentVolume;
-        this.setVolume({ volume: 0 });
-      } else {
-        this.setVolume({ volume: this.previousVolume });
-      }
     }
   }
 });

--- a/frontend/components/Players/HlsPlayer.vue
+++ b/frontend/components/Players/HlsPlayer.vue
@@ -4,6 +4,7 @@
       ref="player"
       :class="{ stretch: stretch }"
       :poster="poster.url"
+      :muted="isMuted"
       autoplay
       crossorigin="anonymous"
       playsinline
@@ -73,6 +74,7 @@ export default Vue.extend({
       'getCurrentItemAssParsedSubtitleTracks'
     ]),
     ...mapState('playbackManager', [
+      'isMuted',
       'currentTime',
       'currentVolume',
       'currentMediaSource',

--- a/frontend/components/Players/PlayerManager.vue
+++ b/frontend/components/Players/PlayerManager.vue
@@ -252,13 +252,7 @@ export default Vue.extend({
       'getCurrentlyPlayingMediaType'
     ]),
     ...mapState('clientSettings', ['darkMode']),
-    ...mapState('playbackManager', [
-      'status',
-      'isMinimized',
-      'currentTime',
-      'isMuted',
-      'currentVolume'
-    ]),
+    ...mapState('playbackManager', ['status', 'isMinimized', 'currentTime']),
     isPlaying(): boolean {
       return this.status !== PlaybackStatus.Stopped;
     },
@@ -308,7 +302,6 @@ export default Vue.extend({
       'setNextTrack',
       'setPreviousTrack',
       'setLastItemIndex',
-      'setVolume',
       'toggleMute',
       'playPause',
       'pause',

--- a/frontend/components/Players/PlayerManager.vue
+++ b/frontend/components/Players/PlayerManager.vue
@@ -241,8 +241,7 @@ export default Vue.extend({
       keepOpen: false,
       playbackData: false,
       isUpNextVisible: false,
-      stretchVideo: true,
-      previousVolume: 0
+      stretchVideo: true
     };
   },
   computed: {
@@ -257,6 +256,7 @@ export default Vue.extend({
       'status',
       'isMinimized',
       'currentTime',
+      'isMuted',
       'currentVolume'
     ]),
     isPlaying(): boolean {

--- a/frontend/components/Players/PlayerManager.vue
+++ b/frontend/components/Players/PlayerManager.vue
@@ -391,6 +391,12 @@ export default Vue.extend({
           case 'ArrowLeft':
             this.skipBackward();
             break;
+          case 'f':
+            if (this.getCurrentlyPlayingMediaType === 'Video') {
+              this.toggleFullScreen();
+            }
+
+            break;
         }
       }
     },

--- a/frontend/components/Players/PlayerManager.vue
+++ b/frontend/components/Players/PlayerManager.vue
@@ -368,7 +368,7 @@ export default Vue.extend({
       this.setNextTrack();
     },
     handleKeyPress(e: KeyboardEvent): void {
-      if (!this.isMinimized && this.isPlaying) {
+      if (!this.isMinimized) {
         const focusEl = document.activeElement;
 
         let spaceEnabled = false;
@@ -409,7 +409,7 @@ export default Vue.extend({
             this.toggleMute();
             break;
         }
-      } else if (this.isMinimized && this.isPlaying) {
+      } else {
         switch (e.key) {
           case 'f':
             if (this.getCurrentlyPlayingMediaType === 'Video') {

--- a/frontend/components/Players/PlayerManager.vue
+++ b/frontend/components/Players/PlayerManager.vue
@@ -309,6 +309,7 @@ export default Vue.extend({
       'setPreviousTrack',
       'setLastItemIndex',
       'setVolume',
+      'toggleMute',
       'playPause',
       'pause',
       'unpause',
@@ -337,14 +338,6 @@ export default Vue.extend({
           this.fullScreenOverlayTimer = null;
         }
       }, this.getOsdTimeoutDuration());
-    },
-    toggleMute(): void {
-      if (this.currentVolume !== 0) {
-        this.previousVolume = this.currentVolume;
-        this.setVolume({ volume: 0 });
-      } else {
-        this.setVolume({ volume: this.previousVolume });
-      }
     },
     handleMouseMove(): void {
       if (

--- a/frontend/components/Players/PlayerManager.vue
+++ b/frontend/components/Players/PlayerManager.vue
@@ -279,6 +279,8 @@ export default Vue.extend({
   },
   mounted() {
     document.addEventListener('mousemove', this.handleMouseMove);
+    window.addEventListener('keyup', this.handleKeyPress);
+    window.addEventListener('click', this.handleVideoClick);
 
     this.addMediaHandlers();
 
@@ -286,9 +288,7 @@ export default Vue.extend({
       switch (mutation.type) {
         case 'playbackManager/TOGGLE_MINIMIZE':
           if (state.playbackManager.isMinimized === true) {
-            window.removeEventListener('keydown', this.handleKeyPress);
-          } else if (state.playbackManager.isMinimized === false) {
-            window.addEventListener('keydown', this.handleKeyPress);
+            window.removeEventListener('keyup', this.handleKeyPress);
           }
 
           break;
@@ -301,6 +301,8 @@ export default Vue.extend({
     }
 
     document.removeEventListener('mousemove', this.handleMouseMove);
+    window.removeEventListener('keyup', this.handleKeyPress);
+    window.removeEventListener('click', this.handleVideoClick);
     this.removeMediaHandlers();
     this.unsubscribe();
   },
@@ -390,6 +392,17 @@ export default Vue.extend({
             this.skipBackward();
             break;
         }
+      }
+    },
+    handleVideoClick(e: MouseEvent) {
+      const target = e.target as HTMLElement;
+
+      if (
+        target &&
+        target.classList.contains('player-overlay') &&
+        this.getCurrentlyPlayingMediaType === 'Video'
+      ) {
+        this.playPause();
       }
     },
     addMediaHandlers(): void {

--- a/frontend/store/playbackManager.ts
+++ b/frontend/store/playbackManager.ts
@@ -49,6 +49,7 @@ export interface PlaybackManagerState {
   currentItemChapters: ChapterInfo[] | null;
   currentTime: number | null;
   lastProgressUpdate: number;
+  previousValume: number;
   currentVolume: number;
   isFullscreen: boolean;
   isMuted: boolean;
@@ -73,6 +74,7 @@ export const defaultState = (): PlaybackManagerState => ({
   currentItemChapters: null,
   currentTime: null,
   lastProgressUpdate: 0,
+  previousValume: 100,
   currentVolume: 100,
   isFullscreen: false,
   isMuted: false,
@@ -333,6 +335,12 @@ export const mutations: MutationTree<PlaybackManagerState> = {
   SET_LAST_PROGRESS_UPDATE(state: PlaybackManagerState, { progress }) {
     state.lastProgressUpdate = progress;
   },
+  SET_PREV_VOLUME(
+    state: PlaybackManagerState,
+    { volume }: VolumeMutationPayload
+  ) {
+    state.previousValume = volume;
+  },
   SET_VOLUME(state: PlaybackManagerState, { volume }: VolumeMutationPayload) {
     state.currentVolume = volume;
   },
@@ -526,6 +534,14 @@ export const actions: ActionTree<PlaybackManagerState, RootState> = {
       commit('PAUSE_PLAYBACK');
     } else if (state.status === PlaybackStatus.Paused) {
       commit('UNPAUSE_PLAYBACK');
+    }
+  },
+  toggleMute({ commit, state, dispatch }) {
+    if (state.currentVolume !== 0) {
+      commit('SET_PREV_VOLUME', { volume: state.currentVolume });
+      dispatch('setVolume', { volume: 0 });
+    } else {
+      dispatch('setVolume', { volume: state.previousValume });
     }
   },
   clearQueue({ commit }) {


### PR DESCRIPTION
Related to #1697:

I **changed** the **keyboard handler** in the player and improved the way listeners are handled.

Added support for the following shortcuts:

_For the full-player_
```
[f] = toggle fullscreen
[Spacebar, k] = play / pause (Spacebar only if there is no focus element, to support Tab)
[Arrowleft, j] =  prev
[Arrowright, l] = next
[m] = mute / unmute
```

_For the mini-player_
```
[f] = toggle back to full-player
```


_Mouse_
Also I added play / pause support by clicking (or touching) on the video player (ignoring the rest of the interface)