### PR TITLE
fix: version selector not working

### DIFF
--- a/frontend/src/pages/item/_itemId/index.vue
+++ b/frontend/src/pages/item/_itemId/index.vue
@@ -145,6 +145,7 @@
                 <v-col class="px-0" :cols="12" :sm="10">
                   <media-stream-selector
                     v-if="currentSource.MediaStreams"
+                    :key="currentSource.Id || ''"
                     :media-streams="
                       getMediaStreams(currentSource.MediaStreams, 'Video')
                     "
@@ -162,6 +163,7 @@
                 <v-col class="px-0" :cols="12" :sm="10">
                   <media-stream-selector
                     v-if="currentSource.MediaStreams"
+                    :key="currentSource.Id || ''"
                     :media-streams="
                       getMediaStreams(currentSource.MediaStreams, 'Audio')
                     "
@@ -179,6 +181,7 @@
                 <v-col class="px-0" :cols="12" :sm="10">
                   <media-stream-selector
                     v-if="currentSource.MediaStreams"
+                    :key="currentSource.Id || ''"
                     :media-streams="
                       getMediaStreams(currentSource.MediaStreams, 'Subtitle')
                     "

--- a/frontend/src/pages/item/_itemId/index.vue
+++ b/frontend/src/pages/item/_itemId/index.vue
@@ -129,8 +129,8 @@
                     <template #selection="{ item: i }">
                       {{ i.value.Name }}
                     </template>
-                    <template #item="{ item: i }">
-                      {{ i.value.Name }}
+                    <template #item="{ item: i, props }">
+                      <v-list-item v-bind="props" :title="i.value.Name" />
                     </template>
                   </v-select>
                 </v-col>


### PR DESCRIPTION
Fixes #1931


NB: One problem I can see here is we are not resetting index of audio, video and subtitles. So, there might be a chance to have empty values while switching across versions here. I'm fairly new to vue, If you have any suggestion on how can I fix that, please let me know :sweat_smile: 