### PR TITLE
Fix direct play stream url regression

### DIFF
--- a/frontend/src/store/playbackManager.ts
+++ b/frontend/src/store/playbackManager.ts
@@ -975,7 +975,9 @@ class PlaybackManagerStore {
 
       const parameters = new URLSearchParams(directOptions).toString();
 
-      if (mediaType === 'Video') mediaType = 'Videos';
+      if (mediaType === 'Video') {
+        mediaType = 'Videos';
+      }
 
       return `${remote.sdk.api.basePath}/${mediaType}/${mediaSource.Id}/stream.${mediaSource.Container}?${parameters}`;
     } else if (remote.sdk.api?.basePath && mediaSource?.SupportsTranscoding && mediaSource.TranscodingUrl) {

--- a/frontend/src/store/playbackManager.ts
+++ b/frontend/src/store/playbackManager.ts
@@ -975,6 +975,8 @@ class PlaybackManagerStore {
 
       const parameters = new URLSearchParams(directOptions).toString();
 
+      if (mediaType === 'Video') mediaType = 'Videos';
+
       return `${remote.sdk.api.basePath}/${mediaType}/${mediaSource.Id}/stream.${mediaSource.Container}?${parameters}`;
     } else if (remote.sdk.api?.basePath && mediaSource?.SupportsTranscoding && mediaSource.TranscodingUrl) {
       return `${remote.sdk.api.basePath}${mediaSource.TranscodingUrl}`;


### PR DESCRIPTION
Stream URLs are at /Videos/ not /Video/.

5e33e8e0fbe465971c92074a366a5eefa2feb9cb introduced this regression, by replacing `'Videos'` with `this.currentlyPlayingMediaType` which contains value `'Video'`.

This regression means that playing videos that have direct play available results in a 404, and the player hangs.

What has me quite confused is... this regression was introduced back in June, almost 4 months ago... how did nobody notice that playing *any* direct play movie/video was broken?