### PR TITLE
Fixed webos useragent

### DIFF
--- a/frontend/plugins/nuxt/browserDetectionPlugin.ts
+++ b/frontend/plugins/nuxt/browserDetectionPlugin.ts
@@ -101,8 +101,8 @@ export class BrowserDetector {
    */
   isChrome(): boolean {
     // The Edge user agent will also contain the "Chrome" keyword, so we need
-    // to make sure this is not Edge.
-    return this.userAgentContains('Chrome') && !this.isEdge();
+    // to make sure this is not Edge. Same happens for webos.
+    return this.userAgentContains('Chrome') && !this.isEdge() && !this.isWebOS();
   }
 
   /**
@@ -232,7 +232,7 @@ export class BrowserDetector {
    * @memberof BrowserDetector
    */
   isWebOS(): boolean {
-    return this.userAgentContains('WebOS');
+    return this.userAgentContains('Web0S');
   }
 
   /**


### PR DESCRIPTION
Web OS User agent is actually with a Web0S (with a zero) for some reason. This PR fixes this.

Find reference in LG docs here 

https://webostv.developer.lge.com/develop/specifications/web-api-and-web-engine