### PR TITLE
More refactors and cleanups

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -95,6 +95,15 @@ module.exports = {
     'promise/no-return-in-finally': 'error',
     'promise/prefer-await-to-callbacks': 'error',
     'promise/prefer-await-to-then': 'error',
+    '@typescript-eslint/ban-ts-comment': [
+      'error',
+      {
+        'ts-expect-error': true,
+        'ts-ignore': true,
+        'ts-nocheck': true,
+        'ts-check': true
+      }
+    ],
     '@typescript-eslint/explicit-function-return-type': 'error',
     '@typescript-eslint/prefer-ts-expect-error': 'error',
     '@typescript-eslint/explicit-member-accessibility': 'error',

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -80,7 +80,7 @@
     "prettier": "2.7.1",
     "rollup-plugin-visualizer": "5.8.1",
     "sass": "1.54.9",
-    "typescript": "4.8.2",
+    "typescript": "5.0.2",
     "unplugin-icons": "0.15.3",
     "unplugin-vue-components": "0.22.9",
     "unplugin-vue-router": "0.2.3",

--- a/frontend/src/components/Buttons/Playback/PlaybackSettingsButton.vue
+++ b/frontend/src/components/Buttons/Playback/PlaybackSettingsButton.vue
@@ -8,8 +8,7 @@
       <tooltip-button
         class="align-self-center"
         v-bind="menu"
-        :tooltip="{ text: $t('playbackSettings'), location: 'top' }"
-        :icon="{ icon: true }">
+        :tooltip="{ text: $t('playbackSettings'), location: 'top' }">
         <v-icon>
           <i-mdi-cog />
         </v-icon>

--- a/frontend/src/components/Forms/AddServerForm.vue
+++ b/frontend/src/components/Forms/AddServerForm.vue
@@ -10,15 +10,14 @@
         autofocus
         :label="$t('login.serverAddress')"
         type="url"
-        :rules="rules"
-        required />
+        :rules="rules" />
       <v-row align="center" no-gutters>
         <v-col v-if="previousServerLength" class="mr-2">
           <v-btn
             block
             size="large"
             variant="elevated"
-            @click="$router.push('/server/select')">
+            @click="router.push('/server/select')">
             {{ $t('login.changeServer') }}
           </v-btn>
         </v-col>

--- a/frontend/src/components/Item/ItemMenu.vue
+++ b/frontend/src/components/Item/ItemMenu.vue
@@ -287,9 +287,9 @@ function onActivatorClick(): void {
 }
 
 onMounted(() => {
-  const parentHtml = parent?.subTree.el as HTMLElement;
+  const parentHtml = parent?.subTree.el;
 
-  if (parentHtml) {
+  if (parentHtml instanceof HTMLElement) {
     useEventListener(parentHtml, 'contextmenu', onRightClick);
   }
 });

--- a/frontend/src/components/Item/Metadata/DateInput.vue
+++ b/frontend/src/components/Item/Metadata/DateInput.vue
@@ -3,14 +3,13 @@
     v-model="menu"
     :close-on-content-click="false"
     transition="scale-transition">
-    <template #activator="{ on, attrs }">
+    <template #activator="{ props }">
       <v-text-field
         :model-value="value"
         :label="label"
+        v-bind="props"
         readonly
-        variant="outlined"
-        v-bind="attrs"
-        v-on="on" />
+        variant="outlined" />
     </template>
     <!-- TODO: Wait for Vuetify 3 implementation (https://github.com/vuetifyjs/vuetify/issues/13480) -->
     <!-- <v-date-picker :value="value" @change="handleChange" /> -->

--- a/frontend/src/components/Item/Metadata/ImageSearch.vue
+++ b/frontend/src/components/Item/Metadata/ImageSearch.vue
@@ -3,7 +3,7 @@
     :model-value="dialog"
     :fullscreen="$vuetify.display.mobile"
     content-class="image-search-dialog-content"
-    @update:model-value="(value) => emit('update:dialog', value)">
+    @update:model-value="(value: boolean) => emit('update:dialog', value)">
     <v-card height="100%" class="image-search-card">
       <v-card-title>{{ t('search.name') }}</v-card-title>
       <v-divider />

--- a/frontend/src/components/Item/Metadata/MetadataEditor.vue
+++ b/frontend/src/components/Item/Metadata/MetadataEditor.vue
@@ -96,7 +96,7 @@
             hide-selected
             multiple
             variant="outlined"
-            @update:search="(s) => (search = s)">
+            @update:search="(s: string) => (search = s)">
             <template #no-data>
               <v-list-item>
                 <v-list-item-title>
@@ -112,7 +112,7 @@
             hide-selected
             multiple
             variant="outlined"
-            @update:search="(s) => (search = s)">
+            @update:search="(s: string) => (search = s)">
             <template #no-data>
               <v-list-item>
                 <v-list-item-title>

--- a/frontend/src/components/Item/SeasonTabs.vue
+++ b/frontend/src/components/Item/SeasonTabs.vue
@@ -72,6 +72,10 @@ const seasonEpisodes = ref<TvShowItem['seasonEpisodes']>({});
  * Fetch component data
  */
 async function fetch(): Promise<void> {
+  if (!props.item.Id) {
+    return;
+  }
+
   seasons.value = (
     await remote.sdk.newUserApi(getTvShowsApi).getSeasons({
       userId: remote.auth.currentUserId,

--- a/frontend/src/components/Layout/AppBar/AppBar.vue
+++ b/frontend/src/components/Layout/AppBar/AppBar.vue
@@ -49,12 +49,7 @@
       </template>
     </app-bar-button-layout>
     <!-- Uncomment when some of the remote play features are fully implemented -->
-    <!-- <cast-button
-      :fab="
-        !(!transparentLayout || $vuetify.display.xsOnly) &&
-        !page.isScrolled
-      "
-    /> -->
+    <!-- <cast-button /> -->
     <user-button />
     <locale-switcher elevated />
   </v-app-bar>

--- a/frontend/src/components/Layout/AppBar/Buttons/CastButton.vue
+++ b/frontend/src/components/Layout/AppBar/Buttons/CastButton.vue
@@ -4,17 +4,14 @@
     :close-on-content-click="false"
     :transition="'slide-y-transition'"
     location="bottom"
-    :nudge-bottom="nudgeBottom"
-    offset-y
     min-width="25em"
     max-width="25em"
     min-height="25em"
     max-height="25em"
     :z-index="500"
     class="menu">
-    <!-- eslint-disable-next-line vue/no-template-shadow -->
-    <template #activator="{ on: menu, attrs }">
-      <app-bar-button-layout :custom-listener="menu" v-bind="attrs" disabled>
+    <template #activator="{ props }">
+      <app-bar-button-layout v-bind="props" disabled>
         <template #icon>
           <v-icon>
             <i-mdi-cast />
@@ -67,16 +64,6 @@
 <script setup lang="ts">
 import { ref } from 'vue';
 import supportedFeatures from '@/utils/supported-features';
-
-withDefaults(
-  defineProps<{
-    fab?: boolean;
-    nudgeBottom?: number;
-  }>(),
-  {
-    nudgeBottom: 5
-  }
-);
 
 const menu = ref(false);
 

--- a/frontend/src/components/Layout/AudioControls.vue
+++ b/frontend/src/components/Layout/AudioControls.vue
@@ -67,7 +67,7 @@
             <like-button
               :item="playbackManager.currentItem"
               class="active-button" />
-            <queue-button nudge-top="35" />
+            <queue-button />
             <div class="hidden-lg-and-down">
               <volume-slider />
             </div>

--- a/frontend/src/components/Layout/Carousel/Item/ItemsCarousel.vue
+++ b/frontend/src/components/Layout/Carousel/Item/ItemsCarousel.vue
@@ -16,7 +16,7 @@
             :key="`${item.Id}-image`"
             :item="getRelatedItem(item)"
             :type="ImageType.Backdrop"
-            :icon-size="$vuetify.display.mdAndUp ? '256' : '128'" />
+            :width="$vuetify.display.mdAndUp ? 256 : 128" />
         </div>
         <div :class="useResponsiveClasses('slide-content')">
           <v-container

--- a/frontend/src/components/Layout/Carousel/Item/ItemsCarouselTitle.vue
+++ b/frontend/src/components/Layout/Carousel/Item/ItemsCarouselTitle.vue
@@ -3,10 +3,11 @@
     <router-link v-if="logo && logo.tag && logoLink" :to="logoLink">
       <v-img
         class="mb-2"
-        :max-width="$vuetify.display.mdAndUp ? '50%' : '40%'"
-        :max-height="$vuetify.display.smAndUp ? '7.5em' : '4em'"
-        contain
         data-swiper-parallax="-300"
+        :style="{
+          'max-width': $vuetify.display.mdAndUp ? '50%' : '40%',
+          'max-height': $vuetify.display.smAndUp ? '7.5em' : '4em'
+        }"
         :src="logo.url" />
     </router-link>
     <router-link

--- a/frontend/src/components/Layout/Images/UserImage.vue
+++ b/frontend/src/components/Layout/Images/UserImage.vue
@@ -3,7 +3,7 @@
     <v-img :src="url" :width="size" cover>
       <template #placeholder>
         <v-avatar color="primary" :size="size">
-          <v-icon :size="iconSize" dark>
+          <v-icon :size="iconSize">
             <i-mdi-account />
           </v-icon>
         </v-avatar>

--- a/frontend/src/components/Layout/Images/__tests__/BlurhashCanvas.spec.ts
+++ b/frontend/src/components/Layout/Images/__tests__/BlurhashCanvas.spec.ts
@@ -14,35 +14,26 @@ beforeEach(() => {
 
 describe('component: BlurhashCanvas', () => {
   it('has a hash property of type String', () => {
-    // @ts-expect-error - props are not defined in the Vue type.
     expect(wrapper.vm.$options.props.hash).toBeDefined();
-    // @ts-expect-error - props are not defined in the Vue type.
     expect(wrapper.vm.$options.props.hash.type).toBe(String);
   });
 
   it('has a width property of type Number', () => {
-    // @ts-expect-error - props are not defined in the Vue type.
     expect(wrapper.vm.$options.props.width).toBeDefined();
-    // @ts-expect-error - props are not defined in the Vue type.
     expect(wrapper.vm.$options.props.width.type).toBe(Number);
   });
 
   it('has a height property of type Number', () => {
-    // @ts-expect-error - props are not defined in the Vue type.
     expect(wrapper.vm.$options.props.height).toBeDefined();
-    // @ts-expect-error - props are not defined in the Vue type.
     expect(wrapper.vm.$options.props.height.type).toBe(Number);
   });
 
   it('has a punch property of type Number', () => {
-    // @ts-expect-error - props are not defined in the Vue type.
     expect(wrapper.vm.$options.props.punch).toBeDefined();
-    // @ts-expect-error - props are not defined in the Vue type.
     expect(wrapper.vm.$options.props.punch.type).toBe(Number);
   });
 
   it('requires a hash', () => {
-    // @ts-expect-error - props are not defined in the Vue type.
     expect(wrapper.vm.$options.props.hash.required).toBeTruthy();
   });
 

--- a/frontend/src/components/Layout/SwiperSection.vue
+++ b/frontend/src/components/Layout/SwiperSection.vue
@@ -65,9 +65,9 @@ const props = withDefaults(
     loading?: boolean;
     title: string;
     items: BaseItemDto[];
-    shape: string;
+    shape?: CardShapes;
   }>(),
-  { loading: false, shape: '' }
+  { loading: false, shape: undefined }
 );
 
 const cardShape = ref<string>(

--- a/frontend/src/components/System/AboutLinks.vue
+++ b/frontend/src/components/System/AboutLinks.vue
@@ -4,8 +4,8 @@
       <v-list-item
         v-for="linkItem in linkItems"
         :key="linkItem.name"
-        rel="noreferrer noopener"
         :href="linkItem.link"
+        rel="noreferrer noopener"
         target="_blank">
         <template #prepend>
           <v-avatar>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -48,8 +48,12 @@ await router.isReady();
  * Without window.setTimeout and window.requestAnimationFrame, the
  * splash screen gets frozen an small (but noticeable) amount of time.
  */
-const appDOM = document.querySelector('#app') as HTMLDivElement;
-const splashDOM = document.querySelector('.splashBackground') as HTMLDivElement;
+const appDOM = document.querySelector('#app');
+const splashDOM = document.querySelector('.splashBackground');
+
+if (!appDOM || !splashDOM) {
+  throw new Error('could not locate app div or splash div in DOM');
+}
 
 /**
  * Once we reach this point, the bundle and the app will be completely loaded and mounted,

--- a/frontend/src/pages/genre/_itemId/index.vue
+++ b/frontend/src/pages/genre/_itemId/index.vue
@@ -1,6 +1,9 @@
 <template>
   <div>
-    <v-app-bar fixed flat dense :class="useResponsiveClasses('second-toolbar')">
+    <v-app-bar
+      flat
+      density="compact"
+      :class="useResponsiveClasses('second-toolbar')">
       <span class="text-h6 hidden-sm-and-down">
         {{ genre.Name }}
       </span>

--- a/frontend/src/pages/index.vue
+++ b/frontend/src/pages/index.vue
@@ -21,19 +21,11 @@
 
 <script setup lang="ts">
 import { computed, onMounted } from 'vue';
-import { pickBy } from 'lodash-es';
 import { useI18n } from 'vue-i18n';
 import { useRoute } from 'vue-router';
 import { CardShapes, getShapeFromCollectionType } from '@/utils/items';
-import { clientSettingsStore, userLibrariesStore } from '@/store';
+import { userLibrariesStore } from '@/store';
 import type { HomeSection } from '@/store/userLibraries';
-
-const VALID_SECTIONS = new Set([
-  'resume',
-  'resumeaudio',
-  'upnext',
-  'latestmedia'
-]);
 
 const { t } = useI18n();
 const route = useRoute();
@@ -42,7 +34,6 @@ route.meta.title = t('home');
 route.meta.transparentLayout = true;
 
 const userLibraries = userLibrariesStore();
-const clientSettings = clientSettingsStore();
 
 /**
  * Items are fetched at logon when switching between the 'fullpage' and 'default' layout. With the help of the
@@ -62,29 +53,13 @@ onMounted(async () => {
 });
 
 const homeSections = computed<HomeSection[]>(() => {
-  // Filter for valid sections in Jellyfin Vue
-  // TODO: Implement custom section order
-  const homeSectionPrefs = pickBy(
-    // @ts-expect-error - No typings for this
-    clientSettings.CustomPrefs as { [key: string]: string },
-    (value, key) => {
-      return (
-        value && VALID_SECTIONS.has(value) && key.startsWith('homesection')
-      );
-    }
-  );
-
-  const homeSectionKeys = Object.keys(homeSectionPrefs);
-
-  if (homeSectionKeys.length === 0) {
-    homeSectionKeys.push(
-      'librarytiles',
-      'resume',
-      'resumeaudio',
-      'upnext',
-      'latestmedia'
-    );
-  }
+  const homeSectionKeys = [
+    'librarytiles',
+    'resume',
+    'resumeaudio',
+    'upnext',
+    'latestmedia'
+  ];
 
   const homeSections: HomeSection[] = [];
 

--- a/frontend/src/pages/library/_itemId/index.vue
+++ b/frontend/src/pages/library/_itemId/index.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <v-app-bar dense flat>
+    <v-app-bar density="compact" flat>
       <span class="text-h6 hidden-sm-and-down">
         {{ library?.Name }}
       </span>

--- a/frontend/src/pages/playback/video/index.vue
+++ b/frontend/src/pages/playback/video/index.vue
@@ -175,15 +175,16 @@ function toggleFullscreen(): void {
     fullscreen.toggle();
   } else if (
     !fullscreen.isSupported.value &&
-    // @ts-expect-error - Property 'webkitEnterFullScreen' does not exist on type 'HTMLMediaElement'
-    mediaElementRef.value?.webkitEnterFullScreen
+    // webkit properties do not exist in all browsers
+    mediaElementRef.value &&
+    'webkitEnterFullScreen' in mediaElementRef.value &&
+    typeof mediaElementRef.value.webkitEnterFullScreen === 'function'
   ) {
     /**
      * Use case for iOS where the fullscreen methods on non <video> elements aren't supported
      */
     // TODO - if entering FS this way, SSA subs won't display. So we should trigger a new encode
-    // @ts-expect-error - Property 'webkitEnterFullScreen' does not exist on type 'HTMLMediaElement'
-    mediaElementRef.value?.webkitEnterFullScreen();
+    mediaElementRef.value.webkitEnterFullScreen();
   }
 }
 

--- a/frontend/src/pages/settings/devices.vue
+++ b/frontend/src/pages/settings/devices.vue
@@ -11,9 +11,9 @@
         {{ t('settings.devices.deleteAll') }}
       </v-btn>
       <v-btn
-        rel="noreferrer noopener"
         variant="elevated"
         href="https://jellyfin.org/docs/general/server/devices.html"
+        rel="noreferrer noopener"
         target="_blank">
         {{ t('settings.help') }}
       </v-btn>

--- a/frontend/src/pages/settings/index.vue
+++ b/frontend/src/pages/settings/index.vue
@@ -7,12 +7,7 @@
             !isEmpty(systemInfo) &&
             $remote.auth.currentUser?.Policy?.IsAdministrator
           ">
-          <v-img
-            class="logo"
-            contain
-            src="/icon.png"
-            height="100px"
-            :alt="$t('jellyfinLogo')" />
+          <v-img class="logo" src="/icon.png" :alt="$t('jellyfinLogo')" />
           <v-table class="mb-4 pb-2 information">
             <tbody>
               <tr>
@@ -285,5 +280,6 @@ const adminSections = computed(() => {
 
 .logo {
   background: rgb(var(--v-theme-card));
+  height: 100px;
 }
 </style>

--- a/frontend/src/plugins/i18n.ts
+++ b/frontend/src/plugins/i18n.ts
@@ -71,8 +71,7 @@ const i18n = createI18n({
   messages
 });
 
-// @ts-expect-error - This is the only place where we need to assign the localeNames variable.
-// Assigning it somewhere else should be completely restricted
-i18n.global.localeNames = languageMap;
+// `localeNames` is readonly but this is the one place it should actually be set
+(i18n.global.localeNames as typeof languageMap) = languageMap;
 
 export default i18n;

--- a/frontend/src/plugins/remote/auth/index.ts
+++ b/frontend/src/plugins/remote/auth/index.ts
@@ -40,28 +40,35 @@ class RemotePluginAuth {
   public get servers(): ServerInfo[] {
     return state.value.servers;
   }
+
   public get currentServer(): ServerInfo | undefined {
     return state.value.servers[state.value.currentServerIndex];
   }
+
   public get currentUser(): UserDto | undefined {
     return state.value.users[state.value.currentUserIndex];
   }
+
   public get currentUserId(): string | undefined {
     return this.currentUser?.Id;
   }
+
   public get currentUserToken(): string | undefined {
     return this.getUserAccessToken(this.currentUser);
   }
+
   public readonly getUserAccessToken = (
     user: UserDto | undefined
   ): string | undefined => {
     return user?.Id ? state.value.accessTokens[user.Id] : undefined;
   };
+
   public readonly getServerById = (
     serverId: string | undefined | null
   ): ServerInfo | undefined => {
     return state.value.servers.find((server) => server.Id === serverId);
   };
+
   public readonly getUsersFromServer = (
     server: ServerInfo | undefined
   ): UserDto[] | undefined => {
@@ -139,6 +146,7 @@ class RemotePluginAuth {
       throw new Error('Server version is too low');
     }
   }
+
   /**
    * Logs the user to the current server
    *
@@ -188,6 +196,7 @@ class RemotePluginAuth {
       }
     }
   }
+
   /**
    * Logs out the user from the server using the current base url and access token parameters.
    *
@@ -200,6 +209,7 @@ class RemotePluginAuth {
       state.value.currentUserIndex = -1;
     }
   }
+
   /**
    * Logs out an user from its server
    *
@@ -214,23 +224,26 @@ class RemotePluginAuth {
   ): Promise<void> {
     try {
       if (!skipRequest) {
-        useOneTimeAPI(
+        await useOneTimeAPI(
           server.PublicAddress,
           this.getUserAccessToken(user)
         ).logout();
       }
-    } finally {
-      const storeUser = state.value.users.find((u) => u.Id === user.Id);
+    } catch (error) {
+      console.error(error);
+    }
 
-      if (!isNil(storeUser)) {
-        state.value.users.splice(state.value.users.indexOf(storeUser), 1);
-      }
+    const storeUser = state.value.users.find((u) => u.Id === user.Id);
 
-      if (!isNil(user.Id)) {
-        delete state.value.accessTokens[user.Id];
-      }
+    if (!isNil(storeUser)) {
+      state.value.users.splice(state.value.users.indexOf(storeUser), 1);
+    }
+
+    if (!isNil(user.Id)) {
+      delete state.value.accessTokens[user.Id];
     }
   }
+
   /**
    * Logs out all the user sessions from the provided server and removes it from the store
    *

--- a/frontend/src/plugins/remote/index.ts
+++ b/frontend/src/plugins/remote/index.ts
@@ -27,7 +27,9 @@ export const remoteInstance = new RemotePlugin();
  * Installs the remote plugin into the Vue instance to enable the usage of
  * $remote to access all the tools for handling a Jellyfin server connection.
  */
-export default function createRemote(): { install: (app: App) => void } {
+export default function createRemote(): {
+  install: (app: App) => Promise<void>;
+} {
   return {
     install: async (app: App): Promise<void> => {
       app.config.globalProperties.$remote = remoteInstance;

--- a/frontend/src/plugins/remote/sdk/index.ts
+++ b/frontend/src/plugins/remote/sdk/index.ts
@@ -46,8 +46,8 @@ class RemotePluginSDK {
    * USE WITH CAUTION. Make sure this is only used in places where an user is logged in
    */
   public newUserApi<T>(apiSec: (api: Api) => T): T {
-    // @ts-expect-error - We want to explicitly assume the user is already logged in here
-    return apiSec(this.api);
+    // We want to explicitly assume the user is already logged in here
+    return apiSec(this.api as Api);
   }
 }
 

--- a/frontend/src/plugins/remote/sdk/index.ts
+++ b/frontend/src/plugins/remote/sdk/index.ts
@@ -20,7 +20,7 @@ class RemotePluginSDK {
     /**
      * Configure app's axios instance to perform requests to the given Jellyfin server.
      */
-    watchEffect(async () => {
+    watchEffect(() => {
       const server = auth.currentServer;
       const accessToken = auth.currentUserToken;
 

--- a/frontend/src/plugins/remote/socket/index.ts
+++ b/frontend/src/plugins/remote/socket/index.ts
@@ -49,7 +49,7 @@ const { data, send } = useWebSocket(socketUrl, {
 
 class RemotePluginSocket {
   public get message(): WebSocketMessage | null {
-    return destr(data.value) as WebSocketMessage | null;
+    return destr(data.value);
   }
 
   /**

--- a/frontend/src/plugins/remote/socket/types.d.ts
+++ b/frontend/src/plugins/remote/socket/types.d.ts
@@ -1,4 +1,4 @@
 export interface WebSocketMessage {
   MessageType: string;
-  Data?: Record<string, unknown> | number;
+  Data?: unknown;
 }

--- a/frontend/src/store/clientSettings.ts
+++ b/frontend/src/store/clientSettings.ts
@@ -7,7 +7,7 @@ import {
   watchPausable
 } from '@vueuse/core';
 import { cloneDeep } from 'lodash-es';
-import preferencesSync, { fetchSettingsFromServer } from '@/utils/store-sync';
+import { fetchDefaultedCustomPrefs, syncCustomPrefs } from '@/utils/store-sync';
 import { usei18n, useSnackbar, useRemote, useVuetify } from '@/composables';
 import { mergeExcludingUnknown } from '@/utils/data-manipulation';
 
@@ -131,7 +131,7 @@ class ClientSettingsStore {
      */
     const syncDataWatcher = watchPausable(this._state, async () => {
       if (remote.auth.currentUser) {
-        await preferencesSync(storeKey, this._state.value);
+        await syncCustomPrefs(storeKey, this._state.value);
       }
     });
 
@@ -143,7 +143,7 @@ class ClientSettingsStore {
       async () => {
         if (remote.auth.currentUser) {
           try {
-            const data = await fetchSettingsFromServer<ClientSettingsState>(
+            const data = await fetchDefaultedCustomPrefs(
               storeKey,
               this._state.value
             );

--- a/frontend/src/store/playbackManager.ts
+++ b/frontend/src/store/playbackManager.ts
@@ -984,8 +984,11 @@ class PlaybackManagerStore {
 
       const parameters = new URLSearchParams(directOptions).toString();
 
-      const mediaType =
-        mediaSource.Type === 'Audio' ? mediaSource.Type : 'Videos';
+      const mediaType = (mediaSource.MediaStreams ?? []).every(
+        (stream) => stream?.Type === 'Audio'
+      )
+        ? 'Audio'
+        : 'Videos';
 
       return `${remote.sdk.api?.basePath}/${mediaType}/${mediaSource.Id}/stream.${mediaSource.Container}?${parameters}`;
     } else if (mediaSource?.SupportsTranscoding && mediaSource.TranscodingUrl) {

--- a/frontend/src/store/playerElement.ts
+++ b/frontend/src/store/playerElement.ts
@@ -85,7 +85,7 @@ class PlayerElementStore {
     }
   };
 
-  private _setSsaTrack = async (trackSrc: string): Promise<void> => {
+  private _setSsaTrack = (trackSrc: string): void => {
     if (
       !jassub &&
       mediaElementRef.value &&

--- a/frontend/src/store/taskManager.ts
+++ b/frontend/src/store/taskManager.ts
@@ -158,8 +158,10 @@ class TaskManagerStore {
 
         if (
           MessageType === 'RefreshProgress' &&
-          Data.ItemId &&
-          typeof Data.ItemId === 'string'
+          'ItemId' in Data &&
+          typeof Data.ItemId === 'string' &&
+          'Progress' in Data &&
+          typeof Data.Progress === 'number'
         ) {
           // TODO: Verify all the different tasks that this message may belong to - here we assume libraries.
 

--- a/frontend/src/utils/external-config.ts
+++ b/frontend/src/utils/external-config.ts
@@ -1,12 +1,45 @@
-import destr from 'destr';
 import { isNil } from 'lodash-es';
 
 interface ExternalJSONConfig {
-  defaultServerURLs: Array<string>;
+  defaultServerURLs: string[];
   routerMode: 'hash' | 'history';
 }
 
 let externalConfig: ExternalJSONConfig | undefined;
+
+/**
+ * Asserts that the config parameter is a valid configuration shape
+ */
+function validateJsonConfig(
+  config: unknown
+): asserts config is ExternalJSONConfig {
+  if (typeof config !== 'object' || !config) {
+    throw new Error('Expected not null or defined config');
+  }
+
+  if (
+    !('defaultServerURLs' in config) ||
+    !Array.isArray(config.defaultServerURLs)
+  ) {
+    throw new Error('Expected defaultServerURLS array');
+  }
+
+  if (
+    config.defaultServerURLs.some(
+      (defaultServerURL) => typeof defaultServerURL !== 'string'
+    )
+  ) {
+    throw new Error('Expected defaultServerURLs to be a list of strings');
+  }
+
+  if (
+    !('routerMode' in config) ||
+    typeof config.routerMode !== 'string' ||
+    !['hash', 'history'].includes(config.routerMode)
+  ) {
+    throw new Error('Expected router mode to be either hash or history');
+  }
+}
 
 /**
  * Fetch configuration at runtime from the config.json file
@@ -14,9 +47,11 @@ let externalConfig: ExternalJSONConfig | undefined;
  */
 export async function getJSONConfig(): Promise<ExternalJSONConfig> {
   if (isNil(externalConfig)) {
-    externalConfig = destr(
-      JSON.stringify(await (await fetch('/config.json')).json())
-    ) as ExternalJSONConfig;
+    const loadedConfig = await (await fetch('/config.json')).json();
+
+    validateJsonConfig(loadedConfig);
+
+    externalConfig = loadedConfig;
   }
 
   return externalConfig;

--- a/frontend/src/utils/playback-profiles/helpers/codec-profiles.ts
+++ b/frontend/src/utils/playback-profiles/helpers/codec-profiles.ts
@@ -26,7 +26,17 @@ import {
 function getGlobalMaxVideoBitrate(): number | undefined {
   let isTizenFhd = false;
 
-  if (isTizen() && window.webapis) {
+  if (
+    isTizen() &&
+    'webapis' in window &&
+    typeof window.webapis === 'object' &&
+    window.webapis &&
+    'productinfo' in window.webapis &&
+    typeof window.webapis.productinfo === 'object' &&
+    window.webapis.productinfo &&
+    'isUdPanelSupported' in window.webapis.productinfo &&
+    typeof window.webapis.productinfo.isUdPanelSupported === 'function'
+  ) {
     isTizenFhd = !window.webapis.productinfo.isUdPanelSupported();
   }
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -21,7 +21,7 @@ import VueI18nPlugin from '@intlify/unplugin-vue-i18n/vite';
 import autoprefixer from 'autoprefixer';
 
 // https://vitejs.dev/config/
-export default defineConfig(async ({ mode }): Promise<UserConfig> => {
+export default defineConfig(({ mode }): UserConfig => {
   const config: UserConfig = {
     server: {
       host: '0.0.0.0',

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,7 @@
         "prettier": "2.7.1",
         "rollup-plugin-visualizer": "5.8.1",
         "sass": "1.54.9",
-        "typescript": "4.8.2",
+        "typescript": "5.0.2",
         "unplugin-icons": "0.15.3",
         "unplugin-vue-components": "0.22.9",
         "unplugin-vue-router": "0.2.3",
@@ -14475,16 +14475,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
-      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.2.tgz",
+      "integrity": "sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=12.20"
       }
     },
     "node_modules/ufo": {


### PR DESCRIPTION
- Refactor the store-sync code into smaller functions which can be composed better, even if only a few are used
- Adds much more explicit checks to satisfy static type checking for WebSocketMessage handling
- Added a parser for verifying the external config is the expected shape
- Add an eslint rule to ban `@ts-` directives, and replaces them with casts. This is minimally safer but prevents multiple unexpected errors from being hidden on a line.
- Upgrades typescript dependency to version 5
- A bunch of minor typefixes and teaks. This resolves almost every non-vuetify-bad-typing error.

Recommend reviewing commit by commit and with whitespace visualization disabled.