### PR TITLE
chore: fix npm CI yet again and faulty renovate manager

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,7 +18,7 @@
   ],
   "dependencyDashboard": false,
   "ignoreDeps": ["npm", "swiper", "node", "hls.js"],
-  "enabledManagers": ["npm", "github-actions", "rust"],
+  "enabledManagers": ["npm", "github-actions", "cargo"],
   "labels": ["dependencies"],
   "rebaseWhen": "behind-base-branch",
   "rangeStrategy": "pin",

--- a/.npmrc
+++ b/.npmrc
@@ -3,5 +3,6 @@ lockfile-version=3
 save-exact=true
 workspace=frontend
 ## Fix socket timeout error in CI
-fetch-retry-mintimeout=50000
-fetch-retry-maxtimeout=250000
+fetch-retries=10
+fetch-retry-mintimeout=500000
+fetch-retry-maxtimeout=900000


### PR DESCRIPTION
Missed to change to the proper manager for Rust while rebasing #1672