### PR TITLE
fix: disable eslastic overscroll

### DIFF
--- a/frontend/src/assets/styles/global.scss
+++ b/frontend/src/assets/styles/global.scss
@@ -3,6 +3,10 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
+html {
+  overscroll-behavior: none;
+}
+
 html.no-forced-scrollbar {
   overflow-y: unset !important;
 }


### PR DESCRIPTION
There is no point in having elastic overscroll since when we have proper data fetching we will have all the updates handled by the websocket.

It also requires proper thinking and testing when introducing UI features and not all developers have a touchpad to notice this behaviour properly
(it went unnoticed for so long in fact).

Main reason is the UI is buggy for it.