### PR TITLE
perf: replace klona with structuredClone

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,7 +38,6 @@
     "dompurify": "3.0.3",
     "hls.js": "1.4.5",
     "jassub": "1.7.1",
-    "klona": "2.0.6",
     "lodash-es": "4.17.21",
     "marked": "5.1.0",
     "sortablejs": "1.15.0",

--- a/frontend/src/components/Item/Identify/IdentifyDialog.vue
+++ b/frontend/src/components/Item/Identify/IdentifyDialog.vue
@@ -107,7 +107,6 @@ import {
   RemoteSearchResult
 } from '@jellyfin/sdk/lib/generated-client';
 import { getItemLookupApi } from '@jellyfin/sdk/lib/utils/api/item-lookup-api';
-import { klona } from 'klona';
 import { computed, ref, toRaw } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useConfirmDialog, useRemote, useSnackbar } from '@/composables';
@@ -192,7 +191,9 @@ const searchFields = computed<IdentifyField[]>(() => {
 
   return result;
 });
-const fieldsInputs = ref<IdentifyField[]>(klona(toRaw(searchFields.value)));
+const fieldsInputs = ref<IdentifyField[]>(
+  structuredClone(toRaw(searchFields.value))
+);
 const tabName = computed(() =>
   searchResults.value === undefined ? 'searchMenu' : 'resultsMenu'
 );

--- a/frontend/src/store/clientSettings.ts
+++ b/frontend/src/store/clientSettings.ts
@@ -6,7 +6,6 @@ import {
   useStorage,
   watchPausable
 } from '@vueuse/core';
-import { klona } from 'klona';
 import { fetchDefaultedCustomPrefs, syncCustomPrefs } from '@/utils/store-sync';
 import { usei18n, useSnackbar, useRemote, useVuetify } from '@/composables';
 import { mergeExcludingUnknown } from '@/utils/data-manipulation';
@@ -51,7 +50,7 @@ class ClientSettingsStore {
 
   private _state: RemovableRef<ClientSettingsState> = useStorage(
     storeKey,
-    klona(this._defaultState),
+    structuredClone(this._defaultState),
     localStorage,
     {
       mergeDefaults: (storageValue, defaults) =>

--- a/frontend/src/store/items.ts
+++ b/frontend/src/store/items.ts
@@ -1,5 +1,4 @@
 import { reactive, watch } from 'vue';
-import { klona } from 'klona';
 import { BaseItemDto, ItemFields } from '@jellyfin/sdk/lib/generated-client';
 import { getItemsApi } from '@jellyfin/sdk/lib/utils/api/items-api';
 import { useRemote } from '@/composables';
@@ -24,7 +23,7 @@ class ItemsStore {
     collectionById: {}
   };
 
-  private _state = reactive<ItemsState>(klona(this._defaultState));
+  private _state = reactive<ItemsState>(structuredClone(this._defaultState));
   /**
    * == GETTERS AND SETTERS ==
    */

--- a/frontend/src/store/playbackManager.ts
+++ b/frontend/src/store/playbackManager.ts
@@ -6,7 +6,6 @@
  */
 import { reactive, watch } from 'vue';
 import { shuffle, isNil } from 'lodash-es';
-import { klona } from 'klona';
 import {
   BaseItemDto,
   ChapterInfo,
@@ -139,7 +138,9 @@ class PlaybackManagerStore {
     playbackInitMode: InitMode.Unknown
   };
 
-  private _state = reactive<PlaybackManagerState>(klona(this._defaultState));
+  private _state = reactive<PlaybackManagerState>(
+    structuredClone(this._defaultState)
+  );
   /**
    * == GETTERS AND SETTERS ==
    */

--- a/frontend/src/store/playerElement.ts
+++ b/frontend/src/store/playerElement.ts
@@ -5,7 +5,6 @@
  * an agnostic way, regardless of where the media is being played (remotely or locally)
  */
 import { isNil } from 'lodash-es';
-import { klona } from 'klona';
 import { nextTick, reactive, watch } from 'vue';
 import JASSUB from 'jassub';
 import jassubWorker from 'jassub/dist/jassub-worker.js?url';
@@ -41,7 +40,9 @@ class PlayerElementStore {
     isStretched: true
   };
 
-  private _state = reactive<PlayerElementState>(klona(this._defaultState));
+  private _state = reactive<PlayerElementState>(
+    structuredClone(this._defaultState)
+  );
   /**
    * == GETTERS AND SETTERS ==
    */

--- a/frontend/src/store/taskManager.ts
+++ b/frontend/src/store/taskManager.ts
@@ -1,5 +1,4 @@
 import { RemovableRef, useStorage } from '@vueuse/core';
-import { klona } from 'klona';
 import { v4 } from 'uuid';
 import { watch } from 'vue';
 import { mergeExcludingUnknown } from '@/utils/data-manipulation';
@@ -59,7 +58,7 @@ class TaskManagerStore {
 
   private _state: RemovableRef<TaskManagerState> = useStorage(
     storeKey,
-    klona(this._defaultState),
+    structuredClone(this._defaultState),
     sessionStorage,
     {
       mergeDefaults: (storageValue, defaults) =>

--- a/frontend/src/store/userLibraries.ts
+++ b/frontend/src/store/userLibraries.ts
@@ -9,7 +9,6 @@ import {
   ImageType,
   ItemFields
 } from '@jellyfin/sdk/lib/generated-client';
-import { klona } from 'klona';
 import { CardShapes } from '@/utils/items';
 import { usei18n, useRemote, useSnackbar } from '@/composables';
 import { mergeExcludingUnknown } from '@/utils/data-manipulation';
@@ -69,7 +68,7 @@ class UserLibrariesStore {
 
   private _state: RemovableRef<UserLibrariesState> = useStorage(
     storeKey,
-    klona(this._defaultState),
+    structuredClone(this._defaultState),
     sessionStorage,
     {
       mergeDefaults: (storageValue, defaults) =>

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,6 @@
         "dompurify": "3.0.3",
         "hls.js": "1.4.5",
         "jassub": "1.7.1",
-        "klona": "2.0.6",
         "lodash-es": "4.17.21",
         "marked": "5.1.0",
         "sortablejs": "1.15.0",
@@ -4891,14 +4890,6 @@
       "resolved": "https://registry.npmjs.org/kebab-case/-/kebab-case-1.0.2.tgz",
       "integrity": "sha512-7n6wXq4gNgBELfDCpzKc+mRrZFs7D+wgfF5WRFLNAr4DA/qtr9Js8uOAVAfHhuLMfAcQ0pRKqbpjx+TcJVdE1Q==",
       "dev": true
-    },
-    "node_modules/klona": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.6.tgz",
-      "integrity": "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==",
-      "engines": {
-        "node": ">= 8"
-      }
     },
     "node_modules/known-css-properties": {
       "version": "0.27.0",


### PR DESCRIPTION
Using the native method will always be better (and probably faster) than using a 3rd party library

Reference from: https://github.com/jellyfin/jellyfin-vue/pull/2047#issuecomment-1596300769