### PR TITLE
fix: missing home sections

### DIFF
--- a/frontend/components/Layout/HomeSection.vue
+++ b/frontend/components/Layout/HomeSection.vue
@@ -42,7 +42,6 @@ export default Vue.extend({
 
     switch (this.section.type) {
       case 'libraries': {
-        await this.homeSection.getLibraries();
         break;
       }
       case 'resume': {

--- a/frontend/components/Layout/Navigation/NavigationDrawer.vue
+++ b/frontend/components/Layout/Navigation/NavigationDrawer.vue
@@ -89,9 +89,6 @@ export default Vue.extend({
         }
       }
     }
-  },
-  async beforeMount() {
-    await this.userViews.refreshUserViews();
   }
 });
 </script>

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -35,6 +35,8 @@ import {
   authStore
 } from '~/store';
 
+const VALID_SECTIONS = ['resume', 'resumeaudio', 'upnext', 'latestmedia'];
+
 export default Vue.extend({
   // TODO: Merge asyncData and fetch once we have Nuxt 3, so we can have proper Vue 3 suspense support and have all the data
   // loaded with a complete Vue instance but with the route not being rendered until the full data is loaded
@@ -70,8 +72,6 @@ export default Vue.extend({
   computed: {
     ...mapStores(clientSettingsStore, pageStore, userViewsStore),
     homeSections(): HomeSection[] {
-      const validSections = ['resume', 'resumeaudio', 'upnext', 'latestmedia'];
-
       // Filter for valid sections in Jellyfin Vue
       // TODO: Implement custom section order
       let homeSectionsArray = pickBy(
@@ -80,7 +80,7 @@ export default Vue.extend({
         (value: string, key: string) => {
           return (
             value &&
-            validSections.includes(value) &&
+            VALID_SECTIONS.includes(value) &&
             key.startsWith('homesection')
           );
         }
@@ -96,7 +96,6 @@ export default Vue.extend({
         };
       }
 
-      // Convert to an array
       homeSectionsArray = Object.values(homeSectionsArray);
 
       const homeSections: HomeSection[] = [];
@@ -171,6 +170,7 @@ export default Vue.extend({
             break;
         }
       }
+
       return homeSections;
     }
   },

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -110,7 +110,7 @@ export default Vue.extend({
           {
             const latestMediaSections = [];
 
-            if (!this.userViews.views) {
+            if (this.userViews.views.length === 0) {
               await this.userViews.refreshUserViews();
             }
 

--- a/frontend/plugins/store/watchers/auth.ts
+++ b/frontend/plugins/store/watchers/auth.ts
@@ -36,6 +36,11 @@ export default function (ctx: Context): void {
    */
   auth.$onAction(({ name, after }) => {
     after(async () => {
+      if ((auth.currentUser && name === 'authInit') || name === 'loginUser') {
+        // Get user info, either at already logged in app start or when manually login in
+        userViews.refreshUserViews();
+      }
+
       if (
         name !== 'authInit' &&
         name !== 'setAxiosHeader' &&

--- a/frontend/store/homeSection.ts
+++ b/frontend/store/homeSection.ts
@@ -17,7 +17,6 @@ interface LatestMedia {
 }
 
 export interface HomeSectionState {
-  libraries: BaseItemDto[];
   audioResumes: BaseItemDto[];
   videoResumes: BaseItemDto[];
   upNext: BaseItemDto[];
@@ -27,7 +26,6 @@ export interface HomeSectionState {
 export const homeSectionStore = defineStore('homeSection', {
   state: () => {
     return {
-      libraries: [],
       audioResumes: [],
       videoResumes: [],
       upNext: [],
@@ -35,13 +33,6 @@ export const homeSectionStore = defineStore('homeSection', {
     } as HomeSectionState;
   },
   actions: {
-    async getLibraries(): Promise<void> {
-      const userViews = userViewsStore();
-
-      await userViews.refreshUserViews();
-
-      this.libraries = Array.from(userViews.views);
-    },
     async getAudioResumes(): Promise<void> {
       const auth = authStore();
       const snackbar = snackbarStore();
@@ -152,12 +143,15 @@ export const homeSectionStore = defineStore('homeSection', {
     }
   },
   getters: {
-    getHomeSectionContent:
-      (state) =>
-      (section: HomeSection): BaseItemDto[] => {
+    libraries: (): BaseItemDto[] => {
+      const userViews = userViewsStore();
+      return Array.from(userViews.views);
+    },
+    getHomeSectionContent(state) {
+      return (section: HomeSection): BaseItemDto[] => {
         switch (section.type) {
           case 'libraries':
-            return state.libraries;
+            return this.libraries;
           case 'resume':
             return state.videoResumes;
           case 'resumeaudio':
@@ -169,6 +163,7 @@ export const homeSectionStore = defineStore('homeSection', {
           default:
             return [];
         }
-      }
+      };
+    }
   }
 });

--- a/frontend/store/homeSection.ts
+++ b/frontend/store/homeSection.ts
@@ -145,21 +145,22 @@ export const homeSectionStore = defineStore('homeSection', {
   getters: {
     libraries: (): BaseItemDto[] => {
       const userViews = userViewsStore();
+
       return Array.from(userViews.views);
     },
-    getHomeSectionContent(state) {
+    getHomeSectionContent() {
       return (section: HomeSection): BaseItemDto[] => {
         switch (section.type) {
           case 'libraries':
             return this.libraries;
           case 'resume':
-            return state.videoResumes;
+            return this.videoResumes;
           case 'resumeaudio':
-            return state.audioResumes;
+            return this.audioResumes;
           case 'upnext':
-            return state.upNext;
+            return this.upNext;
           case 'latestmedia':
-            return state.latestMedia[section.libraryId];
+            return this.latestMedia[section.libraryId];
           default:
             return [];
         }


### PR DESCRIPTION
~~Inefficient fix to a situation where the array was never falsy so it never awaited for it to fetch.~~

~~It's inefficient cause the method is fetched 3 times across the app, and on this specific page it'll fetch every time if the user doesn't have views.~~

~~What could be done is that:~~

~~1. the store is fetched by default by the app once so that others aren't expected to fetch it~~
~~2. convert parts of the app using it to be reactive (this part in this file isn't for instance)~~

* moved the front page home sections logic to a getter to be reactive to the store changes
* nav drawer libraries were already reactive but it manually fetched them still
* fetch the user views at authentication (remembered or not)
* removed the homesection manual "libraries" setup to a getter of the userviews