### PR TITLE
refactor: use browser internationalization APIs and resolve locales at build time

### DIFF
--- a/frontend/locales/en-US.json
+++ b/frontend/locales/en-US.json
@@ -510,6 +510,7 @@
   "undefined": "Undefined",
   "unexpectedError": "Unexpected error",
   "unhandledException": "Unhandled exception",
+  "unknown": "Unknown",
   "units": {
     "bitrate": {
       "kbps": "{value} kbps",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,7 +30,6 @@
     "@jellyfin/sdk": "0.8.1",
     "@vueuse/components": "10.0.0",
     "@vueuse/core": "10.0.0",
-    "all-iso-language-codes": "1.0.12",
     "axios": "1.3.5",
     "blurhash": "2.0.5",
     "comlink": "4.4.1",
@@ -51,6 +50,7 @@
   "devDependencies": {
     "@iconify/json": "2.2.48",
     "@intlify/unplugin-vue-i18n": "0.10.0",
+    "@rollup/plugin-virtual": "3.0.1",
     "@types/dompurify": "3.0.1",
     "@types/lodash-es": "4.17.7",
     "@types/sortablejs": "1.15.1",

--- a/frontend/src/components/Item/MediaStreamSelector.vue
+++ b/frontend/src/components/Item/MediaStreamSelector.vue
@@ -22,7 +22,6 @@
 
 <script lang="ts" setup>
 import { ref, computed, watch } from 'vue';
-import { getName } from 'all-iso-language-codes';
 import { startCase } from 'lodash-es';
 import { MediaStream } from '@jellyfin/sdk/lib/generated-client';
 import { useI18n } from 'vue-i18n';
@@ -31,6 +30,7 @@ import IMdiSurroundSound31 from 'virtual:icons/mdi/surround-sound-3-1';
 import IMdiSurroundSound51 from 'virtual:icons/mdi/surround-sound-5-1';
 import IMdiSurroundSound71 from 'virtual:icons/mdi/surround-sound-7-1';
 import IMdiSurroundSound from 'virtual:icons/mdi/surround-sound';
+import { getLocaleName } from '@/utils/i18n';
 
 const props = withDefaults(
   defineProps<{
@@ -88,7 +88,8 @@ function getTrackIcon(
 function getTrackSubtitle(track: MediaStream): string | undefined {
   if ((props.type === 'Audio' || props.type === 'Subtitle') && track.Language) {
     return startCase(
-      getName(track.Language, locale.value.split('-')[0]) ?? t('undefined')
+      getLocaleName(track.Language, locale.value) ??
+        `${t('unknown')} (${track.Language})`
     );
   } else if (props.type === 'Audio' || props.type === 'Subtitle') {
     return t('undefined');

--- a/frontend/src/components/Item/MediaStreamSelector.vue
+++ b/frontend/src/components/Item/MediaStreamSelector.vue
@@ -22,7 +22,7 @@
 
 <script lang="ts" setup>
 import { ref, computed, watch } from 'vue';
-import { startCase } from 'lodash-es';
+import { upperFirst } from 'lodash-es';
 import { MediaStream } from '@jellyfin/sdk/lib/generated-client';
 import { useI18n } from 'vue-i18n';
 import IMdiSurroundSound20 from 'virtual:icons/mdi/surround-sound-2-0';
@@ -87,7 +87,7 @@ function getTrackIcon(
  */
 function getTrackSubtitle(track: MediaStream): string | undefined {
   if ((props.type === 'Audio' || props.type === 'Subtitle') && track.Language) {
-    return startCase(
+    return upperFirst(
       getLocaleName(track.Language, locale.value) ??
         `${t('unknown')} (${track.Language})`
     );

--- a/frontend/src/components/System/LocaleSwitcher.vue
+++ b/frontend/src/components/System/LocaleSwitcher.vue
@@ -18,10 +18,12 @@
           @click="clientSettings.locale = 'auto'" />
         <v-divider />
         <v-list-item
-          v-for="(item, index) in availableLocales"
+          v-for="(item, index) in i18n.availableLocales"
           :key="index"
           :value="item === i18n.locale.value"
-          :title="languageMap[item]"
+          :title="
+            startCase(getLocaleNativeName(item) ?? `${$t('unknown')} (${item})`)
+          "
           @click="clientSettings.locale = item" />
       </v-list>
     </v-menu>
@@ -29,18 +31,10 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
+import { startCase } from 'lodash-es';
 import { clientSettingsStore } from '@/store';
-
-type Locales = keyof ReturnType<typeof useI18n>['localeNames'];
-
-const i18n = useI18n();
-const languageMap = i18n.localeNames;
-const clientSettings = clientSettingsStore();
-const availableLocales = computed<Locales[]>(
-  () => Object.keys(languageMap) as Array<Locales>
-);
+import { getLocaleNativeName } from '@/utils/i18n';
 
 defineProps<{
   bottom?: boolean;
@@ -48,6 +42,9 @@ defineProps<{
   top?: boolean;
   elevated?: boolean;
 }>();
+
+const i18n = useI18n();
+const clientSettings = clientSettingsStore();
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/src/components/System/LocaleSwitcher.vue
+++ b/frontend/src/components/System/LocaleSwitcher.vue
@@ -22,7 +22,9 @@
           :key="index"
           :value="item === i18n.locale.value"
           :title="
-            startCase(getLocaleNativeName(item) ?? `${$t('unknown')} (${item})`)
+            upperFirst(
+              getLocaleNativeName(item) ?? `${$t('unknown')} (${item})`
+            )
           "
           @click="clientSettings.locale = item" />
       </v-list>
@@ -32,7 +34,7 @@
 
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n';
-import { startCase } from 'lodash-es';
+import { upperFirst } from 'lodash-es';
 import { clientSettingsStore } from '@/store';
 import { getLocaleNativeName } from '@/utils/i18n';
 

--- a/frontend/src/plugins/i18n.ts
+++ b/frontend/src/plugins/i18n.ts
@@ -6,62 +6,6 @@ import messages from '@intlify/unplugin-vue-i18n/messages';
  * See @/store/clientSettings to check where the current user language is initialised
  */
 
-/* eslint sort-keys: "error" */
-export const languageMap = {
-  am: 'አማርኛ',
-  ar: 'العربية',
-  be: 'беларуская мова',
-  ca: 'Català',
-  cs: 'Čeština',
-  de: 'Deutsch',
-  el: 'ελληνικά',
-  'en-US': 'English',
-  eo: 'Esperanto',
-  es: 'Español',
-  'es-419': 'Español (América Latina)',
-  et: 'Eesti keel',
-  fa: 'فارسی',
-  fi: 'Suomi',
-  fil: 'Pilipino',
-  'fr-FR': 'Français',
-  he: 'עברית',
-  hi: 'हिन्दी',
-  hu: 'Magyar',
-  id: 'Bahasa Indonesia',
-  it: 'Italiano',
-  ja: '日本語',
-  kk: 'қазақ тілі',
-  ko: '한국어',
-  lt: 'Lietuvių kalba',
-  ml: 'മലയാളം',
-  mn: 'Монгол хэл',
-  ms: 'بهاس ملايو‎',
-  my: 'မြန်မာဘာသာစကား',
-  'nb-NO': 'Norsk',
-  nl: 'Nederlands',
-  nn: 'Norsk Nynorsk',
-  pa: 'ਪੰਜਾਬੀ',
-  pl: 'Polski',
-  pt: 'Português',
-  'pt-BR': 'Português (Brasil)',
-  ro: 'Română',
-  ru: 'русский',
-  sk: 'Slovenčina',
-  sl: 'Slovenščina',
-  'sr-Latn': 'српски језик',
-  sv: 'Svenska',
-  sw: 'Kiswahili',
-  ta: 'தமிழ்',
-  th: 'ภาษาไทย',
-  tr: 'Türkçe',
-  uk: 'Українська',
-  ur: 'اردو',
-  vi: 'Tiếng Việt',
-  'zh-CN': '简体中文',
-  'zh-TW': '繁體中文'
-};
-/* eslint sort-keys: "off" */
-
 const DEFAULT_LANGUAGE = 'en-US';
 
 const i18n = createI18n({
@@ -70,8 +14,5 @@ const i18n = createI18n({
   legacy: false,
   messages: messages as I18nOptions['messages']
 });
-
-// `localeNames` is readonly but this is the one place it should actually be set
-(i18n.global.localeNames as typeof languageMap) = languageMap;
 
 export default i18n;

--- a/frontend/src/store/clientSettings.ts
+++ b/frontend/src/store/clientSettings.ts
@@ -15,13 +15,10 @@ import { mergeExcludingUnknown } from '@/utils/data-manipulation';
  * == INTERFACES AND TYPES ==
  * Casted typings for the CustomPrefs property of DisplayPreferencesDto
  */
-export type LocaleStateValues =
-  | keyof ReturnType<typeof usei18n>['localeNames']
-  | 'auto';
 
 interface ClientSettingsState {
   darkMode: 'auto' | boolean;
-  locale: LocaleStateValues;
+  locale: 'auto' | string;
 }
 
 /**
@@ -65,17 +62,16 @@ class ClientSettingsStore {
   /**
    * == GETTERS AND SETTERS ==
    */
-  public set locale(newVal: LocaleStateValues) {
-    if (newVal === 'auto') {
-      const i18n = usei18n();
+  public set locale(newVal: string) {
+    const i18n = usei18n();
 
-      this._state.value.locale = i18n.fallbackLocale.value as LocaleStateValues;
-    } else {
-      this._state.value.locale = newVal;
-    }
+    this._state.value.locale =
+      newVal === 'auto' || !(newVal in i18n.availableLocales)
+        ? String(i18n.fallbackLocale.value)
+        : newVal;
   }
 
-  public get locale(): LocaleStateValues {
+  public get locale(): string {
     return this._state.value.locale;
   }
 

--- a/frontend/src/store/clientSettings.ts
+++ b/frontend/src/store/clientSettings.ts
@@ -65,10 +65,12 @@ class ClientSettingsStore {
   public set locale(newVal: string) {
     const i18n = usei18n();
 
+    if (!i18n.availableLocales.includes(newVal) && newVal !== 'auto') {
+      throw new TypeError('This locale has not been registered');
+    }
+
     this._state.value.locale =
-      newVal === 'auto' || !(newVal in i18n.availableLocales)
-        ? String(i18n.fallbackLocale.value)
-        : newVal;
+      newVal === 'auto' ? String(i18n.fallbackLocale.value) : newVal;
   }
 
   public get locale(): string {

--- a/frontend/src/utils/i18n.ts
+++ b/frontend/src/utils/i18n.ts
@@ -1,0 +1,16 @@
+/**
+ * Given a locale code, return the language name of another locale
+ */
+export function getLocaleName(
+  fromCode: string,
+  toCode = 'en-US'
+): string | undefined {
+  return new Intl.DisplayNames([toCode], { type: 'language' }).of(fromCode);
+}
+
+/**
+ * Given a locale code, return the language name in that locale
+ */
+export function getLocaleNativeName(code: string): string | undefined {
+  return getLocaleName(code, code);
+}

--- a/frontend/types/global/plugins.d.ts
+++ b/frontend/types/global/plugins.d.ts
@@ -1,8 +1,6 @@
 import 'vue-router';
 // eslint-disable-next-line no-restricted-imports
 import { RemotePlugin } from '@/plugins/remote/types';
-// eslint-disable-next-line no-restricted-imports
-import { languageMap } from '@/plugins/i18n';
 import enUS from '@/../locales/en-US.json';
 import 'vue-i18n';
 
@@ -35,13 +33,6 @@ declare module 'vue' {
 }
 
 declare module 'vue-i18n' {
-  interface Composer {
-    /**
-     * An array of the locale codes that matches the locale name
-     */
-    readonly localeNames: typeof languageMap;
-  }
-
   type messages = typeof enUS;
   // eslint-disable-next-line @typescript-eslint/no-empty-interface
   export interface DefineLocaleMessage extends messages {}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,6 +1,7 @@
 /* eslint-disable import/no-nodejs-modules */
 import path, { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { readdirSync } from 'node:fs';
 /* eslint-enable import/no-nodejs-modules */
 import { defineConfig, UserConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
@@ -17,10 +18,52 @@ import {
   VueUseDirectiveResolver
 } from 'unplugin-vue-components/resolvers';
 import visualizer from 'rollup-plugin-visualizer';
+import virtual from '@rollup/plugin-virtual';
 import VueI18nPlugin from '@intlify/unplugin-vue-i18n/vite';
 import autoprefixer from 'autoprefixer';
+/**
+ * We need to match our locales to the date-fns ones for proper localization of dates.
+ * In order to reduce bundle size, we calculate here (at build time) only the locales that we
+ * have in our client, to include only those, instead of importing all of them.
+ *
+ * We expose them later as 'virtual:date-fns/locales' using @rollup/plugin-virtual
+ */
+import * as datefnslocales from 'date-fns/locale';
 
-// https://vitejs.dev/config/
+const dfnskeys = Object.keys(datefnslocales);
+const localeFilesFolder = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  './locales/**'
+);
+const localeFiles = readdirSync(localeFilesFolder.replace('**', ''));
+/**
+ * We need this due to the differences between the vue i18n and date-fns locales.
+ */
+const dfnsExports = localeFiles
+  .map((l) => l.replace('.json', ''))
+  .map((l) => {
+    const testStrings = l.split('-');
+    const lang = testStrings.join('');
+
+    /**
+     * - If the i18n locale exactly matches the date-fns one
+     * - Removes the potential dash to match for instance "en-US" from i18n to "enUS" for date-fns.
+     * We also need to remove all the hyphens, as using named exports with them is not valid JS syntax
+     */
+    if (dfnskeys.includes(l) || dfnskeys.includes(lang)) {
+      return lang;
+      /**
+       * Takes the part before the potential hyphen to try, for instance "fr-FR" in i18n to "fr"
+       */
+    } else if (dfnskeys.includes(testStrings[0])) {
+      return `${testStrings[0]} as ${lang}`;
+    }
+  })
+  .filter((l): l is string => typeof l === 'string');
+/**
+ * End of date-fns locale parsing
+ */
+
 export default defineConfig(({ mode }): UserConfig => {
   const config: UserConfig = {
     server: {
@@ -31,6 +74,11 @@ export default defineConfig(({ mode }): UserConfig => {
       __COMMIT_HASH__: JSON.stringify(process.env.COMMIT_HASH || '')
     },
     plugins: [
+      virtual({
+        'virtual:date-fns/locales': `export { ${dfnsExports.join(
+          ', '
+        )} } from 'date-fns/locale'`
+      }),
       /**
        * We're mixing both vite-plugin-pages and unplugin-vue-router because
        * there are issues with layouts and unplugin-vue-router is experimental:
@@ -103,10 +151,7 @@ export default defineConfig(({ mode }): UserConfig => {
         compositionOnly: true,
         fullInstall: false,
         forceStringify: true,
-        include: resolve(
-          dirname(fileURLToPath(import.meta.url)),
-          './locales/**'
-        )
+        include: localeFilesFolder
       })
     ],
     build: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "@jellyfin/sdk": "0.8.1",
         "@vueuse/components": "10.0.0",
         "@vueuse/core": "10.0.0",
-        "all-iso-language-codes": "1.0.12",
         "axios": "1.3.5",
         "blurhash": "2.0.5",
         "comlink": "4.4.1",
@@ -46,6 +45,7 @@
       "devDependencies": {
         "@iconify/json": "2.2.48",
         "@intlify/unplugin-vue-i18n": "0.10.0",
+        "@rollup/plugin-virtual": "3.0.1",
         "@types/dompurify": "3.0.1",
         "@types/lodash-es": "4.17.7",
         "@types/sortablejs": "1.15.1",
@@ -1223,6 +1223,23 @@
         "url": "https://opencollective.com/unts"
       }
     },
+    "node_modules/@rollup/plugin-virtual": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-virtual/-/plugin-virtual-3.0.1.tgz",
+      "integrity": "sha512-fK8O0IL5+q+GrsMLuACVNk2x21g3yaw+sG2qn16SnUd3IlBsQyvWxLMGHmCmXRMecPjGRSZ/1LmZB4rjQm68og==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rollup/pluginutils": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.2.tgz",
@@ -2394,11 +2411,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
-    },
-    "node_modules/all-iso-language-codes": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/all-iso-language-codes/-/all-iso-language-codes-1.0.12.tgz",
-      "integrity": "sha512-nHyzqfHgyyRrKJyh0RW+xgdBiuwAQqNlZ7VC3tph+ndE5yL9WaCyDaofOYmQkeeIBKV6YyrQu6IzjsUIHxZi+Q=="
     },
     "node_modules/ansi-align": {
       "version": "3.0.1",


### PR DESCRIPTION
Beforehand, we used https://github.com/ihmpavel/all-iso-language-codes to get translations of the languages we need. That module generated the locale names using Node.JS Intl API, as seen here: https://github.com/ihmpavel/all-iso-language-codes/blob/5a2cdb56d2662995db27ef4498cb71abbf13efee/scripts/generate.ts#L66

The Intl.DisplayNames API is widely supported according to MDN docs: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DisplayNames Thus, it made sense to get the info we need at runtime. Also, all the language code translation is probably going to be miles better and up-to-date to Unicode standards than whatever library we use, which will always rely on updates. This movement also reduces bundle size by a lot!

Additionally, to reduce the burden the locale mismatch between our locales and date-fns pose, I added some build-time logic to get into the bundle the date-fns locales that match our own locales **ONLY**. This way, we avoid the huge import that `import * as datefnslocales from 'date-fns/locale'` posed and we replace it with `import * as datefnslocales from 'virtual:date-fns/locales'` which is guaranteed to:
- Only include the locales we have
- Be always up to date with our source code

All of this reduced bundle size **from 4,626.04 kB to 2,737.94 kB** according to Vite's stats