### PR TITLE
Queue manager improvements

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -26,7 +26,7 @@ jobs:
         run: npm ci --no-audit
 
       - name: Run linter ✏️
-        run: npm run lint
+        run: 'npm run lint:js && npm run lint:style'
 
   test:
     name: Test 🧫

--- a/frontend/components/Buttons/PlayButton.vue
+++ b/frontend/components/Buttons/PlayButton.vue
@@ -6,6 +6,7 @@
       :text="iconOnly"
       :color="iconOnly ? null : 'primary'"
       :loading="loading"
+      :disabled="disabled"
       @click.prevent="playOrResume"
     >
       <v-icon v-if="shuffle" :size="fab ? 36 : null">mdi-shuffle</v-icon>
@@ -13,7 +14,7 @@
     </v-btn>
     <v-btn
       v-else-if="!fab"
-      :disabled="!canPlay(item)"
+      :disabled="disabled || !canPlay(item)"
       :loading="loading"
       class="mr-2"
       color="primary"
@@ -69,6 +70,10 @@ export default Vue.extend({
     subtitleTrackIndex: {
       type: Number,
       default: undefined
+    },
+    disabled: {
+      type: Boolean,
+      default: false
     }
   },
   data() {

--- a/frontend/components/Buttons/QueueButton.vue
+++ b/frontend/components/Buttons/QueueButton.vue
@@ -122,7 +122,7 @@ export default Vue.extend({
     return {
       menu: false,
       destroy: false,
-      timeout: -1
+      timeout: undefined as undefined | number
     };
   },
   computed: {
@@ -199,7 +199,7 @@ export default Vue.extend({
         }, 500);
       } else {
         window.clearTimeout(this.timeout);
-        this.timeout = -1;
+        this.timeout = undefined;
         this.destroy = false;
       }
     }

--- a/frontend/components/Buttons/QueueButton.vue
+++ b/frontend/components/Buttons/QueueButton.vue
@@ -121,7 +121,8 @@ export default Vue.extend({
   data() {
     return {
       menu: false,
-      destroy: false
+      destroy: false,
+      timeout: -1
     };
   },
   computed: {
@@ -193,10 +194,12 @@ export default Vue.extend({
   watch: {
     menu(): void {
       if (!this.menu) {
-        setTimeout(() => {
+        this.timeout = window.setTimeout(() => {
           this.destroy = true;
         }, 500);
       } else {
+        window.clearTimeout(this.timeout);
+        this.timeout = -1;
         this.destroy = false;
       }
     }

--- a/frontend/components/Players/DraggableQueue.vue
+++ b/frontend/components/Players/DraggableQueue.vue
@@ -90,7 +90,7 @@ export default Vue.extend({
     }
   },
   /**
-   * Scroll the currently playing item to view after opening the queue
+   * Scroll the queue view to the currently playing item
    */
   mounted() {
     const ref = this.$refs.listItems as Vue[];
@@ -101,6 +101,15 @@ export default Vue.extend({
     );
 
     if (el?.$el) {
+      /**
+       * As the queue opening has a transition effect, el.$el.scrollIntoView() doesn't work directly,
+       * as the parent DOM node is not fully rendered while the transition is taking place
+       * (so scrollIntoView() doesn't know exactly what to scroll).
+       *
+       * The browser always give full priority to the DOM manipulation and painting process,
+       * while the idle callback runs with lower priority. This assures us that the view will be scrolled to
+       * the currently playing element as soon as all the DOM operations and transitions are over.
+       */
       window.requestIdleCallback(() => {
         el.$el.scrollIntoView();
       });

--- a/frontend/components/Players/DraggableQueue.vue
+++ b/frontend/components/Players/DraggableQueue.vue
@@ -9,8 +9,8 @@
         <v-list-item ripple @click="onClick(index)">
           <v-list-item-action
             v-if="!hover"
-            class="list-group-item d-flex justify-center d-flex text-caption"
-            :class="{ 'primary--text': isPlaying(index) }"
+            class="list-group-item d-flex justify-center d-flex"
+            :class="{ 'primary--text font-weight-bold': isPlaying(index) }"
           >
             {{ index + 1 }}
           </v-list-item-action>
@@ -23,7 +23,9 @@
 
           <v-list-item-content>
             <v-list-item-title
-              :class="{ 'primary--text': isPlaying(index) }"
+              :class="{
+                'primary--text font-weight-bold': isPlaying(index)
+              }"
               class="text-truncate ml-2 list-group-item"
             >
               {{ item.Name }}
@@ -31,7 +33,9 @@
             <v-list-item-subtitle
               v-if="getArtists(item)"
               class="ml-2 list-group-item"
-              :class="{ 'primary--text': isPlaying(index) }"
+              :class="{
+                'primary--text font-weight-bold': isPlaying(index)
+              }"
             >
               {{ getArtists(item) }}
             </v-list-item-subtitle>

--- a/frontend/components/Players/DraggableQueue.vue
+++ b/frontend/components/Players/DraggableQueue.vue
@@ -5,6 +5,7 @@
         v-for="(item, index) in queue"
         :key="`${item.Id}-${index}`"
         v-slot="{ hover }"
+        ref="listItems"
       >
         <v-list-item ripple @click="onClick(index)">
           <v-list-item-action
@@ -86,6 +87,23 @@ export default Vue.extend({
           })
         );
       }
+    }
+  },
+  /**
+   * Scroll the currently playing item to view after opening the queue
+   */
+  mounted() {
+    const ref = this.$refs.listItems as Vue[];
+    const currentItemId = this.playbackManager.getCurrentItem?.Id || '';
+
+    const el = ref.find(
+      (v) => v.$vnode.key === `${currentItemId}-${ref.indexOf(v)}`
+    );
+
+    if (el?.$el) {
+      window.requestIdleCallback(() => {
+        el.$el.scrollIntoView();
+      });
     }
   },
   methods: {

--- a/frontend/components/Players/DraggableQueue.vue
+++ b/frontend/components/Players/DraggableQueue.vue
@@ -3,13 +3,13 @@
     <draggable v-model="queue" v-bind="dragOptions" class="list-draggable">
       <v-hover
         v-for="(item, index) in queue"
-        :key="`${item.Id}-${getUuid()}`"
+        :key="`${item.Id}-${index}`"
         v-slot="{ hover }"
       >
         <v-list-item ripple @click="onClick(index)">
           <v-list-item-action
             v-if="!hover"
-            class="list-group-item d-flex justify-center d-flex"
+            class="list-group-item d-flex justify-center d-flex transition"
             :class="{ 'primary--text font-weight-bold': isPlaying(index) }"
           >
             {{ index + 1 }}
@@ -26,13 +26,13 @@
               :class="{
                 'primary--text font-weight-bold': isPlaying(index)
               }"
-              class="text-truncate ml-2 list-group-item"
+              class="text-truncate ml-2 list-group-item transition"
             >
               {{ item.Name }}
             </v-list-item-title>
             <v-list-item-subtitle
               v-if="getArtists(item)"
-              class="ml-2 list-group-item"
+              class="ml-2 list-group-item transition"
               :class="{
                 'primary--text font-weight-bold': isPlaying(index)
               }"
@@ -41,10 +41,10 @@
             </v-list-item-subtitle>
           </v-list-item-content>
 
-          <v-list-item-action v-if="!isPlaying(index)">
+          <v-list-item-action v-hide="isPlaying(index)">
             <like-button :item="item" />
           </v-list-item-action>
-          <v-list-item-action v-if="!isPlaying(index)" class="mr-2">
+          <v-list-item-action v-hide="isPlaying(index)" class="mr-2">
             <v-btn icon @click="playbackManager.removeFromQueue(item.Id)">
               <v-icon>mdi-playlist-minus</v-icon>
             </v-btn>
@@ -58,7 +58,6 @@
 <script lang="ts">
 import Vue from 'vue';
 import { mapStores } from 'pinia';
-import { v4 as uuidv4 } from 'uuid';
 import { BaseItemDto } from '@jellyfin/client-axios';
 import { playbackManagerStore } from '~/store';
 
@@ -100,15 +99,6 @@ export default Vue.extend({
         return null;
       }
     },
-    /**
-     * There can be duplicated items in the queue, so we generate an unique uuid
-     * for each item.
-     *
-     * @returns {string} The generated UUID.
-     */
-    getUuid(): string {
-      return uuidv4();
-    },
     onClick(index: number): void {
       this.playbackManager.setCurrentIndex(index);
     }
@@ -117,6 +107,10 @@ export default Vue.extend({
 </script>
 
 <style lang="scss" scoped>
+.transition {
+  transition: all 0.15s ease-in;
+}
+
 .list-group {
   margin: 0 !important;
 }

--- a/frontend/components/Players/TrackList.vue
+++ b/frontend/components/Players/TrackList.vue
@@ -32,7 +32,7 @@
             @dblclick="playTracks(track)"
           >
             <td style="width: 4em" class="pr-0 text-center">
-              <span v-if="hover">
+              <span v-if="hover && !isPlaying(track)">
                 <v-btn small icon @click="playTracks(track)">
                   <v-icon>mdi-play-circle-outline</v-icon>
                 </v-btn>

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -121,7 +121,7 @@ const config: NuxtConfig = {
      ** Vue plugins
      */
     'plugins/vue/components.ts',
-    'plugins/vue/directives/hide.ts'
+    'plugins/vue/directives.ts'
   ],
   /*
    ** Auto import components

--- a/frontend/pages/library/_viewId.vue
+++ b/frontend/pages/library/_viewId.vue
@@ -12,7 +12,7 @@
       <type-button
         v-if="hasViewTypes"
         :type="collectionInfo.CollectionType"
-        :disabled="loading"
+        :disabled="noContent"
         @change="onChangeType"
       />
       <v-divider
@@ -23,7 +23,7 @@
       />
       <sort-button
         v-if="isSortable"
-        :disabled="loading || !items.length"
+        :disabled="noContent"
         @change="onChangeSort"
       />
       <filter-button
@@ -34,8 +34,8 @@
         @change="onChangeFilter"
       />
       <v-spacer />
-      <play-button :item="collectionInfo" shuffle />
-      <play-button :item="collectionInfo" />
+      <play-button :item="collectionInfo" shuffle :disabled="noContent" />
+      <play-button :item="collectionInfo" :disabled="noContent" />
     </v-app-bar>
     <v-container>
       <skeleton-item-grid v-if="loading" :view-type="viewType" />
@@ -104,6 +104,9 @@ export default Vue.extend({
   },
   computed: {
     ...mapStores(authStore, snackbarStore, pageStore),
+    noContent(): boolean {
+      return this.loading || !this.itemsCount;
+    },
     hasViewTypes(): boolean {
       if (
         ['homevideos'].includes(this.collectionInfo.CollectionType || '') ||

--- a/frontend/plugins/vue/directives.ts
+++ b/frontend/plugins/vue/directives.ts
@@ -1,5 +1,8 @@
 import Vue from 'vue';
 
+/**
+ * Toggles the CSS 'visibility' property of an element.
+ */
 Vue.directive('hide', (el, binding) => {
   if (el) {
     if (binding.value === true) {


### PR DESCRIPTION
* Add a transition when switching the text color between non playing tracks and the playing track.
* Disable Play and shuffle buttons in library view when the view is loading or there are no items.
* Fix item jumping in the draggable queue
* Fix animation quirk when the queue was opened and closed too fast by clearing the timeout during the DOM nodes destroy process.
* Current playing item in queue has now bold text.
* Queue is automatically scrolled into the currently playing item (related to #962)
* Fix item images being blurred on all queue changes in queue manager.