### PR TITLE
perf: better GC of time-related computed effects

### DIFF
--- a/frontend/locales/en-US.json
+++ b/frontend/locales/en-US.json
@@ -143,7 +143,7 @@
   "language": "Language",
   "languageLocale": "Language and locale",
   "lastActive": "Last active",
-  "lastActivityDate": "Last seen {value} ago",
+  "lastActivityDate": "Last seen {value}",
   "latestLibrary": "Latest {libraryName}",
   "libraries": "Libraries",
   "librariesSettingsDescription": "Manage libraries and their metadata",

--- a/frontend/src/components/Item/Metadata/MetadataEditor.vue
+++ b/frontend/src/components/Item/Metadata/MetadataEditor.vue
@@ -276,20 +276,12 @@ const tagsModel = computed({
   }
 });
 
-/**
- * TODO: These calls to useDateFns can cause memory leaks because a computed effect is instantiated
- * inside another computed effect.
- *
- * Refactor this so the v-model is effectively in use with computed getters/setters and metadata.value is always defined.
- */
-
 const premiereDate = computed(() => {
   if (!metadata.value?.PremiereDate) {
     return '';
   }
 
-  return useDateFns(format, new Date(metadata.value.PremiereDate), 'yyyy-MM-dd')
-    .value;
+  return useDateFns(format, new Date(metadata.value.PremiereDate), 'yyyy-MM-dd');
 });
 
 const dateCreated = computed(() => {
@@ -297,8 +289,7 @@ const dateCreated = computed(() => {
     return '';
   }
 
-  return useDateFns(format, new Date(metadata.value.DateCreated), 'yyyy-MM-dd')
-    .value;
+  return useDateFns(format, new Date(metadata.value.DateCreated), 'yyyy-MM-dd');
 });
 
 const tagLine = computed({

--- a/frontend/src/components/Playback/UpNext.vue
+++ b/frontend/src/components/Playback/UpNext.vue
@@ -43,7 +43,7 @@
               <span class="pl-4">
                 {{
                   $t('endsAt', {
-                    time: getEndsAtTime(playbackManager.nextItem.RunTimeTicks)
+                    time: getEndsAtTime(playbackManager.nextItem.RunTimeTicks).value
                   })
                 }}
               </span>

--- a/frontend/src/composables/use-datefns.ts
+++ b/frontend/src/composables/use-datefns.ts
@@ -25,7 +25,7 @@ export function useDateFns<T extends (...a: any[]) => any>(
     ''
   ) as keyof typeof datefnslocales;
 
-  if (typeof params.at(-1) === 'object') {
+  if (typeof params.at(-1) === 'object' && !(params.at(-1) instanceof Date)) {
     params.at(-1).locale = datefnslocales[importCode];
   } else {
     params.push({ locale: datefnslocales[importCode] });

--- a/frontend/src/composables/use-datefns.ts
+++ b/frontend/src/composables/use-datefns.ts
@@ -1,6 +1,5 @@
 import { i18n } from '@/plugins/i18n';
 import * as datefnslocales from 'virtual:locales/date-fns';
-import { computed, ComputedRef } from 'vue';
 
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return */
 
@@ -9,30 +8,30 @@ import { computed, ComputedRef } from 'vue';
  * Pass the date-fns function to invoke as the first parameter,
  * and it's parameters as the second parameter
  *
+ * THIS FUNCTION MUST BE CALLED INSIDE A COMPUTED PROPERTY OR A TEMPLATE FOR CHANGES TO THE CURRENT LOCALE TO BE REFLECTED
+ *
  * @param func - date-fns function to invoke
  * @param params - Parameters to pass to the date-fns function
  */
 export function useDateFns<T extends (...a: any[]) => any>(
   func: T,
   ...params: Parameters<T>
-): ComputedRef<ReturnType<T>> {
-  return computed<ReturnType<T>>(() => {
-    /**
-     * We need to remove the hyphen of our locale codes, as using named exports with them is not valid JS syntax
-     */
-    const importCode = i18n.locale.value.replace(
-      '-',
-      ''
-    ) as keyof typeof datefnslocales;
+): ReturnType<T> {
+  /**
+   * We need to remove the hyphen of our locale codes, as using named exports with them is not valid JS syntax
+   */
+  const importCode = i18n.locale.value.replace(
+    '-',
+    ''
+  ) as keyof typeof datefnslocales;
 
-    if (typeof params.at(-1) === 'object') {
-      params.at(-1).locale = datefnslocales[importCode];
-    } else {
-      params.push({ locale: datefnslocales[importCode] });
-    }
+  if (typeof params.at(-1) === 'object') {
+    params.at(-1).locale = datefnslocales[importCode];
+  } else {
+    params.push({ locale: datefnslocales[importCode] });
+  }
 
-    return func(...params);
-  });
+  return func(...params);
 }
 
 /* eslint-enable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return */

--- a/frontend/src/pages/person/[itemId].vue
+++ b/frontend/src/pages/person/[itemId].vue
@@ -194,13 +194,13 @@ const activeTab = ref(4);
 
 const birthDate = computed(() =>
   item.value.PremiereDate
-    ? useDateFns(format, new Date(item.value.PremiereDate), 'PPP').value
+    ? useDateFns(format, new Date(item.value.PremiereDate), 'PPP')
     : undefined
 );
 
 const deathDate = computed(() =>
   item.value.EndDate
-    ? useDateFns(format, new Date(item.value.EndDate), 'PPP').value
+    ? useDateFns(format, new Date(item.value.EndDate), 'PPP')
     : undefined
 );
 

--- a/frontend/src/pages/settings/apikeys.vue
+++ b/frontend/src/pages/settings/apikeys.vue
@@ -47,7 +47,7 @@
                       formatRelative,
                       parseJSON(apiKey[value] ?? 'unknown'),
                       new Date()
-                    ).value
+                    )
                 }}
               </td>
               <td>

--- a/frontend/src/pages/settings/devices.vue
+++ b/frontend/src/pages/settings/devices.vue
@@ -48,7 +48,7 @@
                       formatRelative,
                       parseJSON(device[value] ?? 'unknown'),
                       new Date()
-                    ).value
+                    )
                 }}
               </td>
               <td>

