### PR TITLE
refactor: QoL improvements

### DIFF
--- a/frontend/locales/en-US.json
+++ b/frontend/locales/en-US.json
@@ -540,6 +540,9 @@
     }
   },
   "unknown": "Unknown",
+  "unknownTitle": "Unknown title",
+  "unknownArtist": "Unknown artist",
+  "unknownAlbum": "Unknown album",
   "unliked": "Unliked",
   "unplayed": "Unplayed",
   "upNext": "Up next",

--- a/frontend/src/assets/styles/global.scss
+++ b/frontend/src/assets/styles/global.scss
@@ -85,9 +85,3 @@ html.no-forced-scrollbar {
 .overflow-hidden {
   overflow: hidden;
 }
-
-.card-chip {
-  position: absolute;
-  top: 1em;
-  right: 1em;
-}

--- a/frontend/src/components/Buttons/LikeButton.vue
+++ b/frontend/src/components/Buttons/LikeButton.vue
@@ -2,6 +2,7 @@
   <v-btn
     :icon="isFavorite ? IMdiHeart : IMdiHeartOutline"
     size="small"
+    :color="isFavorite ? 'primary' : undefined"
     :loading="loading"
     @click.stop.prevent="isFavorite = !isFavorite" />
 </template>

--- a/frontend/src/components/Buttons/MarkPlayedButton.vue
+++ b/frontend/src/components/Buttons/MarkPlayedButton.vue
@@ -1,7 +1,7 @@
 <template>
   <v-btn
     v-if="canMarkWatched(item)"
-    :color="isPlayed ? 'primary' : ''"
+    :color="isPlayed ? 'primary' : undefined"
     :icon="IMdiCheck"
     size="small"
     @click.stop.prevent="togglePlayed" />

--- a/frontend/src/components/Item/Card/Card.vue
+++ b/frontend/src/components/Item/Card/Card.vue
@@ -4,31 +4,41 @@
       :is="link ? 'router-link' : 'div'"
       :to="link ? getItemDetailsLink(item) : null"
       :class="{ 'card-box': link }">
-      <!-- CARD -->
       <div :class="shape || cardType" class="elevation-2">
         <div
-          class="card-content card-content-button d-flex justify-center align-center darken-4">
+          class="absolute-cover card-content d-flex justify-center align-center">
           <blurhash-image
             :item="item"
             :type="getImageType"
             :alt="item.Name || ''"
             class="card-image" />
-          <v-progress-circular
-            v-if="refreshProgress !== undefined"
-            class="card-chip"
-            :model-value="refreshProgress"
-            :indeterminate="refreshProgress === 0"
-            color="white"
-            size="24" />
-          <watched-indicator v-if="item.UserData && item.UserData.Played" />
-          <v-chip
-            v-if="item.UserData && item.UserData.UnplayedItemCount"
-            color="primary"
-            variant="elevated"
-            class="card-chip"
-            size="small">
-            {{ item.UserData.UnplayedItemCount }}
-          </v-chip>
+        </div>
+        <div
+          class="absolute-cover card-overlay d-flex justify-center align-center"
+          :class="{ 'card-overlay-hover': overlay && isFinePointer }">
+          <div class="card-upper-content d-flex justify-center align-center">
+            <v-progress-circular
+              v-if="refreshProgress !== undefined"
+              :model-value="refreshProgress"
+              :indeterminate="refreshProgress === 0"
+              size="24" />
+            <watched-indicator v-if="item.UserData && item.UserData.Played" />
+            <v-chip
+              v-if="item.UserData && item.UserData.UnplayedItemCount"
+              color="primary"
+              variant="elevated"
+              size="small">
+              {{ item.UserData.UnplayedItemCount }}
+            </v-chip>
+          </div>
+          <div class="card-overlay-hover-hidden">
+            <play-button fab :item="item" />
+            <div class="card-lower-content d-flex justify-center align-center">
+              <mark-played-button :item="item" />
+              <like-button v-if="canPlay(item)" :item="item" />
+              <item-menu :item="item" />
+            </div>
+          </div>
           <v-progress-linear
             v-if="
               item.UserData &&
@@ -36,21 +46,8 @@
               item.UserData.PlayedPercentage > 0
             "
             v-model="progress"
-            color="primary-accent-4"
             absolute
             location="bottom" />
-        </div>
-        <div
-          v-if="overlay && isFinePointer"
-          class="card-overlay d-flex justify-center align-center">
-          <play-button fab :item="item" />
-          <div
-            v-if="overlay"
-            class="card-lower-buttons d-flex justify-center align-center">
-            <mark-played-button :item="item" />
-            <like-button v-if="canPlay(item)" :item="item" />
-            <item-menu :item="item" />
-          </div>
         </div>
       </div>
     </component>
@@ -244,7 +241,13 @@ const refreshProgress = computed(
 </style>
 
 <style lang="scss" scoped>
-.card-lower-buttons {
+.card-upper-content {
+  position: absolute;
+  right: 0.5em;
+  top: 0.5em;
+  gap: 0.3em;
+}
+.card-lower-content {
   position: absolute;
   right: 0.5em;
   bottom: 0.5em;
@@ -258,14 +261,7 @@ const refreshProgress = computed(
 .card-content {
   background-color: rgb(var(--v-theme-menu));
   overflow: hidden;
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
   margin: 0 !important;
-  height: 100%;
-  width: 100%;
   contain: strict;
   background-size: cover;
   background-repeat: no-repeat;
@@ -275,22 +271,23 @@ const refreshProgress = computed(
 }
 
 .card-overlay {
-  position: absolute;
-  background: radial-gradient(
-    farthest-corner at 50% 50%,
-    rgba(0, 0, 0, 0.5) 50%,
-    rgba(0, 0, 0, 0.7) 100%
-  );
+  transition: all 0.2s;
+}
+
+.overlay-hover {
   transition: opacity 0.2s;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
+}
+
+.card-overlay-hover-hidden {
+  transition: inherit;
   opacity: 0;
 }
 
 @media (hover: hover) and (pointer: fine) {
-  .card-box:hover .card-overlay {
+  .card-box:hover .card-overlay-hover {
+    background: rgba(var(--v-theme-background), 0.5);
+  }
+  .card-box:hover .card-overlay-hover .card-overlay-hover-hidden {
     opacity: 1;
   }
 }
@@ -303,8 +300,9 @@ const refreshProgress = computed(
   text-overflow: ellipsis;
 }
 
-.a {
+a.card-box {
   text-decoration: none;
+  color: unset;
 }
 
 .absolute {

--- a/frontend/src/components/Item/ItemMenu.vue
+++ b/frontend/src/components/Item/ItemMenu.vue
@@ -6,7 +6,7 @@
     @click.stop.prevent="onActivatorClick"
     @contextmenu.stop.prevent="onRightClick">
     <v-icon>
-      <i-mdi-dots-horizontal />
+      <i-mdi-dots-vertical />
     </v-icon>
     <v-menu
       v-model="show"
@@ -66,6 +66,7 @@ import IMdiReplay from 'virtual:icons/mdi/replay';
 import IMdiRefresh from 'virtual:icons/mdi/refresh';
 import { getLibraryApi } from '@jellyfin/sdk/lib/utils/api/library-api';
 import { useRoute, useRouter } from 'vue-router';
+import { v4 } from 'uuid';
 import { useRemote, useSnackbar, useConfirmDialog } from '@/composables';
 import {
   canIdentify,
@@ -85,11 +86,12 @@ type MenuOption = {
 /**
  * SHARED STATE ACROSS ALL THE COMPONENT INSTANCES
  */
-const openItemId = ref<string>();
+const openMenu = ref<string>();
 </script>
 
 <script setup lang="ts">
 const { t } = useI18n();
+const instanceId = v4();
 const remote = useRemote();
 const router = useRouter();
 const route = useRoute();
@@ -111,12 +113,16 @@ const menuProps = withDefaults(
 );
 
 const parent = getCurrentInstance()?.parent;
+/**
+ * Ensure only one item menu is always open at a time, regardless if there are duplicated ones in
+ * the same screen
+ */
 const show = computed({
   get() {
-    return openItemId.value === menuProps.item.Id;
+    return instanceId === openMenu.value;
   },
   set(newVal: boolean) {
-    openItemId.value = newVal ? menuProps.item.Id : undefined;
+    openMenu.value = newVal ? instanceId : undefined;
   }
 });
 const positionX = ref<number | undefined>(undefined);

--- a/frontend/src/components/Item/ItemMenu.vue
+++ b/frontend/src/components/Item/ItemMenu.vue
@@ -2,6 +2,7 @@
   <v-btn
     v-if="options.length > 0"
     :variant="outlined ? 'outlined' : undefined"
+    icon
     size="small"
     @click.stop.prevent="onActivatorClick"
     @contextmenu.stop.prevent="onRightClick">

--- a/frontend/src/components/Item/WatchedIndicator.vue
+++ b/frontend/src/components/Item/WatchedIndicator.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-chip color="success" class="card-chip" size="small" variant="elevated">
+  <v-chip color="success" size="small" variant="elevated">
     <v-icon>
       <i-mdi-check />
     </v-icon>

--- a/frontend/src/components/Layout/AppBar/Buttons/TaskManagerButton.vue
+++ b/frontend/src/components/Layout/AppBar/Buttons/TaskManagerButton.vue
@@ -92,16 +92,13 @@ const allCompleted = computed(
 const buttonColor = computed(() =>
   allCompleted.value ? 'success' : undefined
 );
-const UITaskList = computed(
-  () =>
-    new Set([
-      ...(menu.value
-        ? mappedTaskList.value.filter((t) => t.progress !== 100)
-        : mappedTaskList.value),
-      ...completedTaskList.value
-    ])
-);
-const showButton = computed(() => UITaskList.value.size > 0);
+const UITaskList = computed(() => [
+  ...(menu.value
+    ? mappedTaskList.value.filter((t) => t.progress !== 100)
+    : mappedTaskList.value),
+  ...completedTaskList.value
+]);
+const showButton = computed(() => UITaskList.value.length > 0);
 
 watch([menu, mappedCompleted], () => {
   if (menu.value) {

--- a/frontend/src/components/Layout/Carousel/CarouselProgressBar.vue
+++ b/frontend/src/components/Layout/Carousel/CarouselProgressBar.vue
@@ -101,10 +101,10 @@ const barClasses = computed(() =>
   display: block;
   background-image: linear-gradient(
     to right,
-    rgba(255, 255, 255, 1) 0%,
-    rgba(255, 255, 255, 1) 50%,
-    rgba(255, 255, 255, 0.3) 50.001%,
-    rgba(255, 255, 255, 0.3) 100%
+    rgba(var(--v-border-color), 1) 0%,
+    rgba(var(--v-border-color), 1) 50%,
+    rgba(var(--v-border-color), 0.3) 50.001%,
+    rgba(var(--v-border-color), 0.3) 100%
   );
   background-repeat: no-repeat;
   background-size: 200%;

--- a/frontend/src/components/Layout/Images/Blurhash/BlurhashCanvas.vue
+++ b/frontend/src/components/Layout/Images/Blurhash/BlurhashCanvas.vue
@@ -24,8 +24,8 @@ const pixelWorker = wrap<typeof import('./BlurhashWorker')['default']>(worker);
  */
 watch(
   () => remote.auth.currentUser,
-  async () => {
-    if (remote.auth.currentUser === undefined) {
+  async (newVal) => {
+    if (newVal === undefined) {
       await pixelWorker.clearCache();
     }
   }

--- a/frontend/src/components/Layout/Images/Blurhash/BlurhashWorker.ts
+++ b/frontend/src/components/Layout/Images/Blurhash/BlurhashWorker.ts
@@ -1,36 +1,48 @@
 import { decode } from 'blurhash';
 import { expose } from 'comlink';
 
-const cache: { [key: string]: Uint8ClampedArray } = {};
+const cache = new Map<string, Uint8ClampedArray>();
 
-/**
- * Decodes blurhash outside the main thread, in a web worker
- *
- * @param hash - Hash to decode.
- * @param width - Width of the decoded pixel array
- * @param height - Height of the decoded pixel array.
- * @param punch - Contrast of the decoded pixels
- * @returns - Returns the decoded pixels in the proxied response by Comlink
- */
-export default function getPixels(
-  hash: string,
-  width: number,
-  height: number,
-  punch: number
-): Uint8ClampedArray {
-  try {
-    const params = [hash, width, height, punch].toString();
-    let canvas = cache[params];
+class BlurhashWorker {
+  /**
+   * Decodes blurhash outside the main thread, in a web worker
+   *
+   * @param hash - Hash to decode.
+   * @param width - Width of the decoded pixel array
+   * @param height - Height of the decoded pixel array.
+   * @param punch - Contrast of the decoded pixels
+   * @returns - Returns the decoded pixels in the proxied response by Comlink
+   */
+  public getPixels = (
+    hash: string,
+    width: number,
+    height: number,
+    punch: number
+  ): Uint8ClampedArray => {
+    try {
+      const params = [hash, width, height, punch].toString();
+      let canvas = cache.get(params);
 
-    if (!canvas) {
-      canvas = decode(hash, width, height, punch);
-      cache[params] = canvas;
+      if (!canvas) {
+        canvas = decode(hash, width, height, punch);
+        cache.set(params, canvas);
+      }
+
+      return canvas;
+    } catch {
+      throw new TypeError(`Blurhash ${hash} is not valid`);
     }
+  };
 
-    return canvas;
-  } catch {
-    throw new TypeError(`Blurhash ${hash} is not valid`);
-  }
+  /**
+   * Clear the blurhashes cache
+   */
+  public clearCache = (): void => {
+    cache.clear();
+  };
 }
 
-expose(getPixels);
+const instance = new BlurhashWorker();
+export default instance;
+
+expose(instance);

--- a/frontend/src/components/Layout/TimeSlider.vue
+++ b/frontend/src/components/Layout/TimeSlider.vue
@@ -22,14 +22,12 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue';
 import { playbackManagerStore } from '@/store';
-import { ticksToMs, formatTime } from '@/utils/time';
+import { formatTime } from '@/utils/time';
 
 const playbackManager = playbackManagerStore();
 const currentInput = ref(0);
 const clicked = ref(false);
-const runtime = computed(
-  () => ticksToMs(playbackManager.currentItem?.RunTimeTicks) / 1000
-);
+const runtime = computed(() => playbackManager.currentItemRuntime / 1000);
 const sliderValue = computed({
   get() {
     return clicked.value ? currentInput.value : playbackManager.currentTime;

--- a/frontend/src/components/Playback/PlayerElement.vue
+++ b/frontend/src/components/Playback/PlayerElement.vue
@@ -167,19 +167,24 @@ watch(
       hls.stopLoad();
     }
 
-    if (!newUrl) {
-      return;
-    }
-
     if (
       mediaElementRef.value &&
-      (playbackManager.currentMediaSource?.SupportsDirectPlay || !hls)
+      (!newUrl ||
+        playbackManager.currentMediaSource?.SupportsDirectPlay ||
+        !hls)
     ) {
       /**
-       * For the video case, Safari iOS doesn't support hls.js but supports native HLS
+       * For the video case, Safari iOS doesn't support hls.js but supports native HLS.
+       *
+       * We stringify undefined instead of skipping this block when there's no new source url,
+       * so the player doesn't restart playback of the previous item
        */
-      mediaElementRef.value.src = newUrl;
-    } else if (hls && playbackManager.currentlyPlayingMediaType === 'Video') {
+      mediaElementRef.value.src = String(newUrl);
+    } else if (
+      hls &&
+      playbackManager.currentlyPlayingMediaType === 'Video' &&
+      newUrl
+    ) {
       /**
        * We need to check if HLS.js can handle transcoded audio to remove the video check
        */

--- a/frontend/src/components/Playback/UpNext.vue
+++ b/frontend/src/components/Playback/UpNext.vue
@@ -69,7 +69,7 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue';
 import { playbackManagerStore } from '@/store';
-import { ticksToMs, getEndsAtTime, getRuntimeTime } from '@/utils/time';
+import { getEndsAtTime, getRuntimeTime } from '@/utils/time';
 
 const emit = defineEmits<{
   change: [isVisible: boolean];
@@ -80,7 +80,7 @@ const playbackManager = playbackManagerStore();
 const isHiddenByUser = ref(false);
 
 const currentItemDuration = computed(
-  (): number => ticksToMs(playbackManager.currentItem?.RunTimeTicks) / 1000
+  () => playbackManager.currentItemRuntime / 1000
 );
 const currentItemTimeLeft = computed(() =>
   Math.round(currentItemDuration.value - (playbackManager.currentTime || 0))

--- a/frontend/src/pages/playback/video/index.vue
+++ b/frontend/src/pages/playback/video/index.vue
@@ -252,22 +252,22 @@ watch(staticOverlay, (val) => {
   padding-bottom: 5em;
   background: linear-gradient(
     to bottom,
-    hsla(0, 0%, 0%, 0.75) 0%,
-    hsla(0, 0%, 0%, 0.74) 8.1%,
-    hsla(0, 0%, 0%, 0.714) 15.5%,
-    hsla(0, 0%, 0%, 0.672) 22.5%,
-    hsla(0, 0%, 0%, 0.618) 29%,
-    hsla(0, 0%, 0%, 0.556) 35.3%,
-    hsla(0, 0%, 0%, 0.486) 41.2%,
-    hsla(0, 0%, 0%, 0.412) 47.1%,
-    hsla(0, 0%, 0%, 0.338) 52.9%,
-    hsla(0, 0%, 0%, 0.264) 58.8%,
-    hsla(0, 0%, 0%, 0.194) 64.7%,
-    hsla(0, 0%, 0%, 0.132) 71%,
-    hsla(0, 0%, 0%, 0.078) 77.5%,
-    hsla(0, 0%, 0%, 0.036) 84.5%,
-    hsla(0, 0%, 0%, 0.01) 91.9%,
-    hsla(0, 0%, 0%, 0) 100%
+    rgb(var(--v-theme-background), 0.75) 0%,
+    rgb(var(--v-theme-background), 0.74) 8.1%,
+    rgb(var(--v-theme-background), 0.714) 15.5%,
+    rgb(var(--v-theme-background), 0.672) 22.5%,
+    rgb(var(--v-theme-background), 0.618) 29%,
+    rgb(var(--v-theme-background), 0.556) 35.3%,
+    rgb(var(--v-theme-background), 0.486) 41.2%,
+    rgb(var(--v-theme-background), 0.412) 47.1%,
+    rgb(var(--v-theme-background), 0.338) 52.9%,
+    rgb(var(--v-theme-background), 0.264) 58.8%,
+    rgb(var(--v-theme-background), 0.194) 64.7%,
+    rgb(var(--v-theme-background), 0.132) 71%,
+    rgb(var(--v-theme-background), 0.078) 77.5%,
+    rgb(var(--v-theme-background), 0.036) 84.5%,
+    rgb(var(--v-theme-background), 0.01) 91.9%,
+    rgb(var(--v-theme-background), 0) 100%
   );
 }
 
@@ -275,22 +275,22 @@ watch(staticOverlay, (val) => {
   padding-top: 6em;
   background: linear-gradient(
     to top,
-    hsla(0, 0%, 0%, 0.75) 0%,
-    hsla(0, 0%, 0%, 0.74) 8.1%,
-    hsla(0, 0%, 0%, 0.714) 15.5%,
-    hsla(0, 0%, 0%, 0.672) 22.5%,
-    hsla(0, 0%, 0%, 0.618) 29%,
-    hsla(0, 0%, 0%, 0.556) 35.3%,
-    hsla(0, 0%, 0%, 0.486) 41.2%,
-    hsla(0, 0%, 0%, 0.412) 47.1%,
-    hsla(0, 0%, 0%, 0.338) 52.9%,
-    hsla(0, 0%, 0%, 0.264) 58.8%,
-    hsla(0, 0%, 0%, 0.194) 64.7%,
-    hsla(0, 0%, 0%, 0.132) 71%,
-    hsla(0, 0%, 0%, 0.078) 77.5%,
-    hsla(0, 0%, 0%, 0.036) 84.5%,
-    hsla(0, 0%, 0%, 0.01) 91.9%,
-    hsla(0, 0%, 0%, 0) 100%
+    rgb(var(--v-theme-background), 0.75) 0%,
+    rgb(var(--v-theme-background), 0.74) 8.1%,
+    rgb(var(--v-theme-background), 0.714) 15.5%,
+    rgb(var(--v-theme-background), 0.672) 22.5%,
+    rgb(var(--v-theme-background), 0.618) 29%,
+    rgb(var(--v-theme-background), 0.556) 35.3%,
+    rgb(var(--v-theme-background), 0.486) 41.2%,
+    rgb(var(--v-theme-background), 0.412) 47.1%,
+    rgb(var(--v-theme-background), 0.338) 52.9%,
+    rgb(var(--v-theme-background), 0.264) 58.8%,
+    rgb(var(--v-theme-background), 0.194) 64.7%,
+    rgb(var(--v-theme-background), 0.132) 71%,
+    rgb(var(--v-theme-background), 0.078) 77.5%,
+    rgb(var(--v-theme-background), 0.036) 84.5%,
+    rgb(var(--v-theme-background), 0.01) 91.9%,
+    rgb(var(--v-theme-background), 0) 100%
   );
 }
 

--- a/frontend/src/store/playbackManager.ts
+++ b/frontend/src/store/playbackManager.ts
@@ -1206,9 +1206,20 @@ class PlaybackManagerStore {
      * == Server interaction ==
      */
     /**
-     * Update media source
+     * Update media source, taking into account that currentItemIndex updates
+     * that occur when shuffling must be skipped
      */
-    watch(() => this.currentItemIndex, this._setCurrentMediaSource);
+    watch(
+      [
+        (): typeof this.currentItemIndex => this.currentItemIndex,
+        (): typeof this.isShuffling => this.isShuffling
+      ],
+      async (newValue, oldValue) => {
+        if (newValue[1] === oldValue[1]) {
+          await this._setCurrentMediaSource();
+        }
+      }
+    );
     /**
      * Report stop for the old item and start for the new one
      */

--- a/frontend/src/store/playbackManager.ts
+++ b/frontend/src/store/playbackManager.ts
@@ -1050,13 +1050,13 @@ class PlaybackManagerStore {
      */
     watchEffect(() => {
       if (window.navigator.mediaSession) {
-        const unknownString = usei18n().t('unknown');
+        const { t } = usei18n();
 
         window.navigator.mediaSession.metadata = this.currentItem
           ? new MediaMetadata({
-              title: this.currentItem.Name ?? unknownString,
-              artist: this.currentItem.AlbumArtist ?? unknownString,
-              album: this.currentItem.Album ?? unknownString,
+              title: this.currentItem.Name ?? t('unknownTitle'),
+              artist: this.currentItem.AlbumArtist ?? t('unknownArtist'),
+              album: this.currentItem.Album ?? t('unknownAlbum'),
               artwork: [
                 {
                   src:

--- a/frontend/src/utils/items.ts
+++ b/frontend/src/utils/items.ts
@@ -26,6 +26,7 @@ import IMdiBookMusic from 'virtual:icons/mdi/book-music';
 import IMdiFolderMultiple from 'virtual:icons/mdi/folder-multiple';
 import IMdiFilmstrip from 'virtual:icons/mdi/filmstrip';
 import IMdiAlbum from 'virtual:icons/mdi/album';
+import { ticksToMs } from './time';
 import { useRemote } from '@/composables';
 
 /**
@@ -438,6 +439,13 @@ export function getItemIcon(
   }
 
   return itemIcon;
+}
+
+/**
+ * Get the runtime of an item in milliseconds
+ */
+export function getItemRuntime(item: BaseItemDto): number {
+  return ticksToMs(item.RunTimeTicks);
 }
 
 /**

--- a/frontend/src/utils/time.ts
+++ b/frontend/src/utils/time.ts
@@ -32,11 +32,7 @@ function formatDigits(number: number): string {
  * @returns The converted value in milliseconds
  */
 export function ticksToMs(ticks: number | null | undefined): number {
-  if (!ticks) {
-    ticks = 0;
-  }
-
-  return Math.round(ticks / 10_000);
+  return ticks ? Math.round(ticks / 10_000) : 0;
 }
 
 /**

--- a/frontend/types/global/components.d.ts
+++ b/frontend/types/global/components.d.ts
@@ -53,7 +53,7 @@ declare module 'vue' {
     IMdiContentSave: typeof import('~icons/mdi/content-save')['default']
     IMdiDelete: typeof import('~icons/mdi/delete')['default']
     IMdiDisc: typeof import('~icons/mdi/disc')['default']
-    IMdiDotsHorizontal: typeof import('~icons/mdi/dots-horizontal')['default']
+    IMdiDotsVertical: typeof import('~icons/mdi/dots-vertical')['default']
     IMdiDragHorizontal: typeof import('~icons/mdi/drag-horizontal')['default']
     IMdiEye: typeof import('~icons/mdi/eye')['default']
     IMdiFile: typeof import('~icons/mdi/file')['default']


### PR DESCRIPTION
* Fix multiple menus opened in queue
* Clear Blurhash cache on logout
* Convert Blurhash cache to a map

refactor: playbackManager
    
    * Move item runtime to PlaybackManager
    * Organize watchers by scope
    * Better handle concurrency on setCurrentMediaSource when switching audio tracks really fast, discarding stale data
    * Remove unused properties from state
    * Remove "lastItemIndex" in favor of a watcher that tracks the currentItem Id changes and reports playback changes
    * Attempt to send playback stopped status to server when closing tab (fix #1781)

Requires a vueuse release that includes this PR: https://github.com/vueuse/vueuse/pull/3072 (labeling blocked because of that)

fix: handle undefined media url
In playbackManager, we set the currentMediaSource url to undefined to prevent the previous item from resuming the playback from the beginning.
With the undefined checks we had in place in PlayerElement, that fix was being overriden

fix: Card styling
    
    * Buttons changing colors when clicked
    * Buttons color matches Vue 2 era
    * ItemMenu button being too large
    * Overlay not reaching to the edges
    * Unreadable buttons when changing themes
    * Carousel's progress bar following theme
    * Factorize Card classes so overlay contains all the elements that are above the image: this way, when hovered, the watcher indicator and progress bars are not darkened
    * Use absolute-cover to reduce style declaration

Fix #1982 

fix: no name for refresh task in taskManager
    
    The websocket sends updates with 2 different ids for the same library. We have proper checking
    in the item store to take that into account
    
    Also fixes the display order of the tasks