### PR TITLE
fix(ShakaPlayer): first element in queue won't start playback

### DIFF
--- a/frontend/components/Players/ShakaPlayer.vue
+++ b/frontend/components/Players/ShakaPlayer.vue
@@ -131,7 +131,7 @@ export default Vue.extend({
       }
     }
   },
-  mounted() {
+  async mounted() {
     try {
       // Mux.js needs to be globally available before Shaka is loaded, in order for MPEG2 TS transmuxing to work.
       window.muxjs = muxjs;
@@ -144,6 +144,8 @@ export default Vue.extend({
           this.$refs.shakaPlayer as HTMLMediaElement
         );
         this.player = window.player;
+
+        await this.getPlaybackUrl();
 
         // Create WebAudio context and nodes for added processing
         this.audioContext = new AudioContext();


### PR DESCRIPTION
With this patch ShakaPlayer will get a valid playback URL after creation of the player. Closes https://github.com/jellyfin/jellyfin-vue/issues/1754.

As `shakaPlayer` is structured differently as the `HlsPlayer` I'm unsure whether this is actually the right approach to do this and would appreciate some feedback on the way it's done.