### PR TITLE
fix: Use VItemGroup to display settings list again

### DIFF
--- a/frontend/src/components/System/AboutLinks.vue
+++ b/frontend/src/components/System/AboutLinks.vue
@@ -7,7 +7,7 @@
         rel="noreferrer noopener"
         :href="linkItem.link"
         target="_blank">
-        <template v-slot:prepend>
+        <template #prepend>
           <v-avatar>
             <v-icon :icon="linkItem.icon" />
           </v-avatar>
@@ -15,7 +15,7 @@
         <v-list-item-title>
           {{ linkItem.name }}
         </v-list-item-title>
-        <template v-slot:append>
+        <template #append>
           <v-list-item-action>
             <v-icon>
               <i-mdi-open-in-new />

--- a/frontend/src/components/System/AboutLinks.vue
+++ b/frontend/src/components/System/AboutLinks.vue
@@ -1,25 +1,29 @@
 <template>
   <v-list>
-    <v-list-group>
+    <v-item-group>
       <v-list-item
         v-for="linkItem in linkItems"
         :key="linkItem.name"
         rel="noreferrer noopener"
         :href="linkItem.link"
         target="_blank">
-        <v-avatar>
-          <v-icon :icon="linkItem.icon" />
-        </v-avatar>
+        <template v-slot:prepend>
+          <v-avatar>
+            <v-icon :icon="linkItem.icon" />
+          </v-avatar>
+        </template>
         <v-list-item-title>
           {{ linkItem.name }}
         </v-list-item-title>
-        <v-list-item-action>
-          <v-icon>
-            <i-mdi-open-in-new />
-          </v-icon>
-        </v-list-item-action>
+        <template v-slot:append>
+          <v-list-item-action>
+            <v-icon>
+              <i-mdi-open-in-new />
+            </v-icon>
+          </v-list-item-action>
+        </template>
       </v-list-item>
-    </v-list-group>
+    </v-item-group>
   </v-list>
 </template>
 

--- a/frontend/src/pages/settings/index.vue
+++ b/frontend/src/pages/settings/index.vue
@@ -49,7 +49,7 @@
               :key="userItem.name"
               :to="userItem.link"
               :disabled="!userItem.link">
-              <template v-slot:prepend>
+              <template #prepend>
                 <v-avatar>
                   <v-icon :icon="userItem.icon" />
                 </v-avatar>
@@ -60,7 +60,7 @@
               <v-list-item-subtitle>
                 {{ userItem.description }}
               </v-list-item-subtitle>
-              <template v-slot:append>
+              <template #append>
                 <v-list-item-action>
                   <v-icon>
                     <i-mdi-chevron-right />
@@ -82,7 +82,7 @@
                 :key="adminItem.name"
                 :to="adminItem.link"
                 :disabled="!adminItem.link">
-                <template v-slot:prepend>
+                <template #prepend>
                   <v-avatar>
                     <v-icon :icon="adminItem.icon" />
                   </v-avatar>
@@ -93,7 +93,7 @@
                 <v-list-item-subtitle>
                   {{ adminItem.description }}
                 </v-list-item-subtitle>
-                <template v-slot:append>
+                <template #append>
                   <v-list-item-action>
                     <v-icon>
                       <i-mdi-chevron-right />

--- a/frontend/src/pages/settings/index.vue
+++ b/frontend/src/pages/settings/index.vue
@@ -42,59 +42,66 @@
       </v-col>
       <v-col cols="12" md="6" lg="5" class="py-4">
         <!-- User settings -->
-        <v-list lines="two" class="mb-4">
-          <v-list-group>
+        <v-list lines="two" class="mb-4 overflow-y-hidden">
+          <v-item-group>
             <v-list-item
               v-for="userItem in userItems"
               :key="userItem.name"
               :to="userItem.link"
               :disabled="!userItem.link">
-              <v-avatar>
-                <v-icon :icon="userItem.icon" />
-              </v-avatar>
+              <template v-slot:prepend>
+                <v-avatar>
+                  <v-icon :icon="userItem.icon" />
+                </v-avatar>
+              </template>
               <v-list-item-title>
                 {{ userItem.name }}
               </v-list-item-title>
               <v-list-item-subtitle>
                 {{ userItem.description }}
               </v-list-item-subtitle>
-              <v-list-item-action>
-                <v-icon>
-                  <i-mdi-chevron-right />
-                </v-icon>
-              </v-list-item-action>
+              <template v-slot:append>
+                <v-list-item-action>
+                  <v-icon>
+                    <i-mdi-chevron-right />
+                  </v-icon>
+                </v-list-item-action>
+              </template>
             </v-list-item>
-          </v-list-group>
+          </v-item-group>
         </v-list>
         <!-- Administrator settings -->
         <div v-if="$remote.auth.currentUser.value?.Policy?.IsAdministrator">
           <v-list
             v-for="(adminSection, index) in adminSections"
             :key="`admin-section-${index}`"
-            lines="two"
-            class="mb-4">
-            <v-list-group>
+            class="mb-4 overflow-y-hidden">
+            <v-item-group>
               <v-list-item
                 v-for="adminItem in adminSection"
                 :key="adminItem.name"
                 :to="adminItem.link"
                 :disabled="!adminItem.link">
-                <v-avatar>
-                  <v-icon :icon="adminItem.icon" />
-                </v-avatar>
+                <template v-slot:prepend>
+                  <v-avatar>
+                    <v-icon :icon="adminItem.icon" />
+                  </v-avatar>
+                </template>
                 <v-list-item-title>
                   {{ adminItem.name }}
                 </v-list-item-title>
                 <v-list-item-subtitle>
                   {{ adminItem.description }}
                 </v-list-item-subtitle>
-                <v-list-item-action>
-                  <v-icon>
-                    <i-mdi-chevron-right />
-                  </v-icon>
-                </v-list-item-action>
+                <template v-slot:append>
+                  <v-list-item-action>
+                    <v-icon>
+                      <i-mdi-chevron-right />
+                    </v-icon>
+                  </v-list-item-action>
+                </template>
               </v-list-item>
-            </v-list-group>
+            </v-item-group>
           </v-list>
         </div>
         <about-links v-if="$vuetify.display.mobile" />


### PR DESCRIPTION
v-list-item-group seems to be not available anymore in Vuetify 3. I can't find any information on it. We use v-item-group (not v-list-group which was causing the settings not to show up) instead.
We use templates with v-slot:prepend and v-slot:append to place the icons correctly before or behind the actual settings name and description.