### PR TITLE
fix(video): styles

### DIFF
--- a/frontend/src/components/Playback/PlayerElement.vue
+++ b/frontend/src/components/Playback/PlayerElement.vue
@@ -217,3 +217,9 @@ watch(
   }
 );
 </script>
+
+<style scoped>
+.stretched {
+  object-fit: fill;
+}
+</style>

--- a/frontend/src/pages/playback/video.vue
+++ b/frontend/src/pages/playback/video.vue
@@ -219,20 +219,7 @@ watch(staticOverlay, (val) => {
 <style scoped>
 .fullscreen-video-container {
   background: black;
-}
-
-:deep(.fullscreen-video-container video) {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  max-width: 100%;
-  max-height: 100%;
-}
-
-:deep(.fullscreen-video-container video.stretched) {
-  width: 100%;
-  height: 100%;
+  display: flex;
 }
 
 .controls-wrapper {

--- a/frontend/src/store/playerElement.ts
+++ b/frontend/src/store/playerElement.ts
@@ -37,7 +37,7 @@ class PlayerElementStore {
   private readonly _defaultState: PlayerElementState = {
     isFullscreenMounted: false,
     isPiPMounted: false,
-    isStretched: true
+    isStretched: false
   };
 
   private readonly _state = reactive<PlayerElementState>(


### PR DESCRIPTION
* The video was not centering nor stretching when necessary
* By default, stretch is disabled and the video keeps it's proportions
* This fix also simplifies the styles

Fix #2255 