### PR TITLE
fix: correctly trigger showPassword

### DIFF
--- a/frontend/src/components/Forms/LoginForm.vue
+++ b/frontend/src/components/Forms/LoginForm.vue
@@ -20,7 +20,7 @@
         :label="$t('password')"
         :append-inner-icon="showPassword ? IconEyeOff : IconEye"
         :type="showPassword ? 'text' : 'password'"
-        @click:append="() => (showPassword = !showPassword)" />
+        @click:append-inner="() => (showPassword = !showPassword)" />
       <VCheckbox
         v-model="login.rememberMe"
         hide-details


### PR DESCRIPTION
This is a very, very simple edit. As the icon is added as `inner-icon`, the icon event should also be `click:append-inner`.