### PR TITLE
refactor: stores and websocket

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,5 +10,10 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "eslint.validate": ["vue"],
-  "eslint.workingDirectories": [{ "mode": "auto" }]
+  "eslint.workingDirectories": [{ "mode": "auto" }],
+  "emmet.includeLanguages": {
+    "vue": "html"
+  },
+  "volar.autoCompleteRefs": true,
+  "volar.vueserver.fullCompletionList": true
 }

--- a/frontend/locales/en-US.json
+++ b/frontend/locales/en-US.json
@@ -1,4 +1,5 @@
 {
+  "auto": "Automatic",
   "3DFormat": "3D format",
   "NoMediaSourcesAvailable": "No media sources available",
   "actor": "Actor",
@@ -460,7 +461,8 @@
   "tooltips": {
     "changeLanguage": "Language",
     "switchToDarkMode": "Switch to dark mode",
-    "switchToLightMode": "Switch to light mode"
+    "switchToLightMode": "Switch to light mode",
+    "switchToAuto": "Follow system theme"
   },
   "trailer": "Trailer",
   "transcodingInfo": {

--- a/frontend/src/components/Buttons/LikeButton.vue
+++ b/frontend/src/components/Buttons/LikeButton.vue
@@ -2,60 +2,48 @@
   <v-btn
     :icon="isFavorite ? IMdiHeart : IMdiHeartOutline"
     size="small"
-    @click.stop.prevent="toggleFavorite" />
+    :loading="loading"
+    @click.stop.prevent="isFavorite = !isFavorite" />
 </template>
 
 <script lang="ts" setup>
-import { ref, watch } from 'vue';
+import { computed, ref } from 'vue';
 import { BaseItemDto } from '@jellyfin/sdk/lib/generated-client';
 import { getUserLibraryApi } from '@jellyfin/sdk/lib/utils/api/user-library-api';
 import IMdiHeart from 'virtual:icons/mdi/heart';
 import IMdiHeartOutline from 'virtual:icons/mdi/heart-outline';
-import { useI18n } from 'vue-i18n';
-import { useRemote, useSnackbar } from '@/composables';
+import { useRemote } from '@/composables';
 
 const props = defineProps<{ item: BaseItemDto }>();
-
-const isFavorite = ref(false);
 const remote = useRemote();
-const { t } = useI18n();
+const loading = ref(false);
 
-watch(
-  () => props.item.UserData?.IsFavorite,
-  () => {
-    isFavorite.value = props.item.UserData?.IsFavorite || false;
+const isFavorite = computed({
+  get() {
+    return props.item.UserData?.IsFavorite ?? false;
   },
-  { immediate: true }
-);
+  async set(newValue) {
+    try {
+      if (!props.item.Id) {
+        throw new Error('Item has no Id');
+      }
 
-/**
- * Toggles the favorite on the server
- */
-async function toggleFavorite(): Promise<void> {
-  try {
-    if (!props.item.Id) {
-      throw new Error('Item has no Id');
+      loading.value = true;
+
+      await (newValue
+        ? remote.sdk.newUserApi(getUserLibraryApi).markFavoriteItem({
+            userId: remote.auth.currentUserId || '',
+            itemId: props.item.Id
+          })
+        : remote.sdk.newUserApi(getUserLibraryApi).unmarkFavoriteItem({
+            userId: remote.auth.currentUserId || '',
+            itemId: props.item.Id
+          }));
+      loading.value = false;
+    } catch {
+    } finally {
+      loading.value = false;
     }
-
-    if (!isFavorite.value) {
-      isFavorite.value = true;
-
-      await remote.sdk.newUserApi(getUserLibraryApi).markFavoriteItem({
-        userId: remote.auth.currentUserId || '',
-        itemId: props.item.Id
-      });
-    } else {
-      isFavorite.value = false;
-
-      await remote.sdk.newUserApi(getUserLibraryApi).unmarkFavoriteItem({
-        userId: remote.auth.currentUserId || '',
-        itemId: props.item.Id
-      });
-    }
-  } catch {
-    useSnackbar(t('unableToToggleLike'), 'error');
-
-    isFavorite.value = !isFavorite.value;
   }
-}
+});
 </script>

--- a/frontend/src/components/Buttons/LikeButton.vue
+++ b/frontend/src/components/Buttons/LikeButton.vue
@@ -32,14 +32,13 @@ const isFavorite = computed({
 
       await (newValue
         ? remote.sdk.newUserApi(getUserLibraryApi).markFavoriteItem({
-            userId: remote.auth.currentUserId || '',
+            userId: remote.auth.currentUserId ?? '',
             itemId: props.item.Id
           })
         : remote.sdk.newUserApi(getUserLibraryApi).unmarkFavoriteItem({
-            userId: remote.auth.currentUserId || '',
+            userId: remote.auth.currentUserId ?? '',
             itemId: props.item.Id
           }));
-      loading.value = false;
     } catch {
     } finally {
       loading.value = false;

--- a/frontend/src/components/Buttons/LikeButton.vue
+++ b/frontend/src/components/Buttons/LikeButton.vue
@@ -21,27 +21,12 @@ const remote = useRemote();
 const { t } = useI18n();
 
 watch(
-  () => props.item,
+  () => props.item.UserData?.IsFavorite,
   () => {
     isFavorite.value = props.item.UserData?.IsFavorite || false;
   },
   { immediate: true }
 );
-
-watch(remote.socket.message, () => {
-  if (remote.socket.messageData.value) {
-    const payloadData = remote.socket.messageData.value.UserDataList;
-
-    if (payloadData) {
-      // @ts-expect-error - No typings for WebSocket messages
-      for (const payloadItem of payloadData) {
-        if (payloadItem.ItemId === props.item.Id) {
-          isFavorite.value = payloadItem.IsFavorite;
-        }
-      }
-    }
-  }
-});
 
 /**
  * Toggles the favorite on the server

--- a/frontend/src/components/Buttons/ScrollToTopButton.vue
+++ b/frontend/src/components/Buttons/ScrollToTopButton.vue
@@ -17,9 +17,9 @@
 </template>
 
 <script setup lang="ts">
-import { useWindowScroll } from '@vueuse/core';
+import { windowScroll } from '@/store';
 
-const { y } = useWindowScroll();
+const { y } = windowScroll;
 
 /**
  * Scrolls to the top of the page

--- a/frontend/src/components/Item/Card/Card.vue
+++ b/frontend/src/components/Item/Card/Card.vue
@@ -72,15 +72,15 @@
   </div>
 </template>
 
-<script lang="ts" setup>
+<script lang="ts">
 import { computed } from 'vue';
+import { useMediaQuery } from '@vueuse/core';
 import {
   BaseItemDto,
   BaseItemKind,
   ImageType
 } from '@jellyfin/sdk/lib/generated-client';
 import { useI18n } from 'vue-i18n';
-import { useMediaQuery } from '@vueuse/core';
 import {
   CardShapes,
   getShapeFromItemType,
@@ -89,6 +89,13 @@ import {
 } from '@/utils/items';
 import { taskManagerStore } from '@/store';
 
+/**
+ * SHARED STATE ACROSS ALL THE COMPONENT INSTANCES
+ */
+const isFinePointer = useMediaQuery('(pointer:fine)');
+</script>
+
+<script lang="ts" setup>
 const props = withDefaults(
   defineProps<{
     item: BaseItemDto;
@@ -205,8 +212,6 @@ const getImageType = computed(() =>
 const refreshProgress = computed(
   () => taskManager.getTask(props.item.Id || '')?.progress
 );
-
-const isFinePointer = useMediaQuery('(pointer:fine)');
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/src/components/Item/Card/Card.vue
+++ b/frontend/src/components/Item/Card/Card.vue
@@ -16,7 +16,6 @@
           <v-progress-circular
             v-if="refreshProgress !== undefined"
             class="card-chip"
-            rotate="-90"
             :model-value="refreshProgress"
             :indeterminate="refreshProgress === 0"
             color="white"

--- a/frontend/src/components/Layout/AppBar/AppBar.vue
+++ b/frontend/src/components/Layout/AppBar/AppBar.vue
@@ -62,14 +62,14 @@
 <script setup lang="ts">
 import { computed, inject, Ref } from 'vue';
 import { useRoute } from 'vue-router';
-import { useNetwork, useWindowScroll } from '@vueuse/core';
-import { clientSettingsStore } from '@/store';
+import { useNetwork } from '@vueuse/core';
+import { clientSettingsStore, windowScroll } from '@/store';
 import { useResponsiveClasses } from '@/composables';
 
 const clientSettings = clientSettingsStore();
 const route = useRoute();
 const network = useNetwork();
-const { y } = useWindowScroll();
+const { y } = windowScroll;
 const transparentAppBar = computed<boolean>(() => {
   return (route.meta.transparentLayout || false) && y.value < 10;
 });

--- a/frontend/src/components/Layout/AppBar/AppBar.vue
+++ b/frontend/src/components/Layout/AppBar/AppBar.vue
@@ -27,20 +27,24 @@
       </template>
     </app-bar-button-layout>
     <task-manager-button />
-    <app-bar-button-layout
-      @click="clientSettings.darkMode = !clientSettings.darkMode">
+    <app-bar-button-layout @click="switchColorTheme">
       <template #icon>
         <v-icon>
-          <i-mdi-weather-sunny v-if="clientSettings.darkMode" />
+          <i-mdi-brightness-auto v-if="clientSettings.darkMode === 'auto'" />
+          <i-mdi-weather-sunny v-else-if="clientSettings.darkMode" />
           <i-mdi-weather-night v-else />
         </v-icon>
       </template>
       <template #tooltip>
-        <span>{{
-          clientSettings.darkMode
-            ? $t('tooltips.switchToLightMode')
-            : $t('tooltips.switchToDarkMode')
-        }}</span>
+        <span v-if="clientSettings.darkMode === 'auto'">
+          {{ $t('tooltips.switchToDarkMode') }}
+        </span>
+        <span v-else-if="clientSettings.darkMode">
+          {{ $t('tooltips.switchToLightMode') }}
+        </span>
+        <span v-else>
+          {{ $t('tooltips.switchToAuto') }}
+        </span>
       </template>
     </app-bar-button-layout>
     <!-- Uncomment when some of the remote play features are fully implemented -->
@@ -69,6 +73,19 @@ const { y } = useWindowScroll();
 const transparentAppBar = computed<boolean>(() => {
   return (route.meta.transparentLayout || false) && y.value < 10;
 });
+
+/**
+ * Cycle between the different color schemas
+ */
+function switchColorTheme(): void {
+  if (clientSettings.darkMode === 'auto') {
+    clientSettings.darkMode = true;
+  } else if (clientSettings.darkMode) {
+    clientSettings.darkMode = false;
+  } else {
+    clientSettings.darkMode = 'auto';
+  }
+}
 
 const navigationDrawer = inject<Ref<boolean>>('NavigationDrawer');
 </script>

--- a/frontend/src/components/Layout/AppBar/AppBarButtonLayout.vue
+++ b/frontend/src/components/Layout/AppBar/AppBarButtonLayout.vue
@@ -2,14 +2,13 @@
   <div class="ma-1">
     <v-btn
       class="align-self-center"
+      v-bind="$props"
       icon
       size="small"
-      :color="color"
-      variant="elevated"
-      :disabled="disabled">
+      variant="elevated">
       <slot name="icon" />
 
-      <v-tooltip location="bottom">
+      <v-tooltip v-if="$slots.tooltip" activator="parent" location="bottom">
         <slot name="tooltip" />
       </v-tooltip>
     </v-btn>

--- a/frontend/src/components/Layout/AppBar/Buttons/TaskManagerButton.vue
+++ b/frontend/src/components/Layout/AppBar/Buttons/TaskManagerButton.vue
@@ -59,13 +59,7 @@ interface TaskInfo {
   id: string;
 }
 
-const props = withDefaults(
-  defineProps<{
-    fab?: boolean;
-    timeout?: number;
-  }>(),
-  { timeout: 5000 }
-);
+defineProps<{ fab?: boolean }>();
 
 const menu = ref(false);
 const taskManager = taskManagerStore();
@@ -85,7 +79,7 @@ const runningTaskList = computed<TaskInfo[]>(() => {
           progress: t.progress,
           textKey: 'appbar.tasks.scanningLibrary',
           textParams: {
-            library: t.data || ''
+            library: t.data ?? ''
           },
           id: t.id
         };
@@ -98,23 +92,15 @@ const allCompleted = computed(() =>
   runningTaskList.value.every((t) => t.progress === 100)
 );
 
-const buttonColor = computed(() => {
-  return allCompleted.value ? 'success' : undefined;
-});
+const buttonColor = computed(() =>
+  allCompleted.value ? 'success' : undefined
+);
 
-const taskList = computed(() => {
-  return menu.value && allCompleted.value
-    ? frozenTaskList
-    : runningTaskList.value;
-});
+const taskList = computed(() =>
+  menu.value && allCompleted.value ? frozenTaskList : runningTaskList.value
+);
 
 const showButton = computed(() => taskList.value.length > 0);
-
-watch(
-  () => props.timeout,
-  () => (taskManager.timeout = props.timeout),
-  { immediate: true }
-);
 
 watch([menu, allCompleted], () => {
   if (menu.value && allCompleted.value) {

--- a/frontend/src/components/Layout/AppBar/Buttons/TaskManagerButton.vue
+++ b/frontend/src/components/Layout/AppBar/Buttons/TaskManagerButton.vue
@@ -37,7 +37,6 @@
                 task.progress === undefined || task.progress === 0
               "
               :model-value="task.progress"
-              rotate="-90"
               size="24" />
             <v-icon v-else>
               <i-mdi-check />

--- a/frontend/src/components/Layout/AppBar/Buttons/TaskManagerButton.vue
+++ b/frontend/src/components/Layout/AppBar/Buttons/TaskManagerButton.vue
@@ -7,12 +7,11 @@
     :transition="'slide-y-transition'"
     location="bottom"
     :z-index="500">
-    <!-- eslint-disable-next-line vue/no-template-shadow -->
-    <template #activator="{ props }">
+    <template #activator="{ props: menuProps }">
       <app-bar-button-layout
         :custom-listener="taskList.length > 0 ? menu : undefined"
         :color="buttonColor"
-        v-bind="props">
+        v-bind="menuProps">
         <template #icon>
           <v-progress-circular v-if="!buttonColor" indeterminate size="24" />
           <v-icon v-else>
@@ -49,7 +48,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch } from 'vue';
+import { ref, computed, watch, toRaw } from 'vue';
 import { taskManagerStore } from '@/store';
 import { TaskType } from '@/store/taskManager';
 
@@ -69,104 +68,57 @@ const props = withDefaults(
 );
 
 const menu = ref(false);
-const taskList = ref<TaskInfo[]>([]);
-const scheduledTimeout = ref(0);
 const taskManager = taskManagerStore();
+let frozenTaskList: readonly TaskInfo[] = [];
+const runningTaskList = computed<TaskInfo[]>(() => {
+  return taskManager.tasks.map((t) => {
+    switch (t.type) {
+      case TaskType.ConfigSync: {
+        return {
+          progress: t.progress,
+          textKey: 'appbar.tasks.configSync',
+          id: t.id
+        };
+      }
+      case TaskType.LibraryRefresh: {
+        return {
+          progress: t.progress,
+          textKey: 'appbar.tasks.scanningLibrary',
+          textParams: {
+            library: t.data || ''
+          },
+          id: t.id
+        };
+      }
+    }
+  });
+});
+
+const allCompleted = computed(() =>
+  runningTaskList.value.every((t) => t.progress === 100)
+);
 
 const buttonColor = computed(() => {
-  return taskList.value.every((task) => {
-    return task.progress === 100;
-  })
-    ? 'success'
-    : undefined;
+  return allCompleted.value ? 'success' : undefined;
+});
+
+const taskList = computed(() => {
+  return menu.value && allCompleted.value
+    ? frozenTaskList
+    : runningTaskList.value;
 });
 
 const showButton = computed(() => taskList.value.length > 0);
 
-/**
- *  Clear the tasks list
- */
-function clearState(): void {
-  taskList.value = [];
-}
-
-/**
- * Set a timeout to hide the button
- */
-function setTimeout(): void {
-  scheduledTimeout.value = window.setTimeout(clearState, props.timeout);
-}
-
-/**
- * Locally retrieve and parse the tasks list
- */
-function getTaskList(): void {
-  const list: Array<TaskInfo> = [];
-
-  for (const task of taskManager.tasks) {
-    switch (task.type) {
-      case TaskType.ConfigSync: {
-        list.push({
-          progress: undefined,
-          textKey: 'appbar.tasks.configSync',
-          id: task.id
-        });
-
-        break;
-      }
-      case TaskType.LibraryRefresh: {
-        list.push({
-          progress: task.progress,
-          textKey: 'appbar.tasks.scanningLibrary',
-          textParams: {
-            library: task.data || ''
-          },
-          id: task.id
-        });
-
-        break;
-      }
-    }
-  }
-
-  const taskIds = new Set(
-    list.map((task) => {
-      return task.id;
-    })
-  );
-  const finishedTasks: Array<TaskInfo> = [];
-
-  for (const task of taskList.value) {
-    if (!taskIds.has(task.id)) {
-      task.progress = 100;
-      finishedTasks.push(task);
-    }
-  }
-
-  taskList.value = [...list, ...finishedTasks];
-}
-
 watch(
-  taskManager.tasks,
-  () => {
-    getTaskList();
-  },
+  () => props.timeout,
+  () => (taskManager.timeout = props.timeout),
   { immediate: true }
 );
 
-watch(buttonColor, () => {
-  window.clearTimeout(scheduledTimeout.value);
-
-  if (buttonColor.value && !menu.value) {
-    setTimeout();
-  }
-});
-
-watch(menu, () => {
-  if (menu.value) {
-    window.clearTimeout(scheduledTimeout.value);
-  } else if (buttonColor.value) {
-    setTimeout();
+watch([menu, allCompleted], () => {
+  if (menu.value && allCompleted.value) {
+    frozenTaskList = Object.freeze([...toRaw(runningTaskList.value)]);
   }
 });
 </script>

--- a/frontend/src/components/Layout/HomeSection.vue
+++ b/frontend/src/components/Layout/HomeSection.vue
@@ -11,7 +11,8 @@
 
 <script setup lang="ts">
 import { computed } from 'vue';
-import { HomeSection, userLibrariesStore } from '@/store';
+import { userLibrariesStore } from '@/store';
+import type { HomeSection } from '@/store/userLibraries';
 
 const props = defineProps<{ section: HomeSection }>();
 

--- a/frontend/src/components/Playback/OsdPlayer.vue
+++ b/frontend/src/components/Playback/OsdPlayer.vue
@@ -123,8 +123,11 @@ import {
   useMagicKeys,
   whenever
 } from '@vueuse/core';
-import { playbackManagerStore, playerElementStore } from '@/store';
-import { mediaControls } from '@/store/playbackManager';
+import {
+  playbackManagerStore,
+  playerElementStore,
+  mediaControls
+} from '@/store';
 
 const emit = defineEmits<{
   (e: 'toggleFullscreen'): void;

--- a/frontend/src/components/Playback/PlayerElement.vue
+++ b/frontend/src/components/Playback/PlayerElement.vue
@@ -29,13 +29,16 @@ import { computed, watch, nextTick } from 'vue';
 import { isNil } from 'lodash-es';
 import { useI18n } from 'vue-i18n';
 import Hls, { ErrorData, ErrorTypes, Events } from 'hls.js';
-import { playbackManagerStore, playerElementStore } from '@/store';
+import {
+  playbackManagerStore,
+  playerElementStore,
+  mediaElementRef
+} from '@/store';
 import { getImageInfo } from '@/utils/images';
 import { useSnackbar } from '@/composables';
 /**
  * Playback won't work in development until https://github.com/vuejs/core/pull/7593 is fixed
  */
-import { mediaElementRef } from '@/store/playbackManager';
 
 const playbackManager = playbackManagerStore();
 const playerElement = playerElementStore();

--- a/frontend/src/components/System/LocaleSwitcher.vue
+++ b/frontend/src/components/System/LocaleSwitcher.vue
@@ -19,23 +19,33 @@
     </template>
     <v-list class="overflow-y-auto">
       <v-list-item
-        v-for="(item, index) in $i18n.availableLocales"
+        :value="clientSettings.locale === 'auto'"
+        :title="$t('auto')"
+        @click="clientSettings.locale = 'auto'" />
+      <v-divider />
+      <v-list-item
+        v-for="(item, index) in availableLocales"
         :key="index"
-        :value="item === $i18n.locale"
-        @click="clientSettings.locale = item">
-        <v-list-item-title>{{ localeNames[item] }}</v-list-item-title>
-      </v-list-item>
+        :value="item === i18n.locale.value"
+        :title="languageMap[item]"
+        @click="clientSettings.locale = item" />
     </v-list>
   </v-menu>
 </template>
 
 <script setup lang="ts">
-import { mergeProps } from 'vue';
+import { mergeProps, computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { clientSettingsStore } from '@/store';
 
+type Locales = keyof ReturnType<typeof useI18n>['localeNames'];
+
+const i18n = useI18n();
+const languageMap = i18n.localeNames;
 const clientSettings = clientSettingsStore();
-const localeNames = useI18n().localeNames;
+const availableLocales = computed<Locales[]>(
+  () => Object.keys(languageMap) as Array<Locales>
+);
 
 defineProps<{
   bottom?: boolean;

--- a/frontend/src/composables/use-responsive-classes.ts
+++ b/frontend/src/composables/use-responsive-classes.ts
@@ -1,4 +1,6 @@
-import { useDisplay } from 'vuetify';
+import { useVuetify } from '.';
+
+const display = useVuetify().display;
 
 /**
  * Returns an additional class based on current Vuetify breakpoint.
@@ -15,7 +17,6 @@ import { useDisplay } from 'vuetify';
  * when the mobile breakpoint is active.
  */
 export function useResponsiveClasses(classes: string): string {
-  const display = useDisplay();
   let out = `${classes}`;
 
   if (display.lg.value) {

--- a/frontend/src/pages/index.vue
+++ b/frontend/src/pages/index.vue
@@ -26,7 +26,7 @@ import { useI18n } from 'vue-i18n';
 import { useRoute } from 'vue-router';
 import { CardShapes, getShapeFromCollectionType } from '@/utils/items';
 import { clientSettingsStore, userLibrariesStore } from '@/store';
-import type { HomeSection } from '@/store';
+import type { HomeSection } from '@/store/userLibraries';
 
 const VALID_SECTIONS = new Set([
   'resume',

--- a/frontend/src/pages/playback/video/index.vue
+++ b/frontend/src/pages/playback/video/index.vue
@@ -17,8 +17,11 @@ meta:
 <script lang="ts" setup>
 import { onBeforeUnmount, onMounted, ref } from 'vue';
 import { useFullscreen } from '@vueuse/core';
-import { playbackManagerStore, playerElementStore } from '@/store';
-import { mediaElementRef } from '@/store/playbackManager';
+import {
+  playbackManagerStore,
+  playerElementStore,
+  mediaElementRef
+} from '@/store';
 
 const playbackManager = playbackManagerStore();
 const playerElement = playerElementStore();

--- a/frontend/src/plugins/i18n.ts
+++ b/frontend/src/plugins/i18n.ts
@@ -6,15 +6,6 @@ import messages from '@intlify/unplugin-vue-i18n/messages';
  * See @/store/clientSettings to check where the current user language is initialised
  */
 
-const DEFAULT_LANGUAGE = 'en-US';
-
-const i18n = createI18n({
-  fallbackLocale: DEFAULT_LANGUAGE,
-  globalInjection: true,
-  legacy: false,
-  messages
-});
-
 /* eslint sort-keys: "error" */
 export const languageMap = {
   am: 'አማርኛ',
@@ -70,6 +61,15 @@ export const languageMap = {
   'zh-TW': '繁體中文'
 };
 /* eslint sort-keys: "off" */
+
+const DEFAULT_LANGUAGE = 'en-US';
+
+const i18n = createI18n({
+  fallbackLocale: DEFAULT_LANGUAGE,
+  globalInjection: true,
+  legacy: false,
+  messages
+});
 
 // @ts-expect-error - This is the only place where we need to assign the localeNames variable.
 // Assigning it somewhere else should be completely restricted

--- a/frontend/src/plugins/remote/axios/index.ts
+++ b/frontend/src/plugins/remote/axios/index.ts
@@ -3,7 +3,7 @@
  */
 import { BaseItemDto } from '@jellyfin/sdk/lib/generated-client';
 import axios, { AxiosError, AxiosResponse } from 'axios';
-import RemotePluginAuthInstance from '../auth';
+import remote from '../auth';
 import { itemsStore } from '@/store';
 import { useSnackbar, usei18n } from '@/composables';
 
@@ -26,10 +26,8 @@ class JellyfinInterceptors {
           items.add(i)
         );
       } else if (
-        RemotePluginAuthInstance.currentUser &&
-        response.config.url?.includes(
-          `/Users/${RemotePluginAuthInstance.currentUser?.Id}/Items/`
-        )
+        remote.currentUser &&
+        response.config.url?.includes(`/Users/${remote.currentUser?.Id}/Items/`)
       ) {
         response.data = items.add(data);
       }
@@ -45,10 +43,10 @@ class JellyfinInterceptors {
   public async logoutInterceptor(error: AxiosError): Promise<never | void> {
     if (
       error.response?.status === 401 &&
-      RemotePluginAuthInstance.currentUser &&
+      remote.currentUser &&
       !error.config.url?.includes('/Sessions/Logout')
     ) {
-      await RemotePluginAuthInstance.logoutCurrentUser(true);
+      await remote.logoutCurrentUser(true);
       useSnackbar(usei18n().t('login.kickedOut'), 'error');
     }
 

--- a/frontend/src/plugins/remote/socket/index.ts
+++ b/frontend/src/plugins/remote/socket/index.ts
@@ -52,12 +52,10 @@ class RemotePluginSocket {
     return destr(data.value) as WebSocketMessage | null;
   }
   public get messageType(): WebSocketMessage['MessageType'] | undefined {
-    return this.message && this.message.MessageType
-      ? this.message.MessageType
-      : undefined;
+    return this.message?.MessageType ?? undefined;
   }
   public get messageData(): WebSocketMessage['Data'] | undefined {
-    return this.message && this.message.Data ? this.message.Data : undefined;
+    return this.message?.Data ?? undefined;
   }
 
   /**

--- a/frontend/src/plugins/remote/socket/index.ts
+++ b/frontend/src/plugins/remote/socket/index.ts
@@ -11,7 +11,7 @@ import { WebSocketMessage } from './types';
  */
 function formatSocketMessage(
   name: string,
-  data?: Record<string, unknown>
+  data?: WebSocketMessage['Data']
 ): string {
   const message: WebSocketMessage = { MessageType: name };
 

--- a/frontend/src/plugins/remote/socket/index.ts
+++ b/frontend/src/plugins/remote/socket/index.ts
@@ -5,8 +5,6 @@ import { computed, watch } from 'vue';
 import auth from '../auth';
 import sdk from '../sdk';
 import { WebSocketMessage } from './types';
-import { RunningTask, TaskType } from '@/store/taskManager';
-import { itemsStore, taskManagerStore } from '@/store';
 
 /**
  * Formats the message to be sent to the socket
@@ -43,24 +41,24 @@ const socketUrl = computed(() => {
 });
 
 const { data, send } = useWebSocket(socketUrl, {
-  heartbeat: { message: formatSocketMessage('KeepAlive') },
+  heartbeat: false,
   autoReconnect: { retries: () => true },
   immediate: true,
   autoClose: false
 });
 
 class RemotePluginSocket {
-  public message = computed<WebSocketMessage | undefined>(() => {
-    const m = destr(data) as WebSocketMessage;
-
-    return typeof m.MessageType === 'string' ? m : undefined;
-  });
-  public messageType = computed<WebSocketMessage['MessageType'] | undefined>(
-    () => this.message.value?.MessageType
-  );
-  public messageData = computed<WebSocketMessage['Data'] | undefined>(
-    () => this.message.value?.Data
-  );
+  public get message(): WebSocketMessage | null {
+    return destr(data.value) as WebSocketMessage | null;
+  }
+  public get messageType(): WebSocketMessage['MessageType'] | undefined {
+    return this.message && this.message.MessageType
+      ? this.message.MessageType
+      : undefined;
+  }
+  public get messageData(): WebSocketMessage['Data'] | undefined {
+    return this.message && this.message.Data ? this.message.Data : undefined;
+  }
 
   /**
    * Send message to socket
@@ -74,79 +72,14 @@ class RemotePluginSocket {
   }
 
   public constructor() {
-    watch(this.message, () => {
-      const items = itemsStore();
-      const taskManager = taskManagerStore();
-      let itemsToUpdate: string[];
-
-      switch (this.messageType.value) {
-        case 'ForceKeepAlive': {
-          /**
-           * Although we poll the WebSocket through useWebSocket, the server
-           * might force us to do a KeepAlive.
-           */
+    watch(
+      () => this.message,
+      () => {
+        if (this.messageType === 'ForceKeepAlive') {
           this.sendToSocket('KeepAlive');
-          break;
-        }
-        case 'LibraryChanged': {
-          // Update items when metadata changes
-          // @ts-expect-error -- The Data property doesn't describe its content
-          itemsToUpdate = messageData.ItemsUpdated.filter((itemId: string) => {
-            return Object.keys(items.byId).includes(itemId);
-          });
-
-          items.updateStoreItems(itemsToUpdate);
-          break;
-        }
-        case 'UserDataChanged': {
-          // Update items when their userdata is changed (like, mark as watched, etc)
-          // @ts-expect-error -- The Data property doesn't describe its content
-          itemsToUpdate = messageData.UserDataList.filter(
-            (updatedData: never) => {
-              // @ts-expect-error -- There are no typings for websocket returned data.
-              const itemId = updatedData.ItemId as string;
-
-              return Object.keys(items.byId).includes(itemId);
-            }
-          ).map((updatedData: never) => {
-            // @ts-expect-error -- There are no typings for websocket returned data.
-            return updatedData.ItemId as string;
-          });
-
-          items.updateStoreItems(itemsToUpdate);
-          break;
-        }
-        case 'RefreshProgress': {
-          // TODO: Verify all the different tasks that this message may belong to - here we assume libraries.
-
-          // @ts-expect-error - No typings for this
-          const progress = Number.parseInt(messageData.Progress);
-          // @ts-expect-error - No typings for this
-          const taskPayload = taskManager.getTask(messageData.ItemId || '');
-          const payload: RunningTask = {
-            type: TaskType.LibraryRefresh,
-            // @ts-expect-error - No typings for this
-            id: messageData.ItemId as string,
-            progress
-          };
-
-          if (taskPayload !== undefined) {
-            if (progress >= 0 && progress < 100) {
-              payload.data = taskPayload.data;
-              taskManager.updateTask(payload);
-            } else if (progress >= 0) {
-              // @ts-expect-error - No typings for this
-              taskManager.finishTask(messageData.ItemId);
-            }
-          }
-
-          break;
-        }
-        default: {
-          break;
         }
       }
-    });
+    );
   }
 }
 

--- a/frontend/src/plugins/remote/socket/index.ts
+++ b/frontend/src/plugins/remote/socket/index.ts
@@ -11,7 +11,7 @@ import { WebSocketMessage } from './types';
  */
 function formatSocketMessage(
   name: string,
-  data?: Record<string, never>
+  data?: Record<string, unknown>
 ): string {
   const message: WebSocketMessage = { MessageType: name };
 
@@ -51,12 +51,6 @@ class RemotePluginSocket {
   public get message(): WebSocketMessage | null {
     return destr(data.value) as WebSocketMessage | null;
   }
-  public get messageType(): WebSocketMessage['MessageType'] | undefined {
-    return this.message?.MessageType ?? undefined;
-  }
-  public get messageData(): WebSocketMessage['Data'] | undefined {
-    return this.message?.Data ?? undefined;
-  }
 
   /**
    * Send message to socket
@@ -73,7 +67,7 @@ class RemotePluginSocket {
     watch(
       () => this.message,
       () => {
-        if (this.messageType === 'ForceKeepAlive') {
+        if (this.message?.MessageType === 'ForceKeepAlive') {
           this.sendToSocket('KeepAlive');
         }
       }

--- a/frontend/src/plugins/remote/socket/types.d.ts
+++ b/frontend/src/plugins/remote/socket/types.d.ts
@@ -1,6 +1,6 @@
 export interface WebSocketMessage {
   MessageType: string;
-  Data?: Record<string, never>;
+  Data?: Record<string, unknown>;
 }
 
-export type WebSocketMessageData = Record<string, never> | number | undefined;
+export type WebSocketMessageData = Record<string, unknown> | number | undefined;

--- a/frontend/src/plugins/remote/socket/types.d.ts
+++ b/frontend/src/plugins/remote/socket/types.d.ts
@@ -1,6 +1,4 @@
 export interface WebSocketMessage {
   MessageType: string;
-  Data?: Record<string, unknown>;
+  Data?: Record<string, unknown> | number;
 }
-
-export type WebSocketMessageData = Record<string, unknown> | number | undefined;

--- a/frontend/src/store/globals.ts
+++ b/frontend/src/store/globals.ts
@@ -1,0 +1,24 @@
+import { ref } from 'vue';
+import { useMediaControls, useNow, useScroll } from '@vueuse/core';
+/**
+ * This file contains global variables (specially VueUse refs) that are used multiple times across the client.
+ * VueUse composables will set new event handlers, so it's more
+ * efficient to reuse those, both in components and TS files.
+ */
+
+/**
+ * Reactive Date.now() instance
+ */
+export const now = useNow();
+/**
+ * Reactive window scroll
+ */
+export const windowScroll = useScroll(window);
+/**
+ * Ref to the local media player
+ */
+export const mediaElementRef = ref<HTMLMediaElement>();
+/**
+ * Reactive media controls of the local media player
+ */
+export const mediaControls = useMediaControls(mediaElementRef);

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -47,6 +47,10 @@ export function playerElementStore(): typeof playerElement {
   return playerElement;
 }
 
-export type { HomeSection } from './userLibraries';
-export { TaskType } from './taskManager';
-export * from './playbackManager';
+/**
+ * Please, leave this export as the only wildcard export
+ *
+ * Properties and types relevant to each store should be imported from the store
+ * directly to avoid polluting the global store namespace.
+ */
+export * from './globals';

--- a/frontend/src/store/items.ts
+++ b/frontend/src/store/items.ts
@@ -220,34 +220,34 @@ class ItemsStore {
 
         const { MessageType, Data } = remote.socket.message;
 
-        if (Data) {
-          if (
-            MessageType === 'LibraryChanged' &&
-            Array.isArray(Data.ItemsUpdated)
-          ) {
-            // Update items when metadata changes
-            const itemsToUpdate = Data.ItemsUpdated.filter((itemId: string) => {
-              return Object.keys(this._state.byId).includes(itemId);
-            });
+        if (!Data) {
+          return;
+        }
 
-            this.updateStoreItems(itemsToUpdate);
-          } else if (
-            MessageType === 'UserDataChanged' &&
-            Array.isArray(Data.UserDataList)
-          ) {
-            // Update items when their userdata is changed (like, mark as watched, etc)
-            const itemsToUpdate = Data.UserDataList.filter(
-              (updatedData: any) => {
-                const itemId = updatedData.ItemId ?? '';
+        if (
+          MessageType === 'LibraryChanged' &&
+          Array.isArray(Data.ItemsUpdated)
+        ) {
+          // Update items when metadata changes
+          const itemsToUpdate = Data.ItemsUpdated.filter((itemId: string) => {
+            return Object.keys(this._state.byId).includes(itemId);
+          });
 
-                return Object.keys(this._state.byId).includes(itemId);
-              }
-            ).map((updatedData: any) => {
-              return updatedData.ItemId;
-            });
+          this.updateStoreItems(itemsToUpdate);
+        } else if (
+          MessageType === 'UserDataChanged' &&
+          Array.isArray(Data.UserDataList)
+        ) {
+          // Update items when their userdata is changed (like, mark as watched, etc)
+          const itemsToUpdate = Data.UserDataList.filter((updatedData: any) => {
+            const itemId = updatedData.ItemId ?? '';
 
-            this.updateStoreItems(itemsToUpdate);
-          }
+            return Object.keys(this._state.byId).includes(itemId);
+          }).map((updatedData: any) => {
+            return updatedData.ItemId;
+          });
+
+          this.updateStoreItems(itemsToUpdate);
         }
       }
     );

--- a/frontend/src/store/items.ts
+++ b/frontend/src/store/items.ts
@@ -1,4 +1,4 @@
-import { computed, reactive, watch } from 'vue';
+import { reactive, watch } from 'vue';
 import { cloneDeep } from 'lodash-es';
 import { BaseItemDto, ItemFields } from '@jellyfin/sdk/lib/generated-client';
 import { getItemsApi } from '@jellyfin/sdk/lib/utils/api/items-api';
@@ -30,46 +30,42 @@ class ItemsStore {
    * == GETTERS ==
    */
   public getItemById = (id: string | undefined): BaseItemDto | undefined => {
-    return computed(() => (id ? state.byId[id] : undefined)).value;
+    return id ? state.byId[id] : undefined;
   };
 
   public getItemsById = (ids: string[]): BaseItemDto[] => {
-    return computed(() => {
-      const res: BaseItemDto[] = [];
+    const res: BaseItemDto[] = [];
 
-      for (const index of ids) {
-        const item = state.byId[index];
+    for (const index of ids) {
+      const item = state.byId[index];
 
-        if (!item) {
-          throw new Error(`Item ${index} doesn't exist in the store`);
-        }
-
-        res.push(item);
+      if (!item) {
+        throw new Error(`Item ${index} doesn't exist in the store`);
       }
 
-      return res;
-    }).value;
+      res.push(item);
+    }
+
+    return res;
   };
 
   public getChildrenOfParent = (
     id: string | undefined
   ): BaseItemDto[] | undefined => {
-    return computed(() => {
-      if (!id) {
-        throw new Error('No itemId provided');
+    if (!id) {
+      throw new Error('No itemId provided');
+    }
+
+    const res: BaseItemDto[] = [];
+    const ids = state.collectionById[id];
+
+    if (ids?.length) {
+      for (const _id of ids) {
+        res.push(state.byId[_id]);
       }
 
-      const res: BaseItemDto[] = [];
-      const ids = state.collectionById[id];
-
-      if (ids?.length) {
-        for (const _id of ids) {
-          res.push(state.byId[_id]);
-        }
-
-        return res;
-      }
-    }).value;
+      return res;
+    }
   };
 
   /**

--- a/frontend/src/store/playbackManager.ts
+++ b/frontend/src/store/playbackManager.ts
@@ -103,12 +103,6 @@ interface PlaybackManagerState {
  */
 const progressReportInterval = 3500;
 const remote = useRemote();
-/**
- * Previously, we created a new MediaMetadata every time the item changed. However,
- * that made the MediaSession controls disappear for a second. Keeping the metadata
- * as a global variable and updating it solves this problem.
- */
-const mediaMetadata = new MediaMetadata();
 
 /**
  * == CLASS CONSTRUCTOR ==
@@ -147,6 +141,12 @@ class PlaybackManagerStore {
   /**
    * == GETTERS AND SETTERS ==
    */
+  /**
+   * Previously, we created a new MediaMetadata every time the item changed. However,
+   * that made the MediaSession controls disappear for a second. Keeping the metadata
+   * as a global variable and updating it solves this problem.
+   */
+  private _mediaMetadata = new MediaMetadata();
   public get status(): PlaybackStatus {
     return this._state.status;
   }
@@ -532,7 +532,7 @@ class PlaybackManagerStore {
       window.navigator.mediaSession.metadata = remove
         ? // eslint-disable-next-line unicorn/no-null
           null
-        : mediaMetadata;
+        : this._mediaMetadata;
     }
   };
 
@@ -541,10 +541,10 @@ class PlaybackManagerStore {
    */
   private _updateMediaSessionMetadata = (): void => {
     if (this.status !== PlaybackStatus.Stopped && !isNil(this.currentItem)) {
-      mediaMetadata.title = this.currentItem.Name || '';
-      mediaMetadata.artist = this.currentItem.AlbumArtist || '';
-      mediaMetadata.album = this.currentItem.Album || '';
-      mediaMetadata.artwork = [
+      this._mediaMetadata.title = this.currentItem.Name || '';
+      this._mediaMetadata.artist = this.currentItem.AlbumArtist || '';
+      this._mediaMetadata.album = this.currentItem.Album || '';
+      this._mediaMetadata.artwork = [
         {
           src:
             getImageInfo(this.currentItem, {
@@ -589,10 +589,10 @@ class PlaybackManagerStore {
         }
       ];
     } else {
-      mediaMetadata.title = '';
-      mediaMetadata.artist = '';
-      mediaMetadata.album = '';
-      mediaMetadata.artwork = [];
+      this._mediaMetadata.title = '';
+      this._mediaMetadata.artist = '';
+      this._mediaMetadata.album = '';
+      this._mediaMetadata.artwork = [];
     }
   };
 

--- a/frontend/src/store/playbackManager.ts
+++ b/frontend/src/store/playbackManager.ts
@@ -1219,47 +1219,43 @@ class PlaybackManagerStore {
         }
       }
     );
+
+    const remote = useRemote();
+
+    /**
+     * Dispose on logout
+     */
+    watch(
+      () => remote.auth.currentUser,
+      () => {
+        if (isNil(remote.auth.currentUser)) {
+          playbackManager.stop();
+        }
+      }
+    );
+
+    watch(mediaControls.playing, () => {
+      if (playbackManager.status !== PlaybackStatus.Buffering) {
+        state.status = mediaControls.playing.value
+          ? PlaybackStatus.Playing
+          : PlaybackStatus.Paused;
+      }
+    });
+
+    watch(mediaControls.waiting, () => {
+      state.status = mediaControls.waiting.value
+        ? PlaybackStatus.Buffering
+        : PlaybackStatus.Playing;
+    });
+
+    watch(mediaControls.ended, () => {
+      if (mediaControls.ended.value) {
+        playbackManager.setNextTrack();
+      }
+    });
   }
 }
 
 const playbackManager = new PlaybackManagerStore();
-
-/**
- * == WATCHERS ==
- */
-
-const remote = useRemote();
-
-/**
- * Dispose on logout
- */
-watch(
-  () => remote.auth.currentUser,
-  () => {
-    if (isNil(remote.auth.currentUser)) {
-      playbackManager.stop();
-    }
-  }
-);
-
-watch(mediaControls.playing, () => {
-  if (playbackManager.status !== PlaybackStatus.Buffering) {
-    state.status = mediaControls.playing.value
-      ? PlaybackStatus.Playing
-      : PlaybackStatus.Paused;
-  }
-});
-
-watch(mediaControls.waiting, () => {
-  state.status = mediaControls.waiting.value
-    ? PlaybackStatus.Buffering
-    : PlaybackStatus.Playing;
-});
-
-watch(mediaControls.ended, () => {
-  if (mediaControls.ended.value) {
-    playbackManager.setNextTrack();
-  }
-});
 
 export default playbackManager;

--- a/frontend/src/store/playbackManager.ts
+++ b/frontend/src/store/playbackManager.ts
@@ -4,7 +4,7 @@
  * It must be used in an agnostic way to cover both local and remote playback.
  * If you want to handle the state of the local player element, use playerElement store instead.
  */
-import { reactive, ref, watch } from 'vue';
+import { reactive, watch } from 'vue';
 import { shuffle, isNil, cloneDeep } from 'lodash-es';
 import {
   BaseItemDto,
@@ -22,7 +22,10 @@ import { getItemsApi } from '@jellyfin/sdk/lib/utils/api/items-api';
 import { getTvShowsApi } from '@jellyfin/sdk/lib/utils/api/tv-shows-api';
 import { getPlaystateApi } from '@jellyfin/sdk/lib/utils/api/playstate-api';
 import { getMediaInfoApi } from '@jellyfin/sdk/lib/utils/api/media-info-api';
-import { useMediaControls, useNow } from '@vueuse/core';
+/**
+ * It's important to import these from globals.ts directly to avoid cycles and ReferenceError
+ */
+import { now as reactiveDate, mediaControls } from './globals';
 import { itemsStore } from '.';
 import { usei18n, useRemote, useSnackbar } from '@/composables';
 import { getImageInfo } from '@/utils/images';
@@ -99,9 +102,6 @@ interface PlaybackManagerState {
  * Amount of time to wait between playback reports
  */
 const progressReportInterval = 3500;
-const reactiveDate = useNow();
-export const mediaElementRef = ref<HTMLMediaElement>();
-export const mediaControls = useMediaControls(mediaElementRef);
 const remote = useRemote();
 /**
  * Previously, we created a new MediaMetadata every time the item changed. However,

--- a/frontend/src/store/playbackManager.ts
+++ b/frontend/src/store/playbackManager.ts
@@ -127,6 +127,7 @@ const state = reactive<PlaybackManagerState>(cloneDeep(defaultState));
 const reactiveDate = useNow();
 export const mediaElementRef = ref<HTMLMediaElement>();
 export const mediaControls = useMediaControls(mediaElementRef);
+const remote = useRemote();
 /**
  * Previously, we created a new MediaMetadata every time the item changed. However,
  * that made the MediaSession controls disappear for a second. Keeping the metadata
@@ -602,8 +603,6 @@ class PlaybackManagerStore {
    * Report current item playback progress to server
    */
   private _reportPlaybackProgress = async (): Promise<void> => {
-    const remote = useRemote();
-
     if (!isNil(this.currentTime) && !isNil(this.currentItem)) {
       await remote.sdk.newUserApi(getPlaystateApi).reportPlaybackProgress({
         playbackProgressInfo: {
@@ -627,8 +626,6 @@ class PlaybackManagerStore {
     currentTime = this.currentTime,
     updateState = true
   ): Promise<void> => {
-    const remote = useRemote();
-
     await remote.sdk.newUserApi(getPlaystateApi).reportPlaybackStopped({
       playbackStopInfo: {
         ItemId: itemId,
@@ -646,8 +643,6 @@ class PlaybackManagerStore {
    * Report playback start to the server. Used by the "Now playing" statistics in other clients.
    */
   private _reportPlaybackStart = async (itemId: string): Promise<void> => {
-    const remote = useRemote();
-
     await remote.sdk.newUserApi(getPlaystateApi).reportPlaybackStart({
       playbackStartInfo: {
         CanSeek: true,
@@ -853,8 +848,6 @@ class PlaybackManagerStore {
     this.currentVolume = volume;
 
     window.setTimeout(async () => {
-      const remote = useRemote();
-
       try {
         if (sessionId && itemId && time && remote.auth.currentUser) {
           await this._reportPlaybackStopped(itemId, sessionId, time, false);
@@ -936,8 +929,6 @@ class PlaybackManagerStore {
     audioStreamIndex = this.currentAudioStreamIndex,
     subtitleStreamIndex = this.currentSubtitleStreamIndex
   ): Promise<PlaybackInfoResponse | undefined> => {
-    const remote = useRemote();
-
     if (item) {
       return (
         await remote.sdk.newUserApi(getMediaInfoApi).getPostedPlaybackInfo({
@@ -956,8 +947,6 @@ class PlaybackManagerStore {
   public getItemPlaybackUrl = (
     mediaSource = this.currentMediaSource
   ): string | undefined => {
-    const remote = useRemote();
-
     if (
       mediaSource?.SupportsDirectStream &&
       mediaSource.Type &&
@@ -993,7 +982,6 @@ class PlaybackManagerStore {
     item: BaseItemDto,
     shuffle = false
   ): Promise<string[]> => {
-    const remote = useRemote();
     let responseItems: BaseItemDto[] = [];
 
     if (item.Type === 'Program' && item.ChannelId) {
@@ -1219,8 +1207,6 @@ class PlaybackManagerStore {
         }
       }
     );
-
-    const remote = useRemote();
 
     /**
      * Dispose on logout

--- a/frontend/src/store/userLibraries.ts
+++ b/frontend/src/store/userLibraries.ts
@@ -280,23 +280,21 @@ class UserLibrariesStore {
   public clear = (): void => {
     Object.assign(state.value, defaultState);
   };
+
+  public constructor() {
+    const remote = useRemote();
+
+    watch(
+      () => remote.auth.currentUser,
+      () => {
+        if (!remote.auth.currentUser) {
+          userLibraries.clear();
+        }
+      }
+    );
+  }
 }
 
 const userLibraries = new UserLibrariesStore();
-
-/**
- * == WATCHERS ==
- */
-
-const remote = useRemote();
-
-watch(
-  () => remote.auth.currentUser,
-  () => {
-    if (!remote.auth.currentUser) {
-      userLibraries.clear();
-    }
-  }
-);
 
 export default userLibraries;

--- a/frontend/src/store/userLibraries.ts
+++ b/frontend/src/store/userLibraries.ts
@@ -14,6 +14,9 @@ import { CardShapes } from '@/utils/items';
 import { usei18n, useRemote, useSnackbar } from '@/composables';
 import { mergeExcludingUnknown } from '@/utils/data-manipulation';
 
+/**
+ * == INTERFACES AND TYPES ==
+ */
 interface LatestMedia {
   [key: string]: BaseItemDto[];
 }
@@ -41,43 +44,49 @@ interface UserLibrariesState {
 }
 
 /**
- * == STATE VARIABLES ==
+ * == UTILITY VARIABLES ==
  */
 const storeKey = 'userLibraries';
-const defaultState: UserLibrariesState = {
-  views: [],
-  homeSections: {
-    audioResumes: [],
-    videoResumes: [],
-    upNext: [],
-    latestMedia: {}
-  },
-  carouselItems: [],
-  isReady: false
-};
 
-const state: RemovableRef<UserLibrariesState> = useStorage(
-  storeKey,
-  cloneDeep(defaultState),
-  sessionStorage,
-  {
-    mergeDefaults: (storageValue, defaults) =>
-      mergeExcludingUnknown(storageValue, defaults)
-  }
-);
-
+/**
+ * == CLASS CONSTRUCTOR ==
+ */
 class UserLibrariesStore {
   /**
-   * == GETTERS ==
+   * == STATE ==
    */
-  public get libraries(): typeof state.value.views {
-    return state.value.views;
+  private _defaultState: UserLibrariesState = {
+    views: [],
+    homeSections: {
+      audioResumes: [],
+      videoResumes: [],
+      upNext: [],
+      latestMedia: {}
+    },
+    carouselItems: [],
+    isReady: false
+  };
+
+  private _state: RemovableRef<UserLibrariesState> = useStorage(
+    storeKey,
+    cloneDeep(this._defaultState),
+    sessionStorage,
+    {
+      mergeDefaults: (storageValue, defaults) =>
+        mergeExcludingUnknown(storageValue, defaults)
+    }
+  );
+  /**
+   * == GETTERS AND SETTERS==
+   */
+  public get libraries(): typeof this._state.value.views {
+    return this._state.value.views;
   }
-  public get isReady(): typeof state.value.isReady {
-    return state.value.isReady;
+  public get isReady(): typeof this._state.value.isReady {
+    return this._state.value.isReady;
   }
-  public get carouselItems(): typeof state.value.carouselItems {
-    return state.value.carouselItems;
+  public get carouselItems(): typeof this._state.value.carouselItems {
+    return this._state.value.carouselItems;
   }
 
   public getHomeSectionContent = (section: HomeSection): BaseItemDto[] => {
@@ -87,16 +96,16 @@ class UserLibrariesStore {
           return this.libraries;
         }
         case 'resume': {
-          return state.value.homeSections.videoResumes;
+          return this._state.value.homeSections.videoResumes;
         }
         case 'resumeaudio': {
-          return state.value.homeSections.audioResumes;
+          return this._state.value.homeSections.audioResumes;
         }
         case 'upnext': {
-          return state.value.homeSections.upNext;
+          return this._state.value.homeSections.upNext;
         }
         case 'latestmedia': {
-          return state.value.homeSections.latestMedia[section.libraryId];
+          return this._state.value.homeSections.latestMedia[section.libraryId];
         }
         default: {
           return [];
@@ -125,7 +134,7 @@ class UserLibrariesStore {
           userId: remote.auth.currentUserId || ''
         });
 
-      state.value.views = userViewsResponse.data.Items || [];
+      this._state.value.views = userViewsResponse.data.Items || [];
     } catch (error) {
       this._onError(error);
     }
@@ -152,7 +161,7 @@ class UserLibrariesStore {
       ).data.Items;
 
       if (audioResumes) {
-        state.value.homeSections.audioResumes = audioResumes;
+        this._state.value.homeSections.audioResumes = audioResumes;
       }
     } catch (error) {
       this._onError(error);
@@ -180,7 +189,7 @@ class UserLibrariesStore {
       ).data.Items;
 
       if (videoResumes) {
-        state.value.homeSections.videoResumes = videoResumes;
+        this._state.value.homeSections.videoResumes = videoResumes;
       }
     } catch (error) {
       this._onError(error);
@@ -207,7 +216,7 @@ class UserLibrariesStore {
       ).data.Items;
 
       if (upNext) {
-        state.value.homeSections.upNext = upNext;
+        this._state.value.homeSections.upNext = upNext;
       }
     } catch (error) {
       this._onError(error);
@@ -233,7 +242,7 @@ class UserLibrariesStore {
         })
       ).data;
 
-      state.value.homeSections.latestMedia[libraryId] = latestMedia;
+      this._state.value.homeSections.latestMedia[libraryId] = latestMedia;
     } catch (error) {
       this._onError(error);
     }
@@ -254,7 +263,7 @@ class UserLibrariesStore {
       ).data;
 
       if (carouselItems) {
-        state.value.carouselItems = carouselItems;
+        this._state.value.carouselItems = carouselItems;
       }
     } catch (error) {
       this._onError(error);
@@ -274,11 +283,11 @@ class UserLibrariesStore {
       }
     }
 
-    state.value.isReady = true;
+    this._state.value.isReady = true;
   };
 
-  public clear = (): void => {
-    Object.assign(state.value, defaultState);
+  private _clear = (): void => {
+    Object.assign(this._state.value, this._defaultState);
   };
 
   public constructor() {
@@ -288,7 +297,7 @@ class UserLibrariesStore {
       () => remote.auth.currentUser,
       () => {
         if (!remote.auth.currentUser) {
-          userLibraries.clear();
+          this._clear();
         }
       }
     );

--- a/frontend/src/utils/store-sync.ts
+++ b/frontend/src/utils/store-sync.ts
@@ -132,12 +132,12 @@ export default async function preferencesSync<T>(
   const taskManager = taskManagerStore();
 
   if (!isNil(auth.currentUser)) {
-    try {
-      /**
-       * Creates a config syncing task, so UI can show that there's a syncing in progress
-       */
-      taskManager.startConfigSync();
+    /**
+     * Creates a config syncing task, so UI can show that there's a syncing in progress
+     */
+    const syncTaskId = taskManager.startConfigSync();
 
+    try {
       /**
        * The fetch part is done because DisplayPreferences doesn't accept partial updates
        * TODO: Revisit if we ever get PATCH support
@@ -155,7 +155,7 @@ export default async function preferencesSync<T>(
     } catch {
       useSnackbar(t('failedSettingDisplayPreferences'), 'error');
     } finally {
-      taskManager.stopConfigSync();
+      taskManager.finishTask(syncTaskId);
     }
   }
 }

--- a/frontend/src/utils/time.ts
+++ b/frontend/src/utils/time.ts
@@ -10,7 +10,8 @@ import {
 import { sumBy } from 'lodash-es';
 import { BaseItemDto } from '@jellyfin/sdk/lib/generated-client';
 import { computed, ComputedRef, isRef } from 'vue';
-import { MaybeRef, useNow } from '@vueuse/core';
+import { MaybeRef } from '@vueuse/core';
+import { now } from '@/store';
 import { useDateFns, usei18n } from '@/composables';
 
 /**
@@ -81,7 +82,7 @@ function getEndsAtDate(ticks: MaybeRef<number>): ComputedRef<Date> {
   return computed(() => {
     const ms = ticksToMs(isRef(ticks) ? ticks.value : ticks);
 
-    return addMilliseconds(useNow().value, ms);
+    return addMilliseconds(now.value, ms);
   });
 }
 

--- a/frontend/types/global/plugins.d.ts
+++ b/frontend/types/global/plugins.d.ts
@@ -1,6 +1,8 @@
 import 'vue-router';
 // eslint-disable-next-line no-restricted-imports
 import { RemotePlugin } from '@/plugins/remote/types';
+// eslint-disable-next-line no-restricted-imports
+import { languageMap } from '@/plugins/i18n';
 import 'vue-i18n';
 
 /**
@@ -32,7 +34,7 @@ declare module 'vue-i18n' {
     /**
      * An array of the locale codes that matches the locale name
      */
-    readonly localeNames: Record<string, string>;
+    readonly localeNames: typeof languageMap;
   }
 }
 


### PR DESCRIPTION
* Fix websocket messages watching
* Improve items reactivity to some degree (only playbackManager items are fully reactive for now)
* Locate all the watchers of stores inside the class constructor.
* Move all the handling of websocket messages to the relevant store (the websocket store no longer handles tasks, item updates, etc... Those are handled by the taskManager and items stores instead).
* Fix the display preferences watching.