### PR TITLE
fix: Movie/Episode with no default video track fix

### DIFF
--- a/frontend/components/Item/MediaStreamSelector.vue
+++ b/frontend/components/Item/MediaStreamSelector.vue
@@ -133,6 +133,17 @@ export default Vue.extend({
       this.trackIndex = this.defaultIndex;
     }
 
+    /**
+     * Check if Type is Video and trackIndex is -1 then set trackIndex as this.selectItems[0].value
+     */
+    if (
+      this.type === 'Video' &&
+      this.trackIndex === -1 &&
+      this.selectItems[0].value !== undefined
+    ) {
+      this.trackIndex = this.selectItems[0].value;
+    }
+
     this.$emit('input', this.trackIndex);
   },
   methods: {


### PR DESCRIPTION
Fix to a situation where a Movie/Episode with no default video track has no default set in the Item UI

[1779](https://github.com/jellyfin/jellyfin-vue/issues/1779)

