### PR TITLE
fix(JImg): preload in Safari

### DIFF
--- a/frontend/src/components/lib/JImg.vue
+++ b/frontend/src/components/lib/JImg.vue
@@ -2,7 +2,7 @@
   <template v-if="src">
     <link
       v-if="!shown"
-      rel="preload prerender"
+      rel="preload"
       as="image"
       :href="src"
       @load="onLoad"
@@ -75,6 +75,7 @@ interface Props extends BetterOmit<ImgHTMLAttributes, 'src'> {
 defineOptions({
   inheritAttrs: false
 });
+
 const props = withDefaults(defineProps<Props>(), { transitionProps: true });
 const loading = shallowRef(true);
 const error = shallowRef(false);


### PR DESCRIPTION
The bug in Safari was due to an incorrect usage of the `rel` attribute.

Fixes #2291 