### PR TITLE
Update en-US.json

### DIFF
--- a/frontend/locales/en-US.json
+++ b/frontend/locales/en-US.json
@@ -538,8 +538,8 @@
       "tasks": "Running tasks"
     },
     "tasks": {
-      "configSync": "Syncing settings...",
-      "scanningLibrary": "Scanning library '{library}'..."
+      "configSync": "Syncing settings…",
+      "scanningLibrary": "Scanning library '{library}'…"
     }
   }
 }


### PR DESCRIPTION
As per Weblate's best practice:
"The string uses three dots (...) instead of an ellipsis character (…)"
Reference to error: https://translate.jellyfin.org/translate/jellyfin-vue/jellyfin-vue/en/?q=check%3Aellipsis+OR+dismissed_check%3Aellipsis&offset=1
