### PR TITLE
ci(docker): don't upload build record artifacts

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -26,6 +26,7 @@ env:
   RELEASE_TAG: stable
   PRERELEASE_TAG: stable-rc
   COMMIT_TAG: unstable
+  DOCKER_BUILD_RECORD_UPLOAD: false
 
 permissions:
   id-token: write


### PR DESCRIPTION
Follow-up of https://github.com/docker/build-push-action/issues/1151