### PR TITLE
chore: update repository URL to fix NPM workspace

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jellyfin/jellyfin-vue/"
+    "url": "git+https://github.com/jellyfin/jellyfin-vue.git"
   },
   "license": "GPL-3.0-only",
   "author": "jellyfin-vue Contributors (https://github.com/jellyfin/jellyfin-vue/graphs/contributors)",


### PR DESCRIPTION
`npm i ` was not possible due to a workspace error.

An update for the repository URL in package.json fixed the issue and allowed two subfolders to be detected as workspaces.