### PR TITLE
fix: fix failing github action setup

### DIFF
--- a/.github/workflows/automation.yml
+++ b/.github/workflows/automation.yml
@@ -9,7 +9,7 @@ on:
     branches:
       - master
     paths-ignore:
-      - '**/*.md'
+      - "**/*.md"
   pull_request_target:
 
 jobs:
@@ -63,10 +63,10 @@ jobs:
         if: ${{ github.event_name == 'pull_request_target' }}
         continue-on-error: true
         with:
-          repo-token: '${{ secrets.JF_BOT_TOKEN }}'
+          repo-token: "${{ secrets.JF_BOT_TOKEN }}"
 
       - name: Check all PRs for merge conflicts ⛔
         uses: eps1lon/actions-label-merge-conflict@v2.1.0
         with:
-          dirtyLabel: 'merge conflict'
+          dirtyLabel: "merge conflict"
           repoToken: ${{ secrets.JF_BOT_TOKEN }}

--- a/.github/workflows/codeQL.yml
+++ b/.github/workflows/codeQL.yml
@@ -10,7 +10,7 @@ on:
       - master
   pull_request:
     paths-ignore:
-      - '**/*.md'
+      - "**/*.md"
   workflow_call:
 
 jobs:

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -35,7 +35,6 @@ jobs:
         uses: actions/setup-node@v3.5.1
         with:
           node-version: 18
-          cache: "npm"
           check-latest: true
 
       - name: Install dependencies 📦
@@ -56,7 +55,6 @@ jobs:
         uses: actions/setup-node@v3.5.1
         with:
           node-version: 18
-          cache: "npm"
           check-latest: true
 
       - name: Install dependencies 📦
@@ -139,7 +137,6 @@ jobs:
         uses: actions/setup-node@v3.5.1
         with:
           node-version: 18
-          cache: "npm"
           check-latest: true
 
       - name: Install dependencies 📦

--- a/.github/workflows/job_messages.yml
+++ b/.github/workflows/job_messages.yml
@@ -27,7 +27,7 @@ on:
         value: ${{ jobs.msg.outputs.msg }}
       marker:
         description: Hidden marker to detect PR comments composed by the bot
-        value: 'CFPages-deployment'
+        value: "CFPages-deployment"
 
 jobs:
   msg:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,9 +72,9 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - 'macos-latest'
-          - 'ubuntu-latest'
-          - 'windows-latest'
+          - "macos-latest"
+          - "ubuntu-latest"
+          - "windows-latest"
 
     runs-on: ${{ matrix.platform }}
     steps:
@@ -85,7 +85,6 @@ jobs:
         uses: actions/setup-node@v3.5.1
         with:
           node-version: 18
-          cache: 'npm'
           check-latest: true
 
       - name: Install dependencies 📦
@@ -98,10 +97,10 @@ jobs:
           sudo apt-get install -y webkit2gtk-4.0
 
       - name: Generate Tauri icons 🖌️
-        run: 'npm run tauri:icon -w tauri'
+        run: "npm run tauri:icon -w tauri"
 
       - name: Build Tauri 🛠️
-        run: 'npm run tauri:build -w tauri'
+        run: "npm run tauri:build -w tauri"
 
       - name: Upload artifact (Linux) ⬆️🐧
         uses: actions/upload-artifact@v3.1.1

--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -9,7 +9,7 @@ on:
     branches:
       - master
     paths-ignore:
-      - '**/*.md'
+      - "**/*.md"
 
 jobs:
   docker:
@@ -78,9 +78,9 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - 'macos-latest'
-          - 'ubuntu-latest'
-          - 'windows-latest'
+          - "macos-latest"
+          - "ubuntu-latest"
+          - "windows-latest"
 
     runs-on: ${{ matrix.platform }}
     steps:
@@ -91,7 +91,6 @@ jobs:
         uses: actions/setup-node@v3.5.1
         with:
           node-version: 18
-          cache: 'npm'
           check-latest: true
 
       - name: Install dependencies 📦
@@ -104,10 +103,10 @@ jobs:
           sudo apt-get install -y webkit2gtk-4.0
 
       - name: Generate Tauri icons 🖌️
-        run: 'npm run tauri:icon -w tauri'
+        run: "npm run tauri:icon -w tauri"
 
       - name: Build Tauri 🛠️
-        run: 'npm run tauri:build -w tauri'
+        run: "npm run tauri:build -w tauri"
 
       - name: Upload artifact (Linux) ⬆️🐧
         uses: actions/upload-artifact@v3.1.1


### PR DESCRIPTION
Currently all builds are failing the `Lint` and `Typecheck` (and other) steps due to an error with 
setting up the node environment, `ENOWORKSPACES`. From the Lint logs for recent PRs (like #1881):
<img width="1468" alt="image" src="https://user-images.githubusercontent.com/8809837/219484955-1ac4b466-bc9a-40c1-aee8-2aeb2060a53c.png">

These errors are because the npm cache option doesn't work with npm workspaces - try running `npm config get cache` locally to confirm this. This PR removes the github actions cache option to allow the github action workflows to run.

The jobs still fail now because of linting and type checking errors, but the steps actually run to completio.
This should help monitor how PRs increase/decrease lint rule and type checking violations.
