### PR TITLE
refactor(splashscreen): emit splashcreen code with rollup instead of embedding in index.html

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -90,6 +90,7 @@
         transition: opacity 0.75s linear;
       }
     </style>
+    <script type="module" src="src/splashscreen.ts"></script>
     <script type="module" src="src/main.ts"></script>
     <title>Jellyfin Vue</title>
   </head>
@@ -98,21 +99,5 @@
       <div class="splashLogo"></div>
     </div>
     <div id="app"></div>
-    <!-- Load splashcreen color scheme based on stored settings or user-agent preferences. -->
-    <script>
-      const store = localStorage.getItem('clientSettings') || '{}';
-      const storedMode = JSON.parse(store).darkMode;
-      const matchedDarkColorScheme = window.matchMedia(
-        'prefers-color-scheme: dark'
-      ).matches;
-      const useDarkMode =
-        typeof storedMode === 'boolean' ? storedMode : matchedDarkColorScheme;
-      const classToApply = useDarkMode ? 'dark' : 'light';
-      const element = document.querySelector('.splashBackground');
-
-      if (element) {
-        element.classList.add(classToApply);
-      }
-    </script>
   </body>
 </html>

--- a/frontend/src/splashscreen.ts
+++ b/frontend/src/splashscreen.ts
@@ -1,0 +1,26 @@
+/**
+ * Load splashcreen color scheme based on stored settings or user-agent preferences
+ */
+import { destr } from 'destr';
+import type { ClientSettingsState } from './store/clientSettings';
+
+const store = localStorage.getItem('clientSettings') ?? '{}';
+const parsedStore = destr<ClientSettingsState>(store);
+const matchedDarkColorScheme = window.matchMedia(
+  '(prefers-color-scheme: dark)'
+).matches;
+let classToApply: 'light' | 'dark' = matchedDarkColorScheme ? 'dark' : 'light';
+
+if ('darkMode' in parsedStore) {
+  const storeDarkMode = parsedStore.darkMode;
+
+  if (typeof storeDarkMode === 'boolean') {
+    classToApply = parsedStore.darkMode === true ? 'dark' : 'light';
+  }
+}
+
+const element = document.querySelector('.splashBackground');
+
+if (element) {
+  element.classList.add(classToApply);
+}

--- a/frontend/src/store/clientSettings.ts
+++ b/frontend/src/store/clientSettings.ts
@@ -18,7 +18,7 @@ import { computed, nextTick, watch } from 'vue';
  * Casted typings for the CustomPrefs property of DisplayPreferencesDto
  */
 
-interface ClientSettingsState {
+export interface ClientSettingsState {
   darkMode: 'auto' | boolean;
   locale: string;
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -69,8 +69,12 @@ export default defineConfig(({ mode }): UserConfig => {
       modulePreload: false,
       reportCompressedSize: false,
       rollupOptions: {
+        input: {
+          splashscreen: 'src/splashscreen.ts',
+          main: 'src/main.ts',
+          index: 'index.html'
+        },
         output: {
-          inlineDynamicImports: true,
           validate: true,
           plugins: [
             mode === 'analyze'


### PR DESCRIPTION
This will ease the maintenance burden of that code by allowing us to use the same tooling we use for the rest of the code (type-checking, eslint, etc)
while also allowing us to use npm dependencies (like destr in this case), which could be
helpful in the future.