### PR TITLE
ui: more library cards on big screens + slightly bigger font on home carousel

### DIFF
--- a/frontend/src/components/Item/ItemGrid.vue
+++ b/frontend/src/components/Item/ItemGrid.vue
@@ -107,4 +107,12 @@ withDefaults(
 .large-grid.xl .card-grid-container.xl {
   grid-template-columns: repeat(5, minmax(calc(100% / 5), 1fr));
 }
+
+.card-grid-container.xxl {
+  grid-template-columns: repeat(12, minmax(calc(100% / 12), 1fr));
+}
+
+.large-grid.xxl .card-grid-container.xxl {
+  grid-template-columns: repeat(6, minmax(calc(100% / 6), 1fr));
+}
 </style>

--- a/frontend/src/components/Item/MediaInfo.vue
+++ b/frontend/src/components/Item/MediaInfo.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="text--secondary">
+  <div>
     <span v-if="item.Type === 'Episode'">
       {{
         $t('seasonEpisodeAbbrev', {

--- a/frontend/src/components/Layout/Carousel/Item/ItemsCarouselTitle.vue
+++ b/frontend/src/components/Layout/Carousel/Item/ItemsCarouselTitle.vue
@@ -20,7 +20,7 @@
     <p
       v-if="subtitle"
       data-swiper-parallax="-200"
-      class="text-truncate text-subtitle-2">
+      class="text-truncate text-h6">
       {{ subtitle }}
     </p>
     <h2


### PR DESCRIPTION
fix #1924

* Display 12 cards on `xxl` screens (>1200px width) on the library page
* Slightly bigger font on home carousel titles. I haven't increased much due to text already be in rem and those handled by the browser.