### PR TITLE
style: remove unnecessary `as` casts

### DIFF
--- a/frontend/components/Buttons/__tests__/MarkPlayedButton.spec.ts
+++ b/frontend/components/Buttons/__tests__/MarkPlayedButton.spec.ts
@@ -1,4 +1,3 @@
-import { BaseItemDto } from '@jellyfin/client-axios';
 import { createLocalVue, mount, Wrapper } from '@vue/test-utils';
 import Vuetify from 'vuetify';
 import Vue from 'vue';
@@ -15,7 +14,7 @@ describe('component: MarkPlayedButton', () => {
       localVue,
       vuetify,
       propsData: {
-        item: { Type: 'Series' } as BaseItemDto
+        item: { Type: 'Series' }
       }
     });
   });
@@ -27,7 +26,7 @@ describe('component: MarkPlayedButton', () => {
 
   it('check color is primary when the item has been watched', async (): Promise<void> => {
     await wrapper.setProps({
-      item: { UserData: { Played: true }, Type: 'Series' } as BaseItemDto
+      item: { UserData: { Played: true }, Type: 'Series' }
     });
 
     expect(wrapper.find('.primary--text').exists()).toBe(true);
@@ -35,7 +34,7 @@ describe('component: MarkPlayedButton', () => {
 
   it('check color is unset when the item has been watched', async (): Promise<void> => {
     await wrapper.setProps({
-      item: { UserData: { Played: false }, Type: 'Series' } as BaseItemDto
+      item: { UserData: { Played: false }, Type: 'Series' }
     });
 
     expect(wrapper.find('.primary--text').exists()).toBe(false);
@@ -43,13 +42,13 @@ describe('component: MarkPlayedButton', () => {
 
   it('check color changes, when the props are updated', async (): Promise<void> => {
     await wrapper.setProps({
-      item: { UserData: { Played: true }, Type: 'Series' } as BaseItemDto
+      item: { UserData: { Played: true }, Type: 'Series' }
     });
 
     expect(wrapper.find('.primary--text').exists()).toBe(true);
 
     await wrapper.setProps({
-      item: { UserData: { Played: false }, Type: 'Series' } as BaseItemDto
+      item: { UserData: { Played: false }, Type: 'Series' }
     });
 
     expect(wrapper.find('.primary--text').exists()).toBe(false);

--- a/frontend/plugins/store/watchers/playbackManager.ts
+++ b/frontend/plugins/store/watchers/playbackManager.ts
@@ -12,7 +12,9 @@ function handleMediaSession(
   remove = false
 ): void {
   if (window.navigator.mediaSession) {
-    const actionHandlers = {
+    const actionHandlers: {
+      [key in MediaSessionAction]?: MediaSessionActionHandler;
+    } = {
       play: (): void => {
         playbackManager.unpause();
       },
@@ -37,7 +39,7 @@ function handleMediaSession(
       seekto: (action): void => {
         playbackManager.changeCurrentTime(action.seekTime || 1);
       }
-    } as { [key in MediaSessionAction]?: MediaSessionActionHandler };
+    };
 
     for (const [action, handler] of Object.entries(actionHandlers)) {
       try {

--- a/frontend/store/auth.ts
+++ b/frontend/store/auth.ts
@@ -23,7 +23,7 @@ export interface AuthState {
 }
 
 export const authStore = defineStore('auth', {
-  state: () => {
+  state: (): AuthState => {
     return {
       servers: [],
       currentServerIndex: -1,
@@ -31,7 +31,7 @@ export const authStore = defineStore('auth', {
       users: [],
       rememberMe: true,
       accessTokens: {}
-    } as AuthState;
+    };
   },
   actions: {
     /**

--- a/frontend/store/clientSettings.ts
+++ b/frontend/store/clientSettings.ts
@@ -13,7 +13,7 @@ export interface ClientSettingsState {
 }
 
 export const clientSettingsStore = defineStore('clientSettings', {
-  state: () => {
+  state: (): ClientSettingsState => {
     return {
       darkMode:
         nuxtConfig.vuetify?.theme?.dark !== undefined
@@ -21,7 +21,7 @@ export const clientSettingsStore = defineStore('clientSettings', {
           : true,
       locale: 'auto',
       lastSync: null
-    } as ClientSettingsState;
+    };
   },
   actions: {
     setDarkMode(darkMode: boolean): void {

--- a/frontend/store/deviceProfile.ts
+++ b/frontend/store/deviceProfile.ts
@@ -72,13 +72,13 @@ export interface DeviceState {
 }
 
 export const deviceProfileStore = defineStore('deviceProfile', {
-  state: () => {
+  state: (): DeviceState => {
     return {
       deviceId: '',
       deviceName: '',
       clientVersion: '',
       clientName: ''
-    } as DeviceState;
+    };
   },
   actions: {
     setDeviceProfile(): void {

--- a/frontend/store/homeSection.ts
+++ b/frontend/store/homeSection.ts
@@ -24,13 +24,13 @@ export interface HomeSectionState {
 }
 
 export const homeSectionStore = defineStore('homeSection', {
-  state: () => {
+  state: (): HomeSectionState => {
     return {
       audioResumes: [],
       videoResumes: [],
       upNext: [],
       latestMedia: {}
-    } as HomeSectionState;
+    };
   },
   actions: {
     async getAudioResumes(): Promise<void> {

--- a/frontend/store/items.ts
+++ b/frontend/store/items.ts
@@ -9,11 +9,11 @@ export interface ItemsState {
 }
 
 export const itemsStore = defineStore('items', {
-  state: () => {
+  state: (): ItemsState => {
     return {
       byId: {},
       collectionById: {}
-    } as ItemsState;
+    };
   },
   actions: {
     /**

--- a/frontend/store/page.ts
+++ b/frontend/store/page.ts
@@ -19,7 +19,7 @@ export interface PageState {
 export const defaultBackdropOpacity = 0.75;
 
 export const pageStore = defineStore('page', {
-  state: () => {
+  state: (): PageState => {
     return {
       title: 'Jellyfin',
       transparentLayout: false,
@@ -30,7 +30,7 @@ export const pageStore = defineStore('page', {
         blurhash: '',
         opacity: defaultBackdropOpacity
       }
-    } as PageState;
+    };
   },
   actions: {
     resetBackdropOpacity(): void {

--- a/frontend/store/playbackManager.ts
+++ b/frontend/store/playbackManager.ts
@@ -66,7 +66,7 @@ interface PlaybackManagerState {
 }
 
 export const playbackManagerStore = defineStore('playbackManager', {
-  state: () => {
+  state: (): PlaybackManagerState => {
     return {
       status: PlaybackStatus.Stopped,
       lastItemIndex: null,
@@ -88,7 +88,7 @@ export const playbackManagerStore = defineStore('playbackManager', {
       playSessionId: null,
       playbackInitiator: null,
       playbackInitMode: InitMode.Unknown
-    } as PlaybackManagerState;
+    };
   },
   actions: {
     async addToQueue(item: BaseItemDto) {

--- a/frontend/store/snackbar.ts
+++ b/frontend/store/snackbar.ts
@@ -6,11 +6,11 @@ export interface SnackbarState {
 }
 
 export const snackbarStore = defineStore('snackbar', {
-  state: () => {
+  state: (): SnackbarState => {
     return {
       message: '',
       color: ''
-    } as SnackbarState;
+    };
   },
   actions: {
     /**

--- a/frontend/store/socket.ts
+++ b/frontend/store/socket.ts
@@ -31,14 +31,14 @@ export interface SocketState {
 }
 
 export const socketStore = defineStore('socket', {
-  state: () => {
+  state: (): SocketState => {
     return {
       instance: null,
       isConnected: false,
       messageType: '',
       messageData: undefined,
       isConnecting: false
-    } as SocketState;
+    };
   },
   actions: {
     /**

--- a/frontend/store/taskManager.ts
+++ b/frontend/store/taskManager.ts
@@ -37,10 +37,10 @@ export interface TaskManagerState {
 }
 
 export const taskManagerStore = defineStore('taskManager', {
-  state: () => {
+  state: (): TaskManagerState => {
     return {
       tasks: []
-    } as TaskManagerState;
+    };
   },
   actions: {
     startTask(task: RunningTask): void {

--- a/frontend/store/userViews.ts
+++ b/frontend/store/userViews.ts
@@ -8,10 +8,10 @@ export interface UserViewsState {
 }
 
 export const userViewsStore = defineStore('userViews', {
-  state: () => {
+  state: (): UserViewsState => {
     return {
       views: []
-    } as UserViewsState;
+    };
   },
   actions: {
     async refreshUserViews(): Promise<void> {

--- a/frontend/utils/items.ts
+++ b/frontend/utils/items.ts
@@ -51,10 +51,7 @@ export type ValidCardShapes =
 export function isPerson(
   item: BaseItemDto | BaseItemPerson
 ): item is BaseItemPerson {
-  if (
-    'Role' in (item as BaseItemPerson) ||
-    (item.Type && validPersonTypes.includes(item.Type))
-  ) {
+  if ('Role' in item || (item.Type && validPersonTypes.includes(item.Type))) {
     return true;
   }
 


### PR DESCRIPTION
Just starting to play around in this codebase, and realized there were a few places where `as` casts were being used but the type could be correctly specified and checked instead.