### PR TITLE
fix(ci): docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ## This dockerfile builds the client entirely in a Docker context
 
-FROM node:18-alpine AS build
+FROM node:18 AS build
 
 # Set build arguments
 ARG DEFAULT_SERVERS
@@ -12,8 +12,6 @@ ENV DEFAULT_SERVERS=$DEFAULT_SERVERS
 ENV HISTORY_ROUTER_MODE=$HISTORY_ROUTER_MODE
 ENV IS_STABLE=$IS_STABLE
 
-# Prepare environment. git is needed for fetching the latest commit
-RUN apk add --no-cache git
 WORKDIR /app
 COPY . .
 
@@ -24,7 +22,7 @@ RUN npm ci --no-audit
 RUN if [[ $IS_STABLE == "0" ]] ; then export COMMIT_HASH=$(git rev-parse HEAD) ; fi && npm run build
 
 # Deploy built distribution to nginx
-FROM nginx:alpine-slim
+FROM nginx:stable-alpine-slim
 
 COPY --from=build /app/frontend/dist/ /usr/share/nginx/html/
 COPY .docker/nginx.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
Given Alpine doesn't use glibc, and LightningCSS
doesn't provide a `lightningcss-linux-arm-musl` target,
build fails for `linux/arm` platform. Switch to Debian, since we don't
need the build container to have alpine's small footprint and
this might resolve other incompatibilities in the future.

Reported upstream at https://github.com/parcel-bundler/lightningcss/issues/563

What this commit does:

* Switch nginx to stable version instead of mainline (keeping it in alpine since
we don't have any requirement after the frontend is built).

* Switch from `node:18-alpine` to `node:18`, which also saves us the extra
layer of installing git, ending up being much faster since we don't have to run
`apt update` either to update the apt index (the extra pull bandwidth
required to pull a bigger image is still faster).