### PR TITLE
fix: music visualizer volume change

### DIFF
--- a/frontend/src/components/Playback/MusicVisualizer.vue
+++ b/frontend/src/components/Playback/MusicVisualizer.vue
@@ -3,10 +3,6 @@
 </template>
 
 <script setup lang="ts">
-/**
- * TODO: When the WebAudio node is connected to audiomotion-analyzer, the volume
- * of the media increases abruptly. Investigate why and fix.
- */
 import { shallowRef, onMounted, onBeforeUnmount } from 'vue';
 import AudioMotionAnalyzer from 'audiomotion-analyzer';
 import { mediaWebAudio } from '@/store';
@@ -17,6 +13,7 @@ const visualizerElement = shallowRef<HTMLDivElement>();
 onMounted(() => {
   visualizerInstance = new AudioMotionAnalyzer(visualizerElement.value, {
     source: mediaWebAudio.sourceNode,
+    connectSpeakers: false,
     mode: 2,
     gradient: 'prism',
     reflexRatio: 0.025,


### PR DESCRIPTION
Output was doubled since the visualizer connects to the speakers by default. See https://github.com/hvianna/audioMotion-analyzer#connectspeakers-boolean for reference.