### PR TITLE
Fixed height and width issues with video player

### DIFF
--- a/frontend/src/pages/playback/video.vue
+++ b/frontend/src/pages/playback/video.vue
@@ -220,6 +220,8 @@ watch(staticOverlay, (val) => {
 .fullscreen-video-container {
   background: black;
   display: flex;
+  height: 100vh !important;
+  justify-content: center;
 }
 
 .controls-wrapper {


### PR DESCRIPTION
-Fixed video player taking monitor height instead of window height.

-Fixed video player not centering content less large then the window (4:3 video)

added more info on a new comment in #2255

further fix for #2257