### PR TITLE
feat: cancel previous unstable actions when new one comes in

### DIFF
--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -1,5 +1,9 @@
 name: Unstable release 🪲📦
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:


### PR DESCRIPTION
This is needed to avoid previous builds overwriting a more recent build that was quicker to finish.