### PR TITLE
feat: no styled scrollbars

### DIFF
--- a/frontend/src/assets/styles/global.scss
+++ b/frontend/src/assets/styles/global.scss
@@ -3,14 +3,6 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
-*::-webkit-scrollbar {
-  width: 5px;
-}
-
-*::-webkit-scrollbar-thumb {
-  background: #666;
-}
-
 html.no-forced-scrollbar {
   overflow-y: unset !important;
 }


### PR DESCRIPTION
The last 2 major browsers without overlay scrollbars (Microsoft Edge and Google Chrome) are already adding flags to their experimental settings to allow users to use native overlay scrollbars.
Native overlayed scrollbars are much better than whatever styling we use. Plus, styled scrollbars removes the overlay scrollbar altogether, as there's no way to tell the browser to prefer them instead of our own (which would be nice for backwards compatibility)

Firefox have OverlayScrollbars in all desktop platforms already. Mobile platforms had them since day one.

See also this: https://chromestatus.com/feature/5693137379917824