### PR TITLE
ci: run CI checks on PRs that are not targeted to master

### DIFF
--- a/.github/workflows/codeQL.yml
+++ b/.github/workflows/codeQL.yml
@@ -9,8 +9,6 @@ on:
     branches:
       - master
   pull_request:
-    branches:
-      - master
     paths-ignore:
       - '**/*.md'
   workflow_call:

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -6,8 +6,6 @@ concurrency:
 
 on:
   pull_request:
-    branches:
-      - master
     paths-ignore:
       - '**/*.md'
   schedule:


### PR DESCRIPTION
With all the PRs that are now being targeted at #1812, not having checks on them is a major inconvenience.