### PR TITLE
Allow installation in a sub-path : Fixes #2085 

### DIFF
--- a/frontend/src/utils/external-config.ts
+++ b/frontend/src/utils/external-config.ts
@@ -48,7 +48,7 @@ function validateJsonConfig(
 export async function getJSONConfig(): Promise<ExternalJSONConfig> {
   if (isNil(externalConfig)) {
     const loadedConfig: unknown = await (
-      await fetch('/config.json', { cache: 'no-store' })
+      await fetch('config.json', { cache: 'no-store' })
     ).json();
 
     validateJsonConfig(loadedConfig);

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -23,6 +23,7 @@ import { localeFilesFolder, srcRoot } from './scripts/paths';
 export default defineConfig(({ mode }): UserConfig => {
   const config: UserConfig = {
     appType: 'spa',
+    base: './',
     define: {
       __COMMIT_HASH__: JSON.stringify(process.env.COMMIT_HASH || '')
     },


### PR DESCRIPTION
This PR leverages Vite's [base option](https://vitejs.dev/config/shared-options.html#base) to facilitate the deployment of jellyfin-vue into a sub-directory. Additionally, by modifying the fetch request in external-config.ts to exclude the leading `/`, a more adaptable path resolution is achieved.

Note: A trailing slash is requisite when accessing the instance (e.g., https://example.com/jf/ instead of https://example.com/jf), due to Vite's current configuration constraints.