### PR TITLE
Fixes #2085 - Allow installation in a sub-path

### DIFF
--- a/frontend/src/utils/external-config.ts
+++ b/frontend/src/utils/external-config.ts
@@ -48,7 +48,7 @@ function validateJsonConfig(
 export async function getJSONConfig(): Promise<ExternalJSONConfig> {
   if (isNil(externalConfig)) {
     const loadedConfig: unknown = await (
-      await fetch('/config.json', { cache: 'no-store' })
+      await fetch('config.json', { cache: 'no-store' })
     ).json();
 
     validateJsonConfig(loadedConfig);

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -23,6 +23,7 @@ import { localeFilesFolder, srcRoot } from './scripts/paths';
 export default defineConfig(({ mode }): UserConfig => {
   const config: UserConfig = {
     appType: 'spa',
+    base: './',
     define: {
       __COMMIT_HASH__: JSON.stringify(process.env.COMMIT_HASH || '')
     },


### PR DESCRIPTION
By setting the [`base` option ](https://vitejs.dev/config/shared-options.html#base) to `./` we enable _relative_ loading of assets and replace the current _absolute_ path resolution. This, along with removing the leading `/` when loading the external config via fetch allows the client to be installed in a sub-path at any level of nesting.

This **does not** require any changes to the env file, or any other changes by the user. 