### PR TITLE
feat: fix rating decimals on media rating

### DIFF
--- a/frontend/components/Item/MediaInfo.vue
+++ b/frontend/components/Item/MediaInfo.vue
@@ -12,7 +12,7 @@
     <span v-if="item.OfficialRating && rating">{{ item.OfficialRating }}</span>
     <span v-if="item.CommunityRating && rating">
       <v-icon class="rating-icon" size="16">mdi-star</v-icon>
-      {{ item.CommunityRating }}
+      {{ item.CommunityRating.toFixed(1) }}
     </span>
     <span v-if="item.Type === 'MusicAlbum' && item.ChildCount && tracks">
       {{ $t('numberTracks', { number: item.ChildCount }) }}


### PR DESCRIPTION
This removes the useless decimals in media ratings to 1 decimal.

### Before
![print_screen_2023-01-10-11-10-33](https://user-images.githubusercontent.com/1619359/211523107-953e9e80-b28f-4b20-ba69-ab09cde6f02e.png)

### After
![print_screen_2023-01-10-11-10-47](https://user-images.githubusercontent.com/1619359/211523122-592fa6a8-b4c5-486b-83e5-432511a295ca.png)
