### PR TITLE
fix: wrong item in track list for item menu

### DIFF
--- a/frontend/src/components/Playback/TrackList.vue
+++ b/frontend/src/components/Playback/TrackList.vue
@@ -69,7 +69,7 @@
                     </template>
                   </div>
                   <v-spacer />
-                  <item-menu v-show="isHovering" :item="item" />
+                  <item-menu v-show="isHovering" :item="track" />
                 </div>
               </td>
               <td class="text-center">


### PR DESCRIPTION
Closes #1950

Was originally part of #1962 but since the recent item-menu changes, it would be better if this was fixed sooner.
Without this fix, music album item menu would look like this:

![Screenshot](https://user-images.githubusercontent.com/34302902/235675736-84e06cdb-0f82-4ad5-817e-edef2edb4e47.png)