--- a/frontend/src/pages/settings/logs-and-activity.vue
+++ b/frontend/src/pages/settings/logs-and-activity.vue
@@ -182,17 +182,17 @@ function getIconFromActivityType(
 /**
  * Format activitydates
  */
-function getFormattedActivityDate(date: string | undefined): string {
+function getFormattedActivityDate(date: string | undefined): string | undefined {
   return date
-    ? useDateFns(formatRelative, parseJSON(date), new Date()).value
-    : '';
+    ? useDateFns(formatRelative, parseJSON(date), new Date())
+    : undefined;
 }
 
 /**
  * Format log dates
  */
-function getFormattedLogDate(date: string | undefined): string {
-  return date ? useDateFns(format, parseJSON(date), 'Ppp').value : '';
+function getFormattedLogDate(date: string | undefined): string | undefined {
+  return date ? useDateFns(format, parseJSON(date), 'Ppp') : undefined;
 }
 
 /**

--- a/frontend/src/pages/settings/users/index.vue
+++ b/frontend/src/pages/settings/users/index.vue
@@ -39,7 +39,7 @@
                   class="pa-0 fixed-width">
                   {{
                     $t('lastActivityDate', {
-                      value: useDateFns(formatDistanceToNow, new Date(user.LastActivityDate)).value
+                      value: useDateFns(formatDistanceToNow, new Date(user.LastActivityDate))
                     })
                   }}
                 </VCardSubtitle>

--- a/frontend/src/pages/settings/users/index.vue
+++ b/frontend/src/pages/settings/users/index.vue
@@ -39,7 +39,7 @@
                   class="pa-0 fixed-width">
                   {{
                     $t('lastActivityDate', {
-                      value: useDateFns(formatDistanceToNow, new Date(user.LastActivityDate))
+                      value: useDateFns(formatDistanceToNow, new Date(user.LastActivityDate), { addSuffix: true })
                     })
                   }}
                 </VCardSubtitle>

--- a/frontend/src/utils/time.ts
+++ b/frontend/src/utils/time.ts
@@ -91,11 +91,13 @@ function getEndsAtDate(ticks: MaybeRef<number>): ComputedRef<Date> {
  * @returns The resulting string
  */
 export function getEndsAtTime(ticks: MaybeRef<number>): ComputedRef<string> {
+  const endDate = getEndsAtDate(ticks);
+
   return computed(() => {
-    const form = useDateFns(format, getEndsAtDate(ticks).value, 'p');
+    const form = useDateFns(format, endDate.value, 'p');
 
     return i18n.t('endsAt', {
-      time: form.value
+      time: form
     });
   });
 }
@@ -119,7 +121,7 @@ export function getRuntimeTime(ticks: MaybeRef<number>): ComputedRef<string> {
         format: ['hours', 'minutes']
       }
     );
-  }).value;
+  });
 }
 
 /**

--- a/frontend/src/utils/time.ts
+++ b/frontend/src/utils/time.ts
@@ -13,7 +13,7 @@ import {
   intervalToDuration
 } from 'date-fns';
 import { sumBy } from 'lodash-es';
-import { ComputedRef, computed, isRef } from 'vue';
+import { ComputedRef, computed, toValue } from 'vue';
 
 /**
  * Formats Time
@@ -77,7 +77,7 @@ export function formatTime(seconds: number): string {
  */
 function getEndsAtDate(ticks: MaybeRef<number>): ComputedRef<Date> {
   return computed(() => {
-    const ms = ticksToMs(isRef(ticks) ? ticks.value : ticks);
+    const ms = ticksToMs(toValue(ticks));
 
     return addMilliseconds(now.value, ms);
   });
@@ -110,9 +110,7 @@ export function getEndsAtTime(ticks: MaybeRef<number>): ComputedRef<string> {
  */
 export function getRuntimeTime(ticks: MaybeRef<number>): ComputedRef<string> {
   return computed(() => {
-    ticks = isRef(ticks) ? ticks.value : ticks;
-
-    const ms = ticksToMs(ticks);
+    const ms = ticksToMs(toValue(ticks));
 
     return useDateFns(
       formatDuration,
@@ -133,9 +131,7 @@ export function getRuntimeTime(ticks: MaybeRef<number>): ComputedRef<string> {
 export function getTotalEndsAtTime(
   items: MaybeRef<BaseItemDto[]>
 ): ComputedRef<string> {
-  return computed(() => {
-    const ticks = sumBy(isRef(items) ? items.value : items, 'RunTimeTicks');
+  const aggregatedTicks = computed(() => sumBy(toValue(items), 'RunTimeTicks'));
 
-    return getEndsAtTime(ticks).value;
-  });
+  return getEndsAtTime(aggregatedTicks);
 }


### PR DESCRIPTION
The architecture of the computed effects for time-related functions was not greate and could lead to memory leaks (since we were creating computed properties inside other computed properties in many cases). 

Plus some minor fixes.