### PR TITLE
feat: support multiple streams for item menu

### DIFF
--- a/frontend/locales/en-US.json
+++ b/frontend/locales/en-US.json
@@ -45,6 +45,7 @@
   "communityRating": "Community rating",
   "confirm": "Confirm",
   "connect": "Connect",
+  "contentType": "Content type",
   "continueListening": "Continue listening",
   "continueWatching": "Continue watching",
   "copyPrompt": "Copy the following text into the clipboard?",

--- a/frontend/src/components/Item/Identify/IdentifyDialog.vue
+++ b/frontend/src/components/Item/Identify/IdentifyDialog.vue
@@ -105,7 +105,7 @@ interface IdentifyField {
   value?: string | null;
 }
 
-const props = defineProps<{ item: BaseItemDto; }>();
+const props = defineProps<{ item: BaseItemDto }>();
 
 const emit = defineEmits<{
   close: [];

--- a/frontend/src/components/Item/Identify/IdentifyDialog.vue
+++ b/frontend/src/components/Item/Identify/IdentifyDialog.vue
@@ -105,7 +105,7 @@ interface IdentifyField {
   value?: string | null;
 }
 
-const props = defineProps<{ item: BaseItemDto; mediaSourceIndex?: number }>();
+const props = defineProps<{ item: BaseItemDto; }>();
 
 const emit = defineEmits<{
   close: [];
@@ -208,10 +208,6 @@ const progress = computed(() => {
 const itemPath = computed<string | undefined>(() => {
   if (!props.item) {
     return;
-  }
-
-  if (props.mediaSourceIndex !== undefined) {
-    return props.item.MediaSources?.[props.mediaSourceIndex]?.Path ?? undefined;
   }
 
   return props.item.Path ?? undefined;

--- a/frontend/src/components/Item/ItemMenu.vue
+++ b/frontend/src/components/Item/ItemMenu.vue
@@ -37,6 +37,7 @@
   <MetadataEditorDialog
     v-if="metadataDialog && item.Id"
     :item-id="item.Id"
+    :media-source-index="mediaSourceIndex"
     @close="metadataDialog = false" />
   <RefreshMetadataDialog
     v-if="refreshDialog && item.Id"
@@ -49,6 +50,7 @@
   <MediaDetailDialog
     v-if="mediaInfoDialog && item.Id"
     :item="menuProps.item"
+    :media-source-index="mediaSourceIndex"
     @close="mediaInfoDialog = false" />
 </template>
 
@@ -80,6 +82,7 @@ import {
   canInstantMix,
   canRefreshMetadata,
   canResume,
+  getItemIdFromSourceIndex,
   getItemDownloadUrl,
   getItemSeasonDownloadMap,
   getItemSeriesDownloadMap
@@ -107,12 +110,14 @@ const menuProps = withDefaults(
     zIndex?: number;
     rightClick?: boolean;
     queue?: boolean;
+    mediaSourceIndex?: number;
   }>(),
   {
     outlined: false,
     zIndex: 1000,
     rightClick: true,
-    queue: false
+    queue: false,
+    mediaSourceIndex: undefined
   }
 );
 const { t } = useI18n();
@@ -146,6 +151,23 @@ const errorMessage = t('errors.anErrorHappened');
 const isItemRefreshing = computed(
   () => taskManager.getTask(menuProps.item.Id || '') !== undefined
 );
+const itemDeletionName = computed(() => {
+  const parentName = menuProps.item.Name ?? undefined;
+  const mediaSource =
+    menuProps.item.MediaSources?.[menuProps.mediaSourceIndex ?? -1];
+
+  if (mediaSource?.Name) {
+    let name = mediaSource.Name;
+
+    if (parentName) {
+      name = `${parentName} - ${name}`;
+    }
+
+    return name;
+  }
+
+  return parentName;
+});
 
 /**
  * == ACTIONS ==
@@ -258,16 +280,21 @@ const deleteItemAction = {
   action: async (): Promise<void> => {
     await useConfirmDialog(
       async () => {
-        if (!menuProps.item.Id) {
+        const itemDeletionId = getItemIdFromSourceIndex(
+          menuProps.item,
+          menuProps.mediaSourceIndex
+        );
+
+        if (!itemDeletionId) {
           return;
         }
 
         try {
           await remote.sdk.newUserApi(getLibraryApi).deleteItem({
-            itemId: menuProps.item.Id
+            itemId: itemDeletionId
           });
 
-          if (route.fullPath.includes(menuProps.item.Id)) {
+          if (itemDeletionId === menuProps.item.Id && route.fullPath.includes(itemDeletionId)) {
             await router.replace('/');
           }
         } catch (error) {
@@ -279,6 +306,7 @@ const deleteItemAction = {
       {
         title: t('deleteItem'),
         text: t('deleteItemDescription'),
+        subtitle: itemDeletionName.value,
         confirmText: t('delete')
       }
     );
@@ -315,7 +343,9 @@ const copyDownloadURLAction = {
           break;
         }
         default: {
-          streamUrls = getItemDownloadUrl(menuProps.item.Id);
+          streamUrls = getItemDownloadUrl(
+            getItemIdFromSourceIndex(menuProps.item, menuProps.mediaSourceIndex)
+          );
           break;
         }
       }

--- a/frontend/src/components/Item/ItemMenu.vue
+++ b/frontend/src/components/Item/ItemMenu.vue
@@ -35,9 +35,8 @@
     </VMenu>
   </VBtn>
   <MetadataEditorDialog
-    v-if="metadataDialog && item.Id"
-    :item-id="item.Id"
-    :media-source-index="mediaSourceIndex"
+    v-if="metadataDialog && itemId"
+    :item-id="itemId"
     @close="metadataDialog = false" />
   <RefreshMetadataDialog
     v-if="refreshDialog && item.Id"
@@ -139,6 +138,11 @@ const show = computed({
     openMenu.value = newVal ? instanceId : undefined;
   }
 });
+const itemId = computed(
+  () => getItemIdFromSourceIndex(
+    menuProps.item, menuProps.mediaSourceIndex
+  )
+);
 const positionX = ref<number | undefined>(undefined);
 const positionY = ref<number | undefined>(undefined);
 const metadataDialog = ref(false);
@@ -280,21 +284,16 @@ const deleteItemAction = {
   action: async (): Promise<void> => {
     await useConfirmDialog(
       async () => {
-        const itemDeletionId = getItemIdFromSourceIndex(
-          menuProps.item,
-          menuProps.mediaSourceIndex
-        );
-
-        if (!itemDeletionId) {
+        if (!itemId.value) {
           return;
         }
 
         try {
           await remote.sdk.newUserApi(getLibraryApi).deleteItem({
-            itemId: itemDeletionId
+            itemId: itemId.value
           });
 
-          if (itemDeletionId === menuProps.item.Id && route.fullPath.includes(itemDeletionId)) {
+          if (itemId.value === menuProps.item.Id && route.fullPath.includes(itemId.value)) {
             await router.replace('/');
           }
         } catch (error) {
@@ -343,9 +342,7 @@ const copyDownloadURLAction = {
           break;
         }
         default: {
-          streamUrls = getItemDownloadUrl(
-            getItemIdFromSourceIndex(menuProps.item, menuProps.mediaSourceIndex)
-          );
+          streamUrls = getItemDownloadUrl(itemId.value);
           break;
         }
       }

--- a/frontend/src/components/Item/MediaDetail/MediaDetailDialog.vue
+++ b/frontend/src/components/Item/MediaDetail/MediaDetailDialog.vue
@@ -3,7 +3,7 @@
     :model-value="model"
     :title="displayName"
     @close="close">
-    <template v-if="mediaSources.length > 1">
+    <template v-if="mediaSources.length > 1 && isNil(mediaSourceIndex)">
       <VCardText>
         <MediaSourceSelector
           class="pt-2"

--- a/frontend/src/components/Item/Metadata/MetadataEditor.vue
+++ b/frontend/src/components/Item/Metadata/MetadataEditor.vue
@@ -36,6 +36,14 @@
         v-model="tabName"
         class="pa-2 flex-fill">
         <VWindowItem value="general">
+          <VSelect
+            v-if="contentOptions.length > 1"
+            v-model="contentOption"
+            :items="contentOptions"
+            :label="t('contentType')"
+            item-title="key"
+            item-value="value"
+            return-object />
           <VTextField
             v-model="metadata.Name"
             variant="outlined"
@@ -220,8 +228,14 @@ import { getGenresApi } from '@jellyfin/sdk/lib/utils/api/genres-api';
 import { getItemUpdateApi } from '@jellyfin/sdk/lib/utils/api/item-update-api';
 import { format, formatISO } from 'date-fns';
 import { useDateFns, useRemote, useSnackbar } from '@/composables';
+import { getItemIdFromSourceIndex } from '@/utils/items';
 
-const props = defineProps<{ itemId: string }>();
+type ContentOption = {
+  value: string;
+  key: string;
+};
+
+const props = defineProps<{ itemId: string; mediaSourceIndex?: number }>();
 
 const emit = defineEmits<{
   save: [];
@@ -238,6 +252,9 @@ const person = ref<BaseItemPerson>();
 const genres = ref<string[]>([]);
 const loading = ref(false);
 const tabName = ref<string>();
+const contentOptions = ref<ContentOption[]>([]);
+const contentOption = ref<ContentOption>();
+const contentType = ref<string>();
 const genresModel = computed({
   get() {
     return metadata.value?.Genres === null ? undefined : metadata.value?.Genres;
@@ -294,12 +311,47 @@ const tagLine = computed({
  * Fetch data ancestors for the current item
  */
 async function getData(): Promise<void> {
-  const itemInfo = (
+  let itemInfo = (
     await remote.sdk.newUserApi(getUserLibraryApi).getItem({
       userId: remote.auth.currentUserId ?? '',
       itemId: props.itemId
     })
   ).data;
+
+  const sourceId = getItemIdFromSourceIndex(itemInfo, props.mediaSourceIndex);
+
+  if (sourceId !== props.itemId) {
+    // This is another version of the same item, fetch the actual metadata for this.
+    itemInfo = (
+      await remote.sdk.newUserApi(getUserLibraryApi).getItem({
+        userId: remote.auth.currentUserId ?? '',
+        itemId: sourceId
+      })
+    ).data;
+
+    // Fetch metadata editor info for ContentTypeOptions
+    const options = (
+      await remote.sdk.newUserApi(getItemUpdateApi).getMetadataEditorInfo({
+        itemId: sourceId
+      })
+    ).data;
+
+    contentOptions.value =
+      options?.ContentTypeOptions?.map((r) => {
+        if (r.Name) {
+          return {
+            // The option name
+            key: r.Name,
+            // The one that will be sent
+            value: r.Value ?? ''
+          };
+        }
+      }).filter((r): r is ContentOption => r !== undefined) ?? [];
+    contentOption.value =
+      contentOptions.value.find((r) => r.value === options.ContentType) ??
+      contentOptions.value[0];
+    contentType.value = options.ContentType ?? contentOption.value.value;
+  }
 
   metadata.value = itemInfo;
 
@@ -334,6 +386,26 @@ async function getGenres(parentId: string): Promise<void> {
     ).data.Items?.map((index) => index.Name).filter(
       (genre): genre is string => !!genre
     ) ?? [];
+}
+
+/**
+ * Save metadata content type for the current item
+ */
+async function saveContentType(): Promise<void> {
+  if (!contentOption.value) {
+    return;
+  }
+
+  if (!metadata.value?.Id) {
+    return;
+  }
+
+  if (contentOption.value.value !== contentType.value) {
+    await remote.sdk.newUserApi(getItemUpdateApi).updateItemContentType({
+      itemId: metadata.value?.Id,
+      contentType: contentOption.value.value
+    });
+  }
 }
 
 /**
@@ -395,6 +467,7 @@ async function saveMetadata(): Promise<void> {
       itemId: metadata.value?.Id,
       baseItemDto: item
     });
+    await saveContentType();
     emit('save');
     useSnackbar(t('saved'), 'success');
   } catch (error) {

--- a/frontend/src/components/Item/Metadata/MetadataEditor.vue
+++ b/frontend/src/components/Item/Metadata/MetadataEditor.vue
@@ -37,7 +37,7 @@
         class="pa-2 flex-fill">
         <VWindowItem value="general">
           <VSelect
-            v-if="contentOptions.length > 1"
+            v-if="contentOptions.length > 0"
             v-model="contentOption"
             :items="contentOptions"
             :label="t('contentType')"
@@ -234,7 +234,7 @@ type ContentOption = {
   key: string;
 };
 
-const props = defineProps<{ itemId: string; }>();
+const props = defineProps<{ itemId: string }>();
 
 const emit = defineEmits<{
   save: [];

--- a/frontend/src/components/Item/Metadata/MetadataEditorDialog.vue
+++ b/frontend/src/components/Item/Metadata/MetadataEditorDialog.vue
@@ -6,7 +6,6 @@
     @after-leave="emit('close')">
     <MetadataEditor
       :item-id="itemId"
-      :media-source-index="mediaSourceIndex"
       @cancel="model = false"
       @save="model = false" />
   </VDialog>
@@ -15,7 +14,7 @@
 <script setup lang="ts">
 import { ref } from 'vue';
 
-defineProps<{ itemId: string, mediaSourceIndex?: number }>();
+defineProps<{ itemId: string; }>();
 
 const emit = defineEmits<{
   close: [];

--- a/frontend/src/components/Item/Metadata/MetadataEditorDialog.vue
+++ b/frontend/src/components/Item/Metadata/MetadataEditorDialog.vue
@@ -6,6 +6,7 @@
     @after-leave="emit('close')">
     <MetadataEditor
       :item-id="itemId"
+      :media-source-index="mediaSourceIndex"
       @cancel="model = false"
       @save="model = false" />
   </VDialog>
@@ -14,7 +15,7 @@
 <script setup lang="ts">
 import { ref } from 'vue';
 
-defineProps<{ itemId: string }>();
+defineProps<{ itemId: string, mediaSourceIndex?: number }>();
 
 const emit = defineEmits<{
   close: [];

--- a/frontend/src/components/Item/Metadata/MetadataEditorDialog.vue
+++ b/frontend/src/components/Item/Metadata/MetadataEditorDialog.vue
@@ -14,7 +14,7 @@
 <script setup lang="ts">
 import { ref } from 'vue';
 
-defineProps<{ itemId: string; }>();
+defineProps<{ itemId: string }>();
 
 const emit = defineEmits<{
   close: [];

--- a/frontend/src/components/Layout/AudioControls.vue
+++ b/frontend/src/components/Layout/AudioControls.vue
@@ -80,6 +80,7 @@
             </div>
             <ItemMenu
               :item="playbackManager.currentItem"
+              :media-source-index="playbackManager.currentMediaSourceIndex"
               :z-index="99999" />
             <VBtn
               icon

--- a/frontend/src/pages/item/_itemId/index.vue
+++ b/frontend/src/pages/item/_itemId/index.vue
@@ -52,7 +52,9 @@
             <MarkPlayedButton
               :item="item"
               class="mr-2" />
-            <ItemMenu :item="item" />
+            <ItemMenu
+              :item="item"
+              :media-source-index="currentSourceIndex" />
           </VRow>
           <VCol
             cols="12"

--- a/frontend/src/store/playbackManager.ts
+++ b/frontend/src/store/playbackManager.ts
@@ -445,6 +445,10 @@ class PlaybackManagerStore {
     return this._state.currentMediaSource;
   }
 
+  public get currentMediaSourceIndex(): number | undefined {
+    return this._state.currentMediaSourceIndex;
+  }
+
   public get isMuted(): boolean {
     return this._state.isRemotePlayer
       ? this._state.isRemoteMuted

--- a/frontend/src/utils/items.ts
+++ b/frontend/src/utils/items.ts
@@ -461,6 +461,26 @@ export function getMediaStreams(
 }
 
 /**
+ * Get the item ID either from the item itself or from the MediaSource
+ *
+ * @param item - The item to get the ID from
+ * @param sourceIndex - The index of the MediaSource to get the ID from (optional)
+ * @returns The ID of the item or the MediaSource
+ */
+export function getItemIdFromSourceIndex(
+  item: BaseItemDto,
+  sourceIndex?: number
+): string {
+  if (sourceIndex === undefined) {
+    return item.Id ?? '';
+  }
+
+  const mediaSource = item.MediaSources?.[sourceIndex];
+
+  return (mediaSource ? mediaSource.Id : item.Id) ?? '';
+}
+
+/**
  * Create an item download object that contains the URL and filename.
  *
  * @returns - A download object.


### PR DESCRIPTION
The following context menu has been adjusted for multiple media streams:
- Delete (should correctly delete the selected stream)
- Media Info (hide the stream selector if media index is provided)
- Metadata editor (should correctly show/edit the selected stream)

The multi-supported context menu would only show on the following:
- Item page
- Playback bar (audio mode)

Anything outside just default to the first media source.