### PR TITLE
ci: check compliance with conventional commits

### DIFF
--- a/.github/workflows/automation.yml
+++ b/.github/workflows/automation.yml
@@ -1,5 +1,9 @@
 name: Automation 🤖
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:
@@ -11,7 +15,7 @@ on:
 jobs:
   compose-comment:
     name: Compose PR comment
-    if: ${{ always() && github.event_name == 'pull_request_target' }}
+    if: ${{ always() && !cancelled() && github.event_name == 'pull_request_target' }}
     uses: ./.github/workflows/job_messages.yml
     with:
       commit: ${{ github.event.pull_request.head.sha }}
@@ -20,13 +24,18 @@ jobs:
 
   push-comment:
     name: Push comment to PR 🖥️
-    if: ${{ always() && github.event_name == 'pull_request_target' && needs.compose-comment.result == 'success' }}
+    if: |
+      always() &&
+      !cancelled() &&
+      github.event_name == 'pull_request_target' &&
+      needs.compose-comment.result == 'success'
     runs-on: ubuntu-latest
     needs:
       - compose-comment
 
     steps:
-      - uses: thollander/actions-comment-pull-request@v1.5.0
+      - name: Create comment
+        uses: thollander/actions-comment-pull-request@v1.5.0
         with:
           GITHUB_TOKEN: ${{ secrets.JF_BOT_TOKEN }}
           message: ${{ needs.compose-comment.outputs.msg }}

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -127,7 +127,7 @@ jobs:
           path: |
             dist
 
-  tauri:
+  build_tauri:
     name: Build Tauri 🛠️
     strategy:
       fail-fast: false
@@ -191,8 +191,14 @@ jobs:
 
   pr_context:
     name: Save PR context as artifact
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ always() && !cancelled() && github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
+    needs:
+      - dependency-review
+      - lint
+      - test
+      - build
+      - build_tauri
 
     steps:
       - name: Save PR context

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -210,3 +210,15 @@ jobs:
           path: |
             PR_number
             PR_sha
+
+  conventional_commits:
+    name: Conventional commits check 💬
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout ⬇️
+        uses: actions/checkout@v3.1.0
+
+      - name: Check if all commits comply with the specification
+        uses: webiny/action-conventional-commits@v1.1.0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   cf-pages:
     name: CloudFlare Pages 📃
-    if: ${{ always() && github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     outputs:
       url: ${{ steps.cf.outputs.url }}
@@ -59,22 +59,26 @@ jobs:
 
   compose-comment:
     name: Compose comment
-    if: ${{ always() && github.event.workflow_run.event == 'pull_request' }}
+    if: ${{ always() }}
     uses: ./.github/workflows/job_messages.yml
     needs:
       - cf-pages
       - pr-context
+
     with:
       branch: ${{ github.event.workflow_run.head_branch }}
-      commit: ${{ needs.pr-context.commit != '' && needs.pr-context.commit || github.event.workflow_run.head_sha }}
-      preview_url: ${{ needs.cf-pages.url }}
+      commit: ${{ needs.pr-context.outputs.commit != '' && needs.pr-context.outputs.commit || github.event.workflow_run.head_sha }}
+      preview_url: ${{ needs.cf-pages.outputs.url }}
       build_workflow_run_id: ${{ github.event.workflow_run.id }}
       commenting_workflow_run_id: ${{ github.run_id }}
       in_progress: false
 
   comment-status:
     name: Create comment status
-    if: ${{ always() && github.event.workflow_run.event == 'pull_request' && needs.pr-context.outputs.pr_number != '' }}
+    if: |
+      always() &&
+      github.event.workflow_run.event == 'pull_request' &&
+      needs.pr-context.outputs.pr_number != ''
     runs-on: ubuntu-latest
     needs:
       - compose-comment
@@ -83,7 +87,6 @@ jobs:
     steps:
       - name: Update job summary in PR comment
         uses: thollander/actions-comment-pull-request@v1.5.0
-        if: ${{ always() }}
         with:
           GITHUB_TOKEN: ${{ secrets.JF_BOT_TOKEN }}
           message: ${{ needs.compose-comment.outputs.msg }}

--- a/.github/workflows/job_messages.yml
+++ b/.github/workflows/job_messages.yml
@@ -46,7 +46,7 @@ jobs:
         env:
           COMMIT: ${{ inputs.commit }}
           PREVIEW_URL: ${{ inputs.preview_url != '' && (inputs.branch != 'master' && inputs.preview_url || format('https://jf-vue.pages.dev ({0})', inputs.preview_url)) || 'Not available' }}
-          DEPLOY_STATUS: ${{ inputs.in_progress && '🔄 Deploying...' || (steps.cf.outputs.url != '' && '✅ Deployed!' || '❌ Failure. Check workflow logs for more info') }}
+          DEPLOY_STATUS: ${{ inputs.in_progress && '🔄 Deploying...' || (inputs.preview_url != '' && '✅ Deployed!' || '❌ Failure. Check workflow logs for details') }}
           DEPLOYMENT_TYPE: ${{ inputs.branch != 'master' && '🔀 Preview' || '⚙️ Production' }}
           BUILD_WORKFLOW_RUN: ${{ !inputs.in_progress && format('**[View build logs](https://github.com/{0}/actions/runs/{1})**', 'jellyfin/jellyfin-vue', inputs.build_workflow_run_id) || '' }}
           COMMENTING_WORKFLOW_RUN: ${{ format('**[View bot logs](https://github.com/{0}/actions/runs/{1})**', 'jellyfin/jellyfin-vue', inputs.commenting_workflow_run_id) }}


### PR DESCRIPTION
Check in pull request checks if all the commits of a PR comply with the conventional commits specification, in order to enforce our [contribution guidelines](https://github.com/jellyfin/jellyfin-vue/blob/master/CONTRIBUTING.md)

Also added concurrency keys to the automation workflow and a few style improvements to our workflow files.