### PR TITLE
refactor: remove apparent artificial limits

### DIFF
--- a/frontend/src/store/playbackManager.ts
+++ b/frontend/src/store/playbackManager.ts
@@ -838,8 +838,7 @@ class PlaybackManagerStore {
     const items = (
       await remote.sdk.newUserApi(getInstantMixApi).getInstantMixFromItem({
         id: itemId,
-        userId: remote.auth.currentUserId,
-        limit: 50
+        userId: remote.auth.currentUserId
       })
     ).data.Items;
 
@@ -915,7 +914,6 @@ class PlaybackManagerStore {
         filters: [ItemFilter.IsNotFolder],
         parentId,
         recursive: true,
-        limit: 300,
         sortBy,
         userId: remote.auth.currentUserId,
         fields: Object.values(ItemFields)
@@ -932,7 +930,6 @@ class PlaybackManagerStore {
         seriesId: item.SeriesId,
         isMissing: false,
         startItemId: item.Id,
-        limit: 300,
         userId: remote.auth.currentUserId,
         fields: Object.values(ItemFields)
       });

--- a/frontend/src/store/userLibraries.ts
+++ b/frontend/src/store/userLibraries.ts
@@ -146,7 +146,6 @@ class UserLibrariesStore {
       const audioResumes = (
         await remote.sdk.newUserApi(getItemsApi).getResumeItems({
           userId: remote.auth.currentUserId || '',
-          limit: 24,
           fields: [
             ItemFields.PrimaryImageAspectRatio,
             ItemFields.CanDelete,
@@ -176,7 +175,6 @@ class UserLibrariesStore {
       const videoResumes = (
         await remote.sdk.newUserApi(getItemsApi).getResumeItems({
           userId: remote.auth.currentUserId || '',
-          limit: 24,
           fields: [
             ItemFields.PrimaryImageAspectRatio,
             ItemFields.CanDelete,
@@ -206,7 +204,6 @@ class UserLibrariesStore {
       const upNext = (
         await remote.sdk.newUserApi(getTvShowsApi).getNextUp({
           userId: remote.auth.currentUserId,
-          limit: 24,
           fields: [
             ItemFields.PrimaryImageAspectRatio,
             ItemFields.CanDelete,
@@ -238,7 +235,6 @@ class UserLibrariesStore {
       const latestMedia = (
         await remote.sdk.newUserApi(getUserLibraryApi).getLatestMedia({
           userId: remote.auth.currentUserId || '',
-          limit: 24,
           fields: [
             ItemFields.PrimaryImageAspectRatio,
             ItemFields.CanDelete,
@@ -267,7 +263,6 @@ class UserLibrariesStore {
       const carouselItems = (
         await remote.sdk.newUserApi(getUserLibraryApi).getLatestMedia({
           userId: remote.auth.currentUserId || '',
-          limit: 10,
           fields: [
             ItemFields.Overview,
             ItemFields.PrimaryImageAspectRatio,


### PR DESCRIPTION
We shouldn't put artificial limits to what we want to retrieve from the server based on the performance the server has for a particular request. Server's performance is not a thing client's need to take care about, is solely server's responsability

When the new API is designed, we should follow a GH-like approach, where requests that might be long-running for large data lists are forced to use pagination and request cursors.

More info at https://github.com/jellyfin/jellyfin-next/discussions/7

This commit also fixes #2015

**Marking as draft since I'm not sure if the `userLibraries` limits are because a UI/UX design decision**