### PR TITLE
fix: Report playback progress at regular interval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,7 @@ frontend/dist
 
 # IDE / Editor
 .idea
+.history
 
 # Service worker
 sw.js

--- a/frontend/src/store/playbackManager.ts
+++ b/frontend/src/store/playbackManager.ts
@@ -1270,6 +1270,18 @@ class PlaybackManagerStore {
     }, { flush: 'sync' });
 
     /**
+     * Report progress playback when current time changes
+     */
+    watch(
+      () => this.currentTime,
+      async () => {
+        if (this._pendingProgressReport) {
+          await this._reportPlaybackProgress();
+        }
+      }
+    );
+
+    /**
      * Report playback stop when closing the tab
      */
     useEventListener('beforeunload', async () => {


### PR DESCRIPTION
The UI was only reporting playback on close, meaning when a playback session was lost due to a crash, or server close. Progress would be lost.
The playback in the dashboard would also not see progress if the user was to skip ahead or behind.

This is resolved by adding a watcher to the "currentTime" which triggers the `reportPlaybackProgress` function. This already has a throttle to prevent constant updates (See `_progressReportInterval` variable).

This could be extended in order to support pause/unpause, However not sure the best way to handle this (do we need to send different events to tell the server the media is paused, or is this handled by the isPaused attribute).


Additionally added .history to gitignore due to vscode's local history.

Resolves #2216