### PR TITLE
ui: only use episode name as subtitle

### DIFF
--- a/frontend/src/components/Layout/Carousel/Item/ItemsCarouselTitle.vue
+++ b/frontend/src/components/Layout/Carousel/Item/ItemsCarouselTitle.vue
@@ -34,13 +34,11 @@
 
 <script setup lang="ts">
 import { computed } from 'vue';
-import { useI18n } from 'vue-i18n';
 import { BaseItemDto, BaseItemKind } from '@jellyfin/sdk/lib/generated-client';
 import { getLogo } from '@/utils/images';
 import { getItemDetailsLink } from '@/utils/items';
 
 const props = defineProps<{ item: BaseItemDto }>();
-const { t } = useI18n();
 
 const logo = computed(() => getLogo(props.item));
 const itemLink = computed(() => getItemDetailsLink(props.item));
@@ -72,19 +70,11 @@ const logoLink = computed(() => {
 });
 
 const subtitle = computed(() => {
-  if (props.item.Type === BaseItemKind.MusicAlbum) {
-    return props.item.Name;
-  } else if (
-    props.item.Type === BaseItemKind.Episode &&
-    props.item.SeasonName &&
-    props.item.IndexNumber &&
-    props.item.Name
+  if (
+    props.item.Type === BaseItemKind.MusicAlbum ||
+    props.item.Type === BaseItemKind.Episode
   ) {
-    const episodeString = t('episodeNumber', {
-      episodeNumber: props.item.IndexNumber
-    });
-
-    return `${props.item.SeasonName} - ${episodeString}\n${props.item.Name}`;
+    return props.item.Name;
   }
 });
 </script>


### PR DESCRIPTION
This removes redundant text that could also be mixed up between metadata and application languages (before and after):

![print_screen_2023-04-07-14-50-02](https://user-images.githubusercontent.com/1619359/230614278-68f2394f-772a-471f-9066-4c802a11b55c.png)
![print_screen_2023-04-07-14-54-38](https://user-images.githubusercontent.com/1619359/230614276-b235bcc4-de1e-4301-bdea-5644a5e1acb1.png)
