### PR TITLE
Fix the favorite button not updating its state

### DIFF
--- a/frontend/src/components/Buttons/LikeButton.vue
+++ b/frontend/src/components/Buttons/LikeButton.vue
@@ -17,10 +17,13 @@ import { useRemote } from '@/composables';
 const props = defineProps<{ item: BaseItemDto }>();
 const remote = useRemote();
 const loading = ref(false);
+const isFavoriteOverride = ref<boolean | undefined>(undefined);
 
 const isFavorite = computed({
   get() {
-    return props.item.UserData?.IsFavorite ?? false;
+    return isFavoriteOverride.value === undefined
+      ? props.item.UserData?.IsFavorite ?? false
+      : isFavoriteOverride.value;
   },
   async set(newValue) {
     try {
@@ -39,6 +42,8 @@ const isFavorite = computed({
             userId: remote.auth.currentUserId ?? '',
             itemId: props.item.Id
           }));
+
+      isFavoriteOverride.value = newValue;
     } catch {
     } finally {
       loading.value = false;


### PR DESCRIPTION
When clicking the favorite button, it properly updates the backend but not the frontend. This leads to two issues:
1. It does not visually change to show the new state
2. Clicking the button again does nothing (instead of flip-flopping like it should)

This PR fixes that.

Closes #1921 

> Note: this fix uses local state in the `LikeButton` component to fix the issue. If it is preferred, I can change it so it will refresh the state from the backend and not use local state.