### PR TITLE
fix(tauri): remove useBootstrapper option

### DIFF
--- a/tauri/tauri.conf.json
+++ b/tauri/tauri.conf.json
@@ -22,13 +22,11 @@
       "shortDescription": "",
       "longDescription": "",
       "deb": {
-        "depends": [],
-        "useBootstrapper": false
+        "depends": []
       },
       "macOS": {
         "frameworks": [],
         "minimumSystemVersion": "",
-        "useBootstrapper": false,
         "exceptionDomain": "",
         "signingIdentity": null,
         "entitlements": null


### PR DESCRIPTION
Fixes Tauri build for Ubuntu.

Windows still fails as the frontend itself can't be built on Windows.