### PR TITLE
feat: Reworked video keyboard keys and fix osd visual

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,7 @@
     "serve": "vite preview",
     "lint": "prettier . '!types/global/{components.d.ts,routes.d.ts}|index.html' --check --ignore-path ../.gitignore && eslint . --ext .ts,.js,.json,.vue --ignore-path ../.gitignore --max-warnings=0",
     "lint-fix": "prettier . '!types/global/{components.d.ts,routes.d.ts}|index.html' --write --ignore-path ../.gitignore && eslint . --fix --ext .ts,.js,.json,.vue --ignore-path ../.gitignore --max-warnings=0",
-    "prod": "npm run build && npm run serve",
+    "prod": "vite build && vite preview",
     "typecheck": "vue-tsc --noEmit --skipLibCheck",
     "vue-i18n-extract": "vue-i18n-extract",
     "vue-i18n-extract-remove": "vue-i18n-extract --remove"

--- a/frontend/src/pages/playback/video/index.vue
+++ b/frontend/src/pages/playback/video/index.vue
@@ -2,8 +2,8 @@
   <v-main
     class="fullscreen-video-container fill-height"
     :class="{ 'cursor-none': !overlay }"
-    @mousemove="handleMouseMove"
-    @touchend="handleMouseMove">
+    @mousemove="showOsdWithTimeout"
+    @touchend="showOsdWithTimeout">
     <v-overlay
       v-model="overlay"
       contained
@@ -28,11 +28,10 @@
         <div class="osd-bottom pb-s pl-s pr-s">
           <div class="pa-4">
             <time-slider />
-            <div
-              class="controls-wrapper d-flex align-stretch justify-space-between">
+            <div class="controls-wrapper d-flex align-stretch">
               <div
                 v-if="$vuetify.display.mdAndUp"
-                class="d-flex flex-column align-start justify-center mr-auto video-title">
+                class="d-flex flex-column align-start mr-auto video-title">
                 <template
                   v-if="
                     playbackManager.currentlyPlayingType ===
@@ -57,10 +56,9 @@
                 <template v-else>
                   <span>{{ playbackManager.currentItem?.Name }}</span>
                 </template>
-                <br />
                 <span
                   v-if="playbackManager.currentItem?.RunTimeTicks"
-                  class="text-subtitle-2 text--secondary text-truncate">
+                  class="text-subtitle-2 text--secondary text-truncate mt-auto">
                   {{
                     getEndsAtTime(playbackManager.currentItem.RunTimeTicks)
                       .value
@@ -168,9 +166,12 @@ const timeout = useTimeoutFn(() => {
 /**
  * Shows the overlay on mouse move and starts the timeout to hide it, unless the overlay must stay static
  */
-function handleMouseMove(): void {
+function showOsdWithTimeout(): void {
   overlay.value = true;
-  timeout.start();
+
+  if (!staticOverlay.value) {
+    timeout.start();
+  }
 }
 
 onBeforeUnmount(() => {


### PR DESCRIPTION
* OSD: refactor: end time position uses now flex instead of `<br/>`
* OSD: fixed: chars like `g` or `q` where cut at the bottom
* OSD: fixed: "mouse move" overwrites no longer staticOverlay by starting the timer
* ~~OSD: feat: keyboard events show the osd~~
* ~~VideoPlayer: continous events for left/right key down~~