### PR TITLE
chore(readme): add :unstable to docker run

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,9 @@ This is an alternative client for Jellyfin based on Vue.js. It might not be feat
 
 # Usage instructions for end users 👨‍👩‍👧‍👦
 
-*The following instructions will get you up and running quickly with builds
-from the current `master` branch, which are bleeding edge by default*
+*The following instructions will get you up and running quickly with
+bleeding-edge builds from the current `master` branch.
+There are no stable releases yet.*
 
 ## [Hosted instance 🌍](https://jf-vue.pages.dev/)
 

--- a/README.md
+++ b/README.md
@@ -76,9 +76,12 @@ This is an alternative client for Jellyfin based on Vue.js. It might not be feat
 
 # Usage instructions for end users 👨‍👩‍👧‍👦
 
+*The following instructions will get you up and running quickly with builds
+from the current `master` branch, which are bleeding edge by default*
+
 ## [Hosted instance 🌍](https://jf-vue.pages.dev/)
 
-Our hosted instance points to a version built from the current `master` branch. Hosted by Cloudflare Pages.
+Hosted by Cloudflare Pages.
 
 ⚠️ **This only works for Jellyfin servers that [are behind a reverse proxy and has HTTPS correctly set up](https://jellyfin.org/docs/general/networking/#running-jellyfin-behind-a-reverse-proxy)**. If your server runs over HTTP, you must use another deployment type.
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Our hosted instance points to a version built from the current `master` branch. 
 You can run the Docker container with the following command, replacing 8080 with the port of your choice:
 
 ```bash
-docker run -d -p 8080:80 ghcr.io/jellyfin/jellyfin-vue
+docker run -d -p 8080:80 ghcr.io/jellyfin/jellyfin-vue:unstable
 ```
 
 You can check [GitHub Packages (GHCR)](https://github.com/jellyfin/jellyfin-vue/pkgs/container/jellyfin-vue) (recommended) or [DockerHub](https://hub.docker.com/r/jellyfin/jellyfin-vue) for all the tagged images.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ from the current `master` branch, which are bleeding edge by default*
 
 Hosted by Cloudflare Pages.
 
-⚠️ **This only works for Jellyfin servers that [are behind a reverse proxy and has HTTPS correctly set up](https://jellyfin.org/docs/general/networking/#running-jellyfin-behind-a-reverse-proxy)**. If your server runs over HTTP, you must use another deployment type.
+⚠️ **This only works for Jellyfin servers that [are behind a reverse proxy and have HTTPS set up correctly](https://jellyfin.org/docs/general/networking/#running-jellyfin-behind-a-reverse-proxy)**. If your server runs over HTTP, you must use another deployment type.
 
 ## Docker Container 📦
 


### PR DESCRIPTION
The current command, `docker run -d -p 8080:80 ghcr.io/jellyfin/jellyfin-vue`, simply prints

```
docker: Error response from daemon: manifest unknown.
```

As long as there’s no latest (stable) release the “default” branch should point to unstable.
