### PR TITLE
feat(playback): improve queue options and minor refactor to player manager

### DIFF
--- a/frontend/components/Buttons/PlayButton.vue
+++ b/frontend/components/Buttons/PlayButton.vue
@@ -41,7 +41,6 @@ import { mapStores } from 'pinia';
 import { playbackManagerStore } from '~/store';
 import { canResume, canPlay } from '~/utils/items';
 import { ticksToMs } from '~/utils/time';
-import { PlaybackStatus } from '~/store/playbackManager';
 
 export default Vue.extend({
   props: {
@@ -83,19 +82,12 @@ export default Vue.extend({
   computed: {
     ...mapStores(playbackManagerStore)
   },
-  watch: {
-    'playbackManager.status'(): void {
-      if (this.playbackManager.status === PlaybackStatus.Playing) {
-        this.loading = false;
-      }
-    }
-  },
   methods: {
-    playOrResume(): void {
+    async playOrResume(): Promise<void> {
       this.loading = true;
 
       if (this.item && canResume(this.item)) {
-        this.playbackManager.play({
+        await this.playbackManager.play({
           item: this.item,
           audioTrackIndex: this.audioTrackIndex,
           subtitleTrackIndex: this.subtitleTrackIndex || -1,
@@ -105,7 +97,7 @@ export default Vue.extend({
         });
       } else if (this.shuffle) {
         // We force playback from the start when shuffling, since you wouldn't resume AND shuffle at the same time
-        this.playbackManager.play({
+        await this.playbackManager.play({
           item: this.item,
           audioTrackIndex: this.audioTrackIndex,
           subtitleTrackIndex: this.subtitleTrackIndex || -1,
@@ -113,13 +105,15 @@ export default Vue.extend({
           startShuffled: true
         });
       } else {
-        this.playbackManager.play({
+        await this.playbackManager.play({
           item: this.item,
           audioTrackIndex: this.audioTrackIndex,
           subtitleTrackIndex: this.subtitleTrackIndex || -1,
           videoTrackIndex: this.videoTrackIndex
         });
       }
+
+      this.loading = false;
     },
     canPlay,
     canResume

--- a/frontend/components/Item/ItemMenu.vue
+++ b/frontend/components/Item/ItemMenu.vue
@@ -114,7 +114,7 @@ export default Vue.extend({
         const playNextAction = {
           title: this.$t('playback.playNext'),
           icon: 'mdi-play-speed',
-          action: () => {
+          action: (): void => {
             this.playbackManager.playNext(this.item);
             this.snackbar.push(this.$t('snackbar.playNext'), 'success');
           }
@@ -124,11 +124,12 @@ export default Vue.extend({
          * Queue options
          */
         const queueOptions = [] as MenuOption[];
+
         if (this.queue && this.playbackManager.queue.includes(this.item.Id)) {
           queueOptions.push({
             title: this.$t('itemMenu.pushToTop'),
             icon: 'mdi-arrow-expand-up',
-            action: () => {
+            action: (): void => {
               this.playbackManager.changeItemPosition(this.item.Id, 0);
             }
           });
@@ -137,7 +138,7 @@ export default Vue.extend({
             queueOptions.push({
               title: this.$t('itemMenu.removeFromQueue'),
               icon: 'mdi-playlist-minus',
-              action: () => {
+              action: (): void => {
                 this.playbackManager.removeFromQueue(this.item.Id);
               }
             });
@@ -153,7 +154,7 @@ export default Vue.extend({
           queueOptions.push({
             title: this.$t('itemMenu.pushToBottom'),
             icon: 'mdi-arrow-expand-down',
-            action: () => {
+            action: (): void => {
               this.playbackManager.changeItemPosition(
                 this.item.Id,
                 this.playbackManager.queue.length - 1
@@ -166,11 +167,12 @@ export default Vue.extend({
          * Playback options
          */
         const playbackOptions = [] as MenuOption[];
+
         if (canResume(this.item)) {
           playbackOptions.push({
             title: this.$t('playFromBeginning'),
             icon: 'mdi-replay',
-            action: () => {
+            action: (): void => {
               this.playbackManager.play({
                 item: this.item
               });
@@ -181,7 +183,7 @@ export default Vue.extend({
         playbackOptions.push({
           title: this.$t('playback.shuffle'),
           icon: 'mdi-shuffle',
-          action: () => {
+          action: (): void => {
             this.playbackManager.play({
               item: this.item,
               initiator: this.item,
@@ -202,7 +204,7 @@ export default Vue.extend({
           playbackOptions.push({
             title: this.$t('playback.addToQueue'),
             icon: 'mdi-playlist-plus',
-            action: () => {
+            action: (): void => {
               this.playbackManager.addToQueue(this.item);
               this.snackbar.push(this.$t('snackbar.addedToQueue'), 'success');
             }
@@ -213,6 +215,7 @@ export default Vue.extend({
          * Library options
          */
         const libraryOptions = [] as MenuOption[];
+
         if (
           this.auth.currentUser?.Policy?.IsAdministrator &&
           ['Folder', 'CollectionFolder', 'UserView'].includes(
@@ -222,7 +225,7 @@ export default Vue.extend({
           libraryOptions.push({
             title: this.$t('refreshLibrary'),
             icon: 'mdi-refresh',
-            action: async () => {
+            action: async (): Promise<void> => {
               try {
                 await this.$api.itemRefresh.post({
                   itemId: this.item.Id,
@@ -245,7 +248,7 @@ export default Vue.extend({
           libraryOptions.push({
             title: this.$t('editMetadata'),
             icon: 'mdi-pencil-outline',
-            action: () => {
+            action: (): void => {
               this.metadataDialog = true;
             }
           });
@@ -254,6 +257,7 @@ export default Vue.extend({
         menuOptions.push(queueOptions);
         menuOptions.push(playbackOptions);
         menuOptions.push(libraryOptions);
+
         return menuOptions;
       }
     }

--- a/frontend/components/Players/DraggableQueue.vue
+++ b/frontend/components/Players/DraggableQueue.vue
@@ -45,10 +45,8 @@
           <v-list-item-action v-hide="isPlaying(index)">
             <like-button :item="item" />
           </v-list-item-action>
-          <v-list-item-action v-hide="isPlaying(index)" class="mr-2">
-            <v-btn icon @click="playbackManager.removeFromQueue(item.Id)">
-              <v-icon>mdi-playlist-minus</v-icon>
-            </v-btn>
+          <v-list-item-action class="mr-2">
+            <item-menu :item="item" queue />
           </v-list-item-action>
         </v-list-item>
       </v-hover>

--- a/frontend/locales/en-US.json
+++ b/frontend/locales/en-US.json
@@ -42,6 +42,15 @@
       "startNow": "Start now"
     }
   },
+  "snackbar": {
+    "addedToQueue": "Added to queue",
+    "playNext": "The selected item will be played after the current one"
+  },
+  "itemMenu": {
+    "pushToTop": "Move to the beginning",
+    "pushToBottom": "Move to the end",
+    "removeFromQueue": "Remove from queue"
+  },
   "directing": "Directing",
   "director": "Director",
   "disabled": "Disabled",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -75,7 +75,6 @@
     "@types/swiper": "5.4.3",
     "@types/tizen-tv-webapis": "2.0.1",
     "@types/uuid": "8.3.4",
-    "@types/wicg-mediasession": "1.1.3",
     "@vue/test-utils": "1.3.0",
     "@vue/vue2-jest": "27.0.0",
     "axe": "8.1.2",

--- a/frontend/store/playbackManager.ts
+++ b/frontend/store/playbackManager.ts
@@ -139,39 +139,44 @@ export const playbackManagerStore = defineStore('playbackManager', {
       initiator?: BaseItemDto;
       startShuffled?: boolean;
     }): Promise<void> {
-      if (this.status !== PlaybackStatus.Stopped) {
-        this.stop();
+      try {
+        if (this.status !== PlaybackStatus.Stopped) {
+          this.stop();
+        }
+
+        this.status = PlaybackStatus.Buffering;
+        this.queue = await this.translateItemsForPlayback(item, startShuffled);
+
+        if (videoTrackIndex !== undefined) {
+          this.currentVideoStreamIndex = videoTrackIndex;
+        }
+
+        if (audioTrackIndex !== undefined) {
+          this.currentAudioStreamIndex = audioTrackIndex;
+        }
+
+        if (subtitleTrackIndex !== undefined) {
+          this.currentSubtitleStreamIndex = subtitleTrackIndex;
+        }
+
+        this.currentItemIndex = startFromIndex;
+        this.currentTime = startFromTime;
+
+        if (!startShuffled && initiator) {
+          this.playbackInitMode = InitMode.Item;
+        } else if (startShuffled && !initiator) {
+          this.playbackInitMode = InitMode.Shuffle;
+        } else if (startShuffled && initiator) {
+          this.playbackInitMode = InitMode.ShuffleItem;
+        } else {
+          this.playbackInitMode = InitMode.Unknown;
+        }
+
+        this.playbackInitiator = initiator || null;
+        this.status = PlaybackStatus.Playing;
+      } catch {
+        this.status = PlaybackStatus.Error;
       }
-
-      this.queue = await this.translateItemsForPlayback(item, startShuffled);
-
-      if (videoTrackIndex !== undefined) {
-        this.currentVideoStreamIndex = videoTrackIndex;
-      }
-
-      if (audioTrackIndex !== undefined) {
-        this.currentAudioStreamIndex = audioTrackIndex;
-      }
-
-      if (subtitleTrackIndex !== undefined) {
-        this.currentSubtitleStreamIndex = subtitleTrackIndex;
-      }
-
-      this.currentItemIndex = startFromIndex;
-      this.currentTime = startFromTime;
-
-      if (!startShuffled && initiator) {
-        this.playbackInitMode = InitMode.Item;
-      } else if (startShuffled && !initiator) {
-        this.playbackInitMode = InitMode.Shuffle;
-      } else if (startShuffled && initiator) {
-        this.playbackInitMode = InitMode.ShuffleItem;
-      } else {
-        this.playbackInitMode = InitMode.Unknown;
-      }
-
-      this.playbackInitiator = initiator || null;
-      this.status = PlaybackStatus.Playing;
     },
     /**
      * Adds to the queue the items of a collection item (i.e album, tv show, etc...)

--- a/frontend/store/playbackManager.ts
+++ b/frontend/store/playbackManager.ts
@@ -191,6 +191,7 @@ export const playbackManagerStore = defineStore('playbackManager', {
          * Removes the elements that already exists and append the new ones next to the currently playing item
          */
         const newQueue = this.queue.filter((i) => !translatedItem.includes(i));
+
         newQueue.splice(this.currentItemIndex + 1, 0, ...translatedItem);
         this.setNewQueue(newQueue);
       }
@@ -310,6 +311,7 @@ export const playbackManagerStore = defineStore('playbackManager', {
     changeItemPosition(itemId: string | undefined, newIndex: number): void {
       if (itemId && this.queue.includes(itemId)) {
         const newQueue = this.queue.filter((i) => i !== itemId);
+
         newQueue.splice(newIndex, 0, itemId);
         this.setNewQueue(newQueue);
       }

--- a/frontend/store/playbackManager.ts
+++ b/frontend/store/playbackManager.ts
@@ -187,7 +187,12 @@ export const playbackManagerStore = defineStore('playbackManager', {
       const translatedItem = await this.translateItemsForPlayback(item);
 
       if (this.currentItemIndex !== null) {
-        this.queue.splice(this.currentItemIndex + 1, 0, ...translatedItem);
+        /**
+         * Removes the elements that already exists and append the new ones next to the currently playing item
+         */
+        const newQueue = this.queue.filter((i) => !translatedItem.includes(i));
+        newQueue.splice(this.currentItemIndex + 1, 0, ...translatedItem);
+        this.setNewQueue(newQueue);
       }
     },
     pause(): void {
@@ -301,6 +306,13 @@ export const playbackManagerStore = defineStore('playbackManager', {
       this.queue = queue;
       this.lastItemIndex = lastItemNewIndex;
       this.currentItemIndex = newIndex;
+    },
+    changeItemPosition(itemId: string | undefined, newIndex: number): void {
+      if (itemId && this.queue.includes(itemId)) {
+        const newQueue = this.queue.filter((i) => i !== itemId);
+        newQueue.splice(newIndex, 0, itemId);
+        this.setNewQueue(newQueue);
+      }
     },
     stop(): void {
       const volume = this.currentVolume;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -22,7 +22,6 @@
       "@nuxtjs/vuetify",
       "@nuxtjs/date-fns",
       "@nuxtjs/i18n",
-      "@types/wicg-mediasession",
       "jest",
       "axios",
       "@types/tizen-tv-webapis",

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,6 @@
         "@types/swiper": "5.4.3",
         "@types/tizen-tv-webapis": "2.0.1",
         "@types/uuid": "8.3.4",
-        "@types/wicg-mediasession": "1.1.3",
         "@vue/test-utils": "1.3.0",
         "@vue/vue2-jest": "27.0.0",
         "axe": "8.1.2",
@@ -5898,12 +5897,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/@types/wicg-mediasession": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@types/wicg-mediasession/-/wicg-mediasession-1.1.3.tgz",
-      "integrity": "sha512-lzoszzJJfW9vcaIxf6tDx3lCJq/4oaD+mplA7sCV7W21PGdR6yUPwErN047ziIcwFx61w8WMURIwUyj1V7KJIQ==",
-      "dev": true
     },
     "node_modules/@types/yargs": {
       "version": "16.0.4",


### PR DESCRIPTION
* Move MediaSession API handling to playbackWatcher
* Improve context menu in queue manager (based on comments in #1753)
* All "Play Next" options will, by default, append the item(s) to the next position in queue, but if some items already exist in the queue, they will be moved (not added again, so duplicates can only be made by using the "Add to queue" option).

_For current playing item_
![image](https://user-images.githubusercontent.com/10274099/171614493-3f3b4df3-e458-4341-9c13-58599de0c586.png)

_For other items_
![image](https://user-images.githubusercontent.com/10274099/171614758-a4a6c733-d4f8-4d08-9d95-55b1fd7e1b2d.png)

