### PR TITLE
Update CloudFlare -> Cloudflare in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ This is an alternative client for Jellyfin based on Vue.js. It might not be feat
 
 ## [Hosted instance 🌍](https://jf-vue.pages.dev/)
 
-Our hosted instance points to a version built from the current `master` branch. Hosted by CloudFlare Pages.
+Our hosted instance points to a version built from the current `master` branch. Hosted by Cloudflare Pages.
 
 ⚠️ **This only works for Jellyfin servers that [are behind a reverse proxy and has HTTPS correctly set up](https://jellyfin.org/docs/general/networking/#running-jellyfin-behind-a-reverse-proxy)**. If your server runs over HTTP, you must use another deployment type.
 


### PR DESCRIPTION
In 2016, CloudFlare changed their name to Cloudflare (lack of capital F). See blog: https://blog.cloudflare.com/time-for-an-update/

This PR is just a simple, one-letter fix for the README to match this branding. Not important really but I thought I'd correct it since I noticed it.