### PR TITLE
fix: volume keep resetting after stopping playback

### DIFF
--- a/frontend/src/components/Layout/VolumeSlider.vue
+++ b/frontend/src/components/Layout/VolumeSlider.vue
@@ -8,13 +8,13 @@
       <v-icon :icon="icon" />
     </v-btn>
     <v-slider
-      v-model="sliderValue"
+      v-model="mediaVolume"
       class="volume-slider"
       hide-details
       thumb-label
       max="100">
       <template #thumb-label>
-        {{ Math.round(sliderValue) }}
+        {{ Math.round(mediaVolume) }}
       </template>
     </v-slider>
   </div>
@@ -26,33 +26,38 @@ import IMdiVolumeMute from 'virtual:icons/mdi/volume-mute';
 import IMdiVolumeMedium from 'virtual:icons/mdi/volume-medium';
 import IMdiVolumeHigh from 'virtual:icons/mdi/volume-high';
 import IMdiVolumeLow from 'virtual:icons/mdi/volume-low';
+import { syncRef, toRef } from '@vueuse/core';
 import { playbackManagerStore } from '@/store';
 
 const playbackManager = playbackManagerStore();
 
-const sliderValue = computed({
-  get() {
-    return playbackManager.mediaCurrentVolume;
-  },
-  set(value: number) {
-    playbackManager.mediaCurrentVolume = value;
+const mediaVolumeComputed = computed({
+  get: () => playbackManager.mediaCurrentVolume,
+  set: (newValue: number) => {
+    playbackManager.mediaCurrentVolume = newValue;
   }
 });
+
+const remoteVolumeComputed = computed({
+  get: () => playbackManager.remoteCurrentVolume,
+  set: (newValue: number) => {
+    playbackManager.remoteCurrentVolume = newValue;
+  }
+});
+
+const mediaVolume = toRef(mediaVolumeComputed);
+const remoteVolume = toRef(remoteVolumeComputed);
+
+syncRef(mediaVolume, remoteVolume);
 
 const icon = computed(() => {
   if (playbackManager.isMuted) {
     return IMdiVolumeMute;
-  } else if (playbackManager.mediaCurrentVolume >= 80) {
+  } else if (mediaVolume.value >= 80) {
     return IMdiVolumeHigh;
-  } else if (
-    playbackManager.mediaCurrentVolume < 80 &&
-    playbackManager.mediaCurrentVolume >= 25
-  ) {
+  } else if (mediaVolume.value < 80 && mediaVolume.value >= 25) {
     return IMdiVolumeMedium;
-  } else if (
-    playbackManager.mediaCurrentVolume < 25 &&
-    playbackManager.mediaCurrentVolume >= 1
-  ) {
+  } else if (mediaVolume.value < 25 && mediaVolume.value >= 1) {
     return IMdiVolumeLow;
   } else {
     return IMdiVolumeMute;

--- a/frontend/src/components/Layout/VolumeSlider.vue
+++ b/frontend/src/components/Layout/VolumeSlider.vue
@@ -32,26 +32,26 @@ const playbackManager = playbackManagerStore();
 
 const sliderValue = computed({
   get() {
-    return playbackManager.currentVolume;
+    return playbackManager.mediaCurrentVolume;
   },
-  set(newValue) {
-    playbackManager.currentVolume = newValue;
+  set(value: number) {
+    playbackManager.mediaCurrentVolume = value;
   }
 });
 
 const icon = computed(() => {
   if (playbackManager.isMuted) {
     return IMdiVolumeMute;
-  } else if (playbackManager.currentVolume >= 80) {
+  } else if (playbackManager.mediaCurrentVolume >= 80) {
     return IMdiVolumeHigh;
   } else if (
-    playbackManager.currentVolume < 80 &&
-    playbackManager.currentVolume >= 25
+    playbackManager.mediaCurrentVolume < 80 &&
+    playbackManager.mediaCurrentVolume >= 25
   ) {
     return IMdiVolumeMedium;
   } else if (
-    playbackManager.currentVolume < 25 &&
-    playbackManager.currentVolume >= 1
+    playbackManager.mediaCurrentVolume < 25 &&
+    playbackManager.mediaCurrentVolume >= 1
   ) {
     return IMdiVolumeLow;
   } else {

--- a/frontend/src/components/Playback/PlayerElement.vue
+++ b/frontend/src/components/Playback/PlayerElement.vue
@@ -102,6 +102,7 @@ async function onLoadedData(): Promise<void> {
       mediaElementRef.value.currentTime = playbackManager.currentTime;
     }
 
+    playerElement.applyInitialVolume();
     await playerElement.applyCurrentSubtitle();
   }
 }

--- a/frontend/src/store/playbackManager.ts
+++ b/frontend/src/store/playbackManager.ts
@@ -22,7 +22,6 @@ import { getItemsApi } from '@jellyfin/sdk/lib/utils/api/items-api';
 import { getTvShowsApi } from '@jellyfin/sdk/lib/utils/api/tv-shows-api';
 import { getPlaystateApi } from '@jellyfin/sdk/lib/utils/api/playstate-api';
 import { getMediaInfoApi } from '@jellyfin/sdk/lib/utils/api/media-info-api';
-import { syncRef, toRef } from '@vueuse/core';
 /**
  * It's important to import these from globals.ts directly to avoid cycles and ReferenceError
  */
@@ -150,10 +149,6 @@ class PlaybackManagerStore {
    * as a global variable and updating it solves this problem.
    */
   private _mediaMetadata = new MediaMetadata();
-  public syncVolume = syncRef(
-    toRef(this.mediaCurrentVolume),
-    toRef(this.remoteCurrentVolume)
-  );
 
   public get status(): PlaybackStatus {
     return this._state.status;
@@ -875,10 +870,10 @@ class PlaybackManagerStore {
     const sessionId = String(this._state.playSessionId || '');
     const time = Number(this.currentTime);
     const itemId = String(this.currentItem?.Id || '');
-    const volumeRemote = Number(this.remoteCurrentVolume);
+    const volumeMedia = Number(this.mediaCurrentVolume);
 
     Object.assign(this._state, this._defaultState);
-    this.remoteCurrentVolume = volumeRemote;
+    this.mediaCurrentVolume = volumeMedia;
 
     window.setTimeout(async () => {
       try {

--- a/frontend/src/store/playbackManager.ts
+++ b/frontend/src/store/playbackManager.ts
@@ -25,7 +25,7 @@ import { getMediaInfoApi } from '@jellyfin/sdk/lib/utils/api/media-info-api';
 /**
  * It's important to import these from globals.ts directly to avoid cycles and ReferenceError
  */
-import { now as reactiveDate, mediaControls } from './globals';
+import { now as reactiveDate, mediaControls, mediaElementRef } from './globals';
 import { itemsStore } from '.';
 import { usei18n, useRemote, useSnackbar } from '@/composables';
 import { getImageInfo } from '@/utils/images';
@@ -1265,6 +1265,12 @@ class PlaybackManagerStore {
     watch(mediaControls.ended, () => {
       if (mediaControls.ended.value) {
         playbackManager.setNextTrack();
+      }
+    });
+
+    watch(mediaElementRef, () => {
+      if (!isNil(mediaElementRef.value)) {
+        mediaElementRef.value.volume = this.currentVolume / 100;
       }
     });
   }

--- a/frontend/src/store/playerElement.ts
+++ b/frontend/src/store/playerElement.ts
@@ -208,7 +208,7 @@ class PlayerElementStore {
     volume: number = playbackManager.mediaCurrentVolume
   ): void => {
     if (mediaElementRef.value) {
-      mediaElementRef.value.volume = volume;
+      mediaElementRef.value.volume = volume / 100;
     }
   };
 
@@ -242,8 +242,6 @@ class PlayerElementStore {
         ) {
           this.toggleFullscreenVideoPlayer();
         }
-
-        this.applyInitialVolume();
       }
     );
 
@@ -254,6 +252,14 @@ class PlayerElementStore {
           this._clear();
         }
       }
+    );
+
+    watch(
+      mediaElementRef,
+      () => {
+        this.applyInitialVolume();
+      },
+      { immediate: true }
     );
   }
 }

--- a/frontend/src/store/playerElement.ts
+++ b/frontend/src/store/playerElement.ts
@@ -197,6 +197,21 @@ class PlayerElementStore {
     }
   };
 
+  /**
+   * Apply initial volume to the media element directly.
+   * The element is recreated every time we changed item
+   * so the volume is resetted.
+   *
+   * @param volume - Volume to be set on
+   */
+  public applyInitialVolume = (
+    volume: number = playbackManager.mediaCurrentVolume
+  ): void => {
+    if (mediaElementRef.value) {
+      mediaElementRef.value.volume = volume;
+    }
+  };
+
   private _clear = (): void => {
     Object.assign(this._state, this._defaultState);
   };
@@ -227,6 +242,8 @@ class PlayerElementStore {
         ) {
           this.toggleFullscreenVideoPlayer();
         }
+
+        this.applyInitialVolume();
       }
     );
 


### PR DESCRIPTION
Since the media element itself got removed after stopping, we basically need to reapply the current volume.
The solution is to just check if the `mediaElementRef` got set to `null` or `HTMLMediaElement` and then manually apply the current volume to the element directly.

Fix #1956 