### PR TITLE
style: remove unnecessary as casts

### DIFF
--- a/frontend/src/components/Item/ItemMenu.vue
+++ b/frontend/src/components/Item/ItemMenu.vue
@@ -57,7 +57,7 @@ import IMdiRefresh from 'virtual:icons/mdi/refresh';
 import IMdiDotsHorizontal from 'virtual:icons/mdi/dots-horizontal';
 import { useRemote, useSnackbar } from '@/composables';
 import { canResume } from '@/utils/items';
-import { TaskType, RunningTask } from '@/store/taskManager';
+import { TaskType } from '@/store/taskManager';
 import { playbackManagerStore, taskManagerStore } from '@/store';
 
 type MenuOption = {
@@ -119,7 +119,7 @@ const playNextAction = {
  * Options to show when the item menu is invoked in a queue item
  */
 function getQueueOptions(): MenuOption[] {
-  const queueOptions = [] as MenuOption[];
+  const queueOptions: MenuOption[] = [];
 
   if (
     menuProps.queue &&
@@ -169,7 +169,7 @@ function getQueueOptions(): MenuOption[] {
  * Playback options for the items
  */
 function getPlaybackOptions(): MenuOption[] {
-  const playbackOptions = [] as MenuOption[];
+  const playbackOptions: MenuOption[] = [];
 
   if (canResume(menuProps.item)) {
     playbackOptions.push({
@@ -221,7 +221,7 @@ function getPlaybackOptions(): MenuOption[] {
  * Library options for libraries
  */
 function getLibraryOptions(): MenuOption[] {
-  const libraryOptions = [] as MenuOption[];
+  const libraryOptions: MenuOption[] = [];
 
   if (
     remote.auth.currentUser?.Policy?.IsAdministrator &&
@@ -244,10 +244,10 @@ function getLibraryOptions(): MenuOption[] {
             useSnackbar(t('libraryRefreshQueued'), 'normal');
             taskManager.startTask({
               type: TaskType.LibraryRefresh,
-              id: menuProps.item.Id,
-              data: menuProps.item.Name,
+              id: menuProps.item.Id || '',
+              data: menuProps.item.Name || '',
               progress: 0
-            } as RunningTask);
+            });
           } catch (error) {
             console.error(error);
 

--- a/frontend/src/components/Item/Metadata/ImageEditor.vue
+++ b/frontend/src/components/Item/Metadata/ImageEditor.vue
@@ -94,7 +94,7 @@ export default defineComponent({
   },
   computed: {
     generalImages(): boolean {
-      return this.images.filter((image: ImageInfo) => {
+      return this.images.filter((image) => {
         return (
           image.ImageType !== ImageType.Screenshot &&
           image.ImageType !== ImageType.Backdrop &&

--- a/frontend/src/components/Layout/AppBar/Buttons/TaskManagerButton.vue
+++ b/frontend/src/components/Layout/AppBar/Buttons/TaskManagerButton.vue
@@ -52,7 +52,7 @@
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue';
 import { taskManagerStore } from '@/store';
-import { RunningTask, TaskType } from '@/store/taskManager';
+import { TaskType } from '@/store/taskManager';
 
 interface TaskInfo {
   progress: undefined | number;
@@ -104,7 +104,7 @@ function setTimeout(): void {
 function getTaskList(): void {
   const list: Array<TaskInfo> = [];
 
-  for (const task of taskManager.tasks as RunningTask[]) {
+  for (const task of taskManager.tasks) {
     switch (task.type) {
       case TaskType.ConfigSync: {
         list.push({
@@ -131,7 +131,7 @@ function getTaskList(): void {
   }
 
   const taskIds = new Set(
-    (list as TaskInfo[]).map((task) => {
+    list.map((task) => {
       return task.id;
     })
   );

--- a/frontend/src/components/Layout/VirtualGrid/pipeline.ts
+++ b/frontend/src/components/Layout/VirtualGrid/pipeline.ts
@@ -111,8 +111,8 @@ export function fromScrollParent(
   return computed(() => {
     const el = unrefElement(elRef);
 
-    if (el) {
-      const { vertical, horizontal } = getScrollParents(el as HTMLElement);
+    if (el && el instanceof HTMLElement) {
+      const { vertical, horizontal } = getScrollParents(el);
 
       /**
        * If the scrolling parent is the doc root, use window instead as using
@@ -320,10 +320,7 @@ export function getVisibleItems<T>(
 
   return allItems.slice(first, last).map((value, localIndex) => {
     const index = first + localIndex;
-    const { x, y } = getItemOffsetByIndex(
-      index,
-      resizeMeasurement
-    ) as ItemOffset;
+    const { x, y } = getItemOffsetByIndex(index, resizeMeasurement);
 
     return {
       index,

--- a/frontend/src/components/Skeletons/SkeletonCard.vue
+++ b/frontend/src/components/Skeletons/SkeletonCard.vue
@@ -28,7 +28,7 @@ export default defineComponent({
     cardShape: {
       type: String,
       default: (): string => CardShapes.Portrait,
-      validator: (value): boolean =>
+      validator: (value: string): boolean =>
         Object.values(CardShapes).includes(value as CardShapes)
     }
   }

--- a/frontend/src/components/Skeletons/SkeletonHomeSection.vue
+++ b/frontend/src/components/Skeletons/SkeletonHomeSection.vue
@@ -21,7 +21,7 @@ export default defineComponent({
   props: {
     cardShape: {
       type: String,
-      validator: (value): boolean =>
+      validator: (value: string): boolean =>
         Object.values(CardShapes).includes(value as CardShapes),
       default: CardShapes.Thumb
     }

--- a/frontend/src/pages/index.vue
+++ b/frontend/src/pages/index.vue
@@ -66,31 +66,31 @@ if (userLibraries.isReady) {
 const homeSections = computed<HomeSection[]>(() => {
   // Filter for valid sections in Jellyfin Vue
   // TODO: Implement custom section order
-  let homeSectionsArray = pickBy(
+  const homeSectionPrefs = pickBy(
     // @ts-expect-error - No typings for this
-    clientSettings.CustomPrefs,
-    (value: string, key: string) => {
+    clientSettings.CustomPrefs as { [key: string]: string },
+    (value, key) => {
       return (
         value && VALID_SECTIONS.has(value) && key.startsWith('homesection')
       );
     }
   );
 
-  if (Object.keys(homeSectionsArray).length === 0) {
-    homeSectionsArray = {
-      homeSection0: 'librarytiles',
-      homeSection1: 'resume',
-      homeSection2: 'resumeaudio',
-      homeSection3: 'upnext',
-      homeSection4: 'latestmedia'
-    };
-  }
+  const homeSectionKeys = Object.keys(homeSectionPrefs);
 
-  homeSectionsArray = Object.values(homeSectionsArray);
+  if (homeSectionKeys.length === 0) {
+    homeSectionKeys.push(
+      'librarytiles',
+      'resume',
+      'resumeaudio',
+      'upnext',
+      'latestmedia'
+    );
+  }
 
   const homeSections: HomeSection[] = [];
 
-  for (const homeSection of homeSectionsArray as Array<string>) {
+  for (const homeSection of homeSectionKeys) {
     switch (homeSection) {
       case 'librarytiles': {
         homeSections.push({
@@ -113,7 +113,10 @@ const homeSections = computed<HomeSection[]>(() => {
           ]);
 
           for (const userView of userLibraries.libraries) {
-            if (excludeViewTypes.has(userView.CollectionType as string)) {
+            if (
+              userView.CollectionType &&
+              excludeViewTypes.has(userView.CollectionType)
+            ) {
               continue;
             }
 

--- a/frontend/src/pages/item/_itemId/index.vue
+++ b/frontend/src/pages/item/_itemId/index.vue
@@ -272,7 +272,8 @@ export default defineComponent({
   computed: {
     isPlayable(): boolean {
       // TODO: Move this to a mixin
-      return ['PhotoAlbum', 'Photo', 'Book'].includes(this.item.Type as string)
+      return this.item.Type &&
+        ['PhotoAlbum', 'Photo', 'Book'].includes(this.item.Type)
         ? false
         : !(
             this.item.MediaType === 'Video' &&

--- a/frontend/src/store/items.ts
+++ b/frontend/src/store/items.ts
@@ -85,20 +85,24 @@ class ItemsStore {
     payload: BaseItemDto | BaseItemDto[]
   ): BaseItemDto | BaseItemDto[] => {
     const isArray = Array.isArray(payload);
+    const itemArray = isArray ? payload : [payload];
 
-    if (!isArray) {
-      payload = [payload as BaseItemDto];
-    }
+    const res: BaseItemDto[] = [];
 
-    const res = [];
-
-    for (const item of payload as BaseItemDto[]) {
+    for (const item of itemArray) {
       if (!item.Id) {
         throw new Error("One item doesn't have an id");
       }
 
       state.value.byId[item.Id] = item;
-      res.push(this.getItemById(item.Id) as BaseItemDto);
+
+      const fetched = this.getItemById(item.Id);
+
+      if (!fetched) {
+        throw new Error('Expected to receive newly added item to store');
+      }
+
+      res.push(fetched);
     }
 
     if (res.length === 1 && !isArray) {

--- a/frontend/src/utils/data-manipulation.ts
+++ b/frontend/src/utils/data-manipulation.ts
@@ -7,12 +7,12 @@ import { defaultsDeep } from 'lodash-es';
  * @param defaultObject - Sample/default representation of the object that should be used to detect which keys
  * should/shouldn't exist in the target.
  */
-export function mergeExcludingUnknown<T, K extends keyof T>(
+export function mergeExcludingUnknown<T extends object, K extends keyof T>(
   object: T,
   defaultObject: T
 ): T {
-  const defaultKeys = new Set(Object.keys(defaultObject as object) as K[]);
-  const missingKeys = (Object.keys(object as object) as K[]).filter(
+  const defaultKeys = new Set(Object.keys(defaultObject) as K[]);
+  const missingKeys = (Object.keys(object) as K[]).filter(
     (key) => !defaultKeys.has(key)
   );
 

--- a/frontend/src/utils/items.ts
+++ b/frontend/src/utils/items.ts
@@ -70,7 +70,7 @@ export function isPerson(
   item: BaseItemDto | BaseItemPerson
 ): item is BaseItemPerson {
   return !!(
-    'Role' in (item as BaseItemPerson) ||
+    'Role' in item ||
     (item.Type && validPersonTypes.includes(item.Type))
   );
 }


### PR DESCRIPTION
Removes unnecessary `as` casts, along with a few other typing updates. Mostly low-hanging fruit.
See #1869 for original effort on master branch.

Some of my own notes from going through `as` casts in code base:
1. `as` casts are being used to type component data structures, rather than using interfaces. I'll look into converting these next.
2. `as` casts are being used as not-null assertions fairly often. This should either be changed to actual not-null-assertions operators (`!`), which are still not ideal and are currently sent to error with linting, or actually have null checks performed. This is difficult because of the DTO types from the api.
3. At the moment, there are likely too many `as` casts for a linting rule to be useful, but we should consider adding them as these narrow down.