### PR TITLE
fix(lang): Fixed pluralization for russian language

### DIFF
--- a/frontend/components/Buttons/QueueButton.vue
+++ b/frontend/components/Buttons/QueueButton.vue
@@ -47,7 +47,7 @@
             <v-list-item-subtitle>
               {{ getTotalEndsAtTime(playbackManager.getQueueItems) }} -
               {{
-                $t('playback.queueItems', {
+                $tc('playback.queueItems', playbackManager.getQueueItems.length, {
                   items: playbackManager.getQueueItems.length
                 })
               }}

--- a/frontend/components/Item/MediaInfo.vue
+++ b/frontend/components/Item/MediaInfo.vue
@@ -15,7 +15,7 @@
       {{ item.CommunityRating }}
     </span>
     <span v-if="item.Type === 'MusicAlbum' && item.ChildCount && tracks">
-      {{ $t('numberTracks', { number: item.ChildCount }) }}
+      {{ $tc('numberTracks', item.ChildCount, { number: item.ChildCount }) }}
     </span>
     <span v-if="item.RunTimeTicks && runtime">{{
       getRuntimeTime(item.RunTimeTicks)

--- a/frontend/locales/ru.json
+++ b/frontend/locales/ru.json
@@ -222,7 +222,7 @@
   "noInformationAvailable": "Нет доступной информации",
   "noNetworkConnection": "Нет сетевого подключения",
   "noResultsFound": "Здесь ничего нет",
-  "numberTracks": "{number} дорож[ка/ки/ек]",
+  "numberTracks": "{n} дорожек|{n} дорожка|{n} дорожки|{n} дорожек",
   "operatingSystem": "Операционная система",
   "originalAspectRatio": "Исходное соотношение сторон",
   "originalTitle": "Оригинальное название",
@@ -245,7 +245,7 @@
       "shuffleItem": "Воспроизвести {item} в случайном порядке",
       "unknown": "Воспроизвести из очереди"
     },
-    "queueItems": "{items} дорожки",
+    "queueItems": "{n} дорожек|{n} дорожка|{n} дорожки|{n} дорожек",
     "saveAsPlaylist": "Сохранить очередь как плей-лист",
     "shuffle": "Перемешать",
     "shuffleAll": "Перемешать все"
@@ -497,11 +497,11 @@
   "unhandledException": "Необработанное исключение",
   "units": {
     "bitrate": {
-      "kbps": "{value} Kibit/s",
-      "mbps": "{value} Mibit/s"
+      "kbps": "{value} Кибит/c",
+      "mbps": "{value} Мибит/c"
     },
     "time": {
-      "seconds": "{count} секунда | {count} секунд"
+      "seconds": "{n} секунд|{n} секунда|{n} секунды|{n} секунд"
     }
   },
   "unliked": "Не нравится",

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -210,7 +210,7 @@ const config: NuxtConfig = {
         file: 'pt_BR.json'
       },
       { code: 'ro', iso: 'ro', name: 'Română', file: 'ro.json' },
-      { code: 'ru', iso: 'ru', name: 'русский', file: 'ru.json' },
+      { code: 'ru', iso: 'ru', name: 'Русский', file: 'ru.json' },
       { code: 'sk', iso: 'sk', name: 'Slovenčina', file: 'sk.json' },
       { code: 'sl', iso: 'sl', name: 'Slovenščina', file: 'sl.json' },
       {
@@ -233,9 +233,7 @@ const config: NuxtConfig = {
     langDir: 'locales/',
     strategy: 'no_prefix',
     defaultLocale: 'en-US',
-    vueI18n: {
-      fallbackLocale: 'en-US'
-    }
+    vueI18n: '~/plugins/vue/vue-i18n.ts',
   },
   dateFns: {
     locales: [

--- a/frontend/plugins/vue/vue-i18n.ts
+++ b/frontend/plugins/vue/vue-i18n.ts
@@ -1,0 +1,35 @@
+export default () => {
+  return {
+    fallbackLocale: 'en-US',
+    pluralizationRules: {
+      /**
+       * @param choice {number} a choice index given by the input to $tc: `$tc('path.to.rule', choiceIndex)`
+       * @param choicesLength {number} an overall amount of available choices
+       * @returns a final choice index to select plural word by
+       */
+      'ru': function(choice: number, choicesLength: number) {
+        // this === VueI18n instance, so the locale property also exists here
+
+        if (choice === 0) {
+          return 0;
+        }
+
+        const teen = choice > 10 && choice < 20;
+        const endsWithOne = choice % 10 === 1;
+
+        if (choicesLength < 4) {
+          return (!teen && endsWithOne) ? 1 : 2;
+        }
+        if (!teen && endsWithOne) {
+          return 1;
+        }
+        if (!teen && choice % 10 >= 2 && choice % 10 <= 4) {
+          return 2;
+        }
+
+        return (choicesLength < 4) ? 2 : 3;
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
This changes Vue-i18n configuration so that `$tc` function can be used for correct pluralization in russian (and other languages).

Function options cannot be stringified (as per [nuxt-18n docs](https://i18n.nuxtjs.org/options-reference#vuei18n)), so I had to move these options to separate file.

I'm not sure about place for options file, suggestions are welcome.

