### PR TITLE
fix: TaskManagerButton hide by app-bar

### DIFF
--- a/frontend/src/components/Layout/AppBar/Buttons/TaskManagerButton.vue
+++ b/frontend/src/components/Layout/AppBar/Buttons/TaskManagerButton.vue
@@ -11,7 +11,7 @@
         persistent
         :transition="'slide-y-transition'"
         location="bottom"
-        :z-index="500">
+        :z-index="1006">
         <v-card min-width="25em">
           <v-list>
             <v-list-item


### PR DESCRIPTION
The first menu item in TaskManagerButton hided by app-bar

- Before
![before](https://github.com/jellyfin/jellyfin-vue/assets/22337304/157241a8-8db4-417e-9aee-2b30087d3b4a)

- After
![after](https://github.com/jellyfin/jellyfin-vue/assets/22337304/c792798e-d886-4d54-98fd-519819ab5dc7)

