### PR TITLE
chore(codespaces): switch to node as base image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "jellyfin-vue Codespace (with support for Tauri and Docker development)",
-  "image": "mcr.microsoft.com/devcontainers/typescript-node:0-18",
+  "image": "node:18-slim",
   "features": {
     "ghcr.io/devcontainers/features/rust:1": {
       "profile": "default"
@@ -10,7 +10,6 @@
     },
     "ghcr.io/devcontainers/features/github-cli:1": {}
   },
-  "containerEnv": { "SHELL": "/bin/bash" },
   "forwardPorts": [3000],
   "portsAttributes": {
     "3000": {
@@ -18,6 +17,7 @@
       "onAutoForward": "notify"
     }
   },
+  "onCreateCommand": "unset YARN_VERSION && rm -rf /bin/sh /opt/yarn* && ln -s /bin/bash /bin/sh && apt update && apt install -y --no-install-recommends jq && apt clean && apt autoclean && rm -rf /var/lib/apt/lists /var/cache/apt/archives",
   "postCreateCommand": "npm ci --no-audit",
   "postAttachCommand": "cat .vscode/extensions.json | jq -r .recommendations[] | xargs -n 1 code --install-extension",
   "hostRequirements": { "cpus": 4, "memory": "8gb" }


### PR DESCRIPTION
The Microsoft image includes some dependencies installed globally, which increases load times and storage space
for Codespaces unnecessarily.

It also let us debug the Dockerfile more easily in case it's needed since we share the same base image with it.