### PR TITLE
fix(AudioControls): downgrade Vuetify to fix persistent footer

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -65,7 +65,8 @@
   },
   "ignoreDeps": [
     "npm",
-    "node"
+    "node",
+    "vuetify"
   ],
   "enabledManagers": [
     "npm",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,7 +44,7 @@
     "vue": "3.4.27",
     "vue-i18n": "9.13.1",
     "vue-router": "4.3.2",
-    "vuetify": "3.6.5"
+    "vuetify": "3.5.18"
   },
   "devDependencies": {
     "@eslint/config-inspector": "0.4.8",

--- a/frontend/src/components/Layout/AudioControls.vue
+++ b/frontend/src/components/Layout/AudioControls.vue
@@ -6,7 +6,7 @@
       v-if="
         playbackManager.isPlaying &&
           playbackManager.isAudio &&
-          playbackManager.currentItem
+          !isNil(playbackManager.currentItem)
       "
       app
       class="uno-select-none pa-0">
@@ -109,6 +109,7 @@
 </template>
 
 <script setup lang="ts">
+import { isNil } from '@/utils/validation';
 import { playbackManager } from '@/store/playback-manager';
 import { getItemDetailsLink } from '@/utils/items';
 </script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "vue": "3.4.27",
         "vue-i18n": "9.13.1",
         "vue-router": "4.3.2",
-        "vuetify": "3.6.5"
+        "vuetify": "3.5.18"
       },
       "devDependencies": {
         "@eslint/config-inspector": "0.4.8",
@@ -10932,9 +10932,9 @@
       }
     },
     "node_modules/vuetify": {
-      "version": "3.6.5",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.6.5.tgz",
-      "integrity": "sha512-YrHTM1vb7UllAtfH9tWfTo1wYMjyCSybu4WtXrfMRpMwAaZWgfrMmqD/4Tc+0KqDsDsYMXaYs0nJ6HtdMJZbyA==",
+      "version": "3.5.18",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.5.18.tgz",
+      "integrity": "sha512-33eRhaLkKaiyH7PDau1xDvFzAGFKNo/nFvyiKhB+DePDZBkvMEphUul+zCitHgUrQCZo1i7kfY97k6q+7QURuQ==",
       "engines": {
         "node": "^12.20 || >=14.13"
       },


### PR DESCRIPTION
When all the queue is finished, the footer gets stuck in the middle of the page. Vuetify changed something that makes Vue's v-if not work properly.

Given I'm going to remove Vuetify from the app sooner than later, I'm removing it from renoavet dependency updates