### PR TITLE
feat(auth&config): add 'allowServerSelection', fix server wait on boot

### DIFF
--- a/frontend/public/config.json
+++ b/frontend/public/config.json
@@ -1,4 +1,5 @@
 {
   "defaultServerURLs": [],
+  "allowServerSelection": true,
   "routerMode": "hash"
 }

--- a/frontend/src/components/Forms/AddServerForm.vue
+++ b/frontend/src/components/Forms/AddServerForm.vue
@@ -18,6 +18,7 @@
           v-if="previousServerLength"
           class="mr-2">
           <VBtn
+            v-if="jsonConfig.allowServerSelection"
             block
             size="large"
             variant="elevated"
@@ -47,7 +48,9 @@ import { ref, unref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRouter } from 'vue-router/auto';
 import { remote } from '@/plugins/remote';
+import { getJSONConfig } from '@/utils/external-config';
 
+const jsonConfig = await getJSONConfig();
 const router = useRouter();
 const i18n = useI18n();
 const valid = ref(false);

--- a/frontend/src/components/Forms/LoginForm.vue
+++ b/frontend/src/components/Forms/LoginForm.vue
@@ -32,7 +32,7 @@
         no-gutters>
         <VCol class="mr-2">
           <VBtn
-            v-if="isEmpty(user)"
+            v-if="isEmpty(user) && jsonConfig.allowServerSelection"
             to="/server/select"
             block
             size="large"
@@ -75,6 +75,7 @@ import { useI18n } from 'vue-i18n';
 import { useRouter } from 'vue-router/auto';
 import { fetchIndexPage } from '@/utils/items';
 import { remote } from '@/plugins/remote';
+import { getJSONConfig } from '@/utils/external-config';
 
 const props = defineProps<{ user: UserDto }>();
 
@@ -82,6 +83,7 @@ defineEmits<{
   change: [];
 }>();
 
+const jsonConfig = await getJSONConfig();
 const { t } = useI18n();
 
 const router = useRouter();

--- a/frontend/src/pages/server/login.vue
+++ b/frontend/src/pages/server/login.vue
@@ -45,6 +45,7 @@
             sm="6"
             class="d-flex justify-center">
             <VBtn
+              v-if="jsonConfig.allowServerSelection"
               block
               to="/server/select"
               size="large"
@@ -102,7 +103,9 @@ import { ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRoute, useRouter } from 'vue-router/auto';
 import { remote } from '@/plugins/remote';
+import { getJSONConfig } from '@/utils/external-config';
 
+const jsonConfig = await getJSONConfig();
 const { t } = useI18n();
 const route = useRoute();
 const router = useRouter();

--- a/frontend/src/plugins/remote/index.ts
+++ b/frontend/src/plugins/remote/index.ts
@@ -39,13 +39,18 @@ export function createPlugin(): {
       const auth = remote.auth;
       const config = await getJSONConfig();
       const defaultServers = config.defaultServerURLs;
-      const missingServers = defaultServers.filter((serverUrl) => {
-        const server = auth.servers.find(
-          (lsServer) => lsServer.PublicAddress === serverUrl
-        );
+      /**
+       * We reverse the list so the first server is the last to be connected,
+       * and thus is the chosen one by default
+       */
+      const missingServers = defaultServers
+        .filter((serverUrl) => {
+          const server = auth.servers.find(
+            (lsServer) => lsServer.PublicAddress === serverUrl
+          );
 
-        return isNil(server);
-      });
+          return isNil(server);
+        }).reverse();
 
       for (const serverUrl of missingServers) {
         await auth.connectServer(serverUrl, true);

--- a/frontend/src/utils/external-config.ts
+++ b/frontend/src/utils/external-config.ts
@@ -1,7 +1,8 @@
-import { isArray, isNil, isObj, isStr } from '@/utils/validation';
+import { isArray, isBool, isNil, isObj, isStr } from '@/utils/validation';
 
 interface ExternalJSONConfig {
   defaultServerURLs: string[];
+  allowServerSelection: boolean;
   routerMode: 'hash' | 'history';
 }
 
@@ -30,6 +31,10 @@ function validateJsonConfig(
     )
   ) {
     throw new Error('Expected defaultServerURLs to be a list of strings');
+  }
+
+  if (!('allowServerSelection' in config) || !isBool(config.allowServerSelection)) {
+    throw new Error('Expected allowServerSelection to be boolean');
   }
 
   if (

--- a/packaging/docker/contents/setup.sh
+++ b/packaging/docker/contents/setup.sh
@@ -9,12 +9,20 @@ else
     ROUTER_MODE="history"
 fi
 
+if [[ "$ALLOW_SERVER_SELECTION" == "1" ]]; then
+    ALLOW_SERVER_SELECTION="true"
+else
+    ALLOW_SERVER_SELECTION="false"
+fi
+
 echo "DEFAULT_SERVERS value: $DEFAULT_SERVERS"
+echo "ALLOW_SERVER_SELECTION value: $ALLOW_SERVER_SELECTION"
 echo "ROUTER_MODE value: $ROUTER_MODE"
 
-output=$(jq -r --arg R_MODE "$ROUTER_MODE" --arg SERVS "$DEFAULT_SERVERS" '
+output=$(jq -r --arg R_MODE "$ROUTER_MODE" --arg SERVS "$DEFAULT_SERVERS" --arg SELECTION_ALLOW "$ALLOW_SERVER_SELECTION" '
     .defaultServerURLs = ($SERVS | split(",")) |
-    .routerMode = $R_MODE
+    .routerMode = $R_MODE |
+    .allowServerSelection = $SELECTION_ALLOW
     ' $CONFIG_FILE_PATH
 )
 


### PR DESCRIPTION
* Fix the users being redirected to the 'Add Server' screen (#2117) on first start
* Allow to disable the server selection screen with a new key: 'allowServerSelection'

WARNING: When it's false, the following situations will leave the client in an endless loading state if:

- This is enabled and no default servers have been provided
- The first server in the 'defaultServerURLs' array can't be reached