### PR TITLE
feat(Queue): items can now be deleted from the queue

### DIFF
--- a/frontend/components/Players/DraggableQueue.vue
+++ b/frontend/components/Players/DraggableQueue.vue
@@ -41,7 +41,9 @@
             <like-button :item="item" />
           </v-list-item-action>
           <v-list-item-action v-if="!isPlaying(index)" class="mr-2">
-            <item-menu :item="item" />
+            <v-btn icon @click="playbackManager.removeFromQueue(item.Id)">
+              <v-icon>mdi-playlist-minus</v-icon>
+            </v-btn>
           </v-list-item-action>
         </v-list-item>
       </v-hover>

--- a/frontend/store/playbackManager.ts
+++ b/frontend/store/playbackManager.ts
@@ -98,6 +98,11 @@ export const playbackManagerStore = defineStore('playbackManager', {
       queue.push(...translatedItem);
       this.queue = queue;
     },
+    removeFromQueue(itemId: string) {
+      if (this.queue.includes(itemId)) {
+        this.queue.splice(this.queue.indexOf(itemId), 1);
+      }
+    },
     clearQueue(): void {
       this.queue = [];
     },

--- a/frontend/store/playbackManager.ts
+++ b/frontend/store/playbackManager.ts
@@ -92,11 +92,9 @@ export const playbackManagerStore = defineStore('playbackManager', {
   },
   actions: {
     async addToQueue(item: BaseItemDto) {
-      const queue = Array.from(this.queue);
       const translatedItem = await this.translateItemsForPlayback(item);
 
-      queue.push(...translatedItem);
-      this.queue = queue;
+      this.queue.push(...translatedItem);
     },
     removeFromQueue(itemId: string) {
       if (this.queue.includes(itemId)) {
@@ -181,12 +179,10 @@ export const playbackManagerStore = defineStore('playbackManager', {
      * @param item
      */
     async playNext(item: BaseItemDto): Promise<void> {
-      const queue = Array.from(this.queue);
       const translatedItem = await this.translateItemsForPlayback(item);
 
       if (this.currentItemIndex !== null) {
-        queue.splice(this.currentItemIndex + 1, 0, ...translatedItem);
-        this.queue = queue;
+        this.queue.splice(this.currentItemIndex + 1, 0, ...translatedItem);
       }
     },
     pause(): void {


### PR DESCRIPTION
As there hasn't been any activity related to https://github.com/jellyfin/jellyfin-vue/issues/975 for almost a year I'm allowing myself to add a PR to this feature. Closes https://github.com/jellyfin/jellyfin-vue/issues/975.

I am claiming the space from the `itemMenu` which really has no use in the queue panel in order to make space for the button which removes an item from the queue.

![image](https://user-images.githubusercontent.com/11832982/166429648-4e22814b-7096-4540-b2e0-5a2da03fefbf.png)

Looks like the screenshot above. If there is a specific reason why the `itemMenu` button was there we could also work out another solution for the placement of the `remove` button.
