### PR TITLE
Fix/nav drawer

### DIFF
--- a/frontend/components/Layout/AppBar/AppBar.vue
+++ b/frontend/components/Layout/AppBar/AppBar.vue
@@ -1,7 +1,7 @@
 <template>
   <v-app-bar
     clipped-left
-    class="ml-n3 mr-n3 app-bar-safe-zone"
+    class="app-bar-safe-zone"
     flat
     app
     elevate-on-scroll

--- a/frontend/components/Layout/Navigation/NavigationDrawer.vue
+++ b/frontend/components/Layout/Navigation/NavigationDrawer.vue
@@ -8,7 +8,9 @@
     floating
     clipped
     class="pa-s"
-    :class="{ transparent: page.transparentLayout }"
+    :class="{
+      transparent: page.transparentLayout && !$vuetify.breakpoint.mobile
+    }"
   >
     <v-list nav>
       <v-list-item


### PR DESCRIPTION
* disable transparency on navigation drawer on mobile screens, which made it unusable when opened and transparency was enabled (when at the top of the home page for instance)
* remove negative margins on the appbar cause it made buttons too close to the extremities of the screen on mobile