### PR TITLE
chore: remove unnecessary rust dependencies

### DIFF
--- a/tauri/Cargo.lock
+++ b/tauri/Cargo.lock
@@ -1529,8 +1529,6 @@ dependencies = [
 name = "jellyfin-vue-tauri"
 version = "0.0.0"
 dependencies = [
- "serde",
- "serde_json",
  "tauri",
  "tauri-build",
 ]

--- a/tauri/Cargo.toml
+++ b/tauri/Cargo.toml
@@ -17,10 +17,8 @@ edition = "2021"
 tauri-build = { version = "=1.3.0", features = [] }
 
 [dependencies]
-serde_json = "=1.0.96"
-serde = { version = "=1.0.163", features = [ "derive" ] }
 tauri = { version = "=1.3.0", features = ["api-all"] }
 
 [features]
-default = [ "custom-protocol" ]
-custom-protocol = [ "tauri/custom-protocol" ]
+default = ["custom-protocol"]
+custom-protocol = ["tauri/custom-protocol"]


### PR DESCRIPTION
serde was automatically added when scaffolding the Tauri project. However, it doesn't seem necessary (at least for now that we don't have intercommunication betwen the frontend and Tauri).

If it's necessary for inter-communication with the frontend in the future we can always add them back