### PR TITLE
fix(routing): fix history routerMode

### DIFF
--- a/frontend/public/config.json
+++ b/frontend/public/config.json
@@ -1,5 +1,5 @@
 {
   "defaultServerURLs": [],
   "allowServerSelection": true,
-  "routerMode": "hash"
+  "routerMode": "history"
 }

--- a/frontend/src/plugins/router/middlewares/login.ts
+++ b/frontend/src/plugins/router/middlewares/login.ts
@@ -24,10 +24,6 @@ export async function loginGuard(
 
   if (!isNil(remote.auth.currentServer) && !isNil(remote.auth.currentUser) && !isNil(remote.auth.currentUserToken) && routes.has(to.path)) {
     destinationRoute = { path: '/', replace: true };
-  } else if (to.path === serverAddUrl && remote.auth.servers.length > 0 || to.path === serverSelectUrl) {
-    if (!jsonConfig.allowServerSelection) {
-      destinationRoute = { path: serverLoginUrl, replace: true };
-    }
   }
 
   if (remote.auth.servers.length <= 0 && jsonConfig.defaultServerURLs.length <= 0) {

--- a/frontend/src/plugins/router/middlewares/login.ts
+++ b/frontend/src/plugins/router/middlewares/login.ts
@@ -24,6 +24,10 @@ export async function loginGuard(
 
   if (!isNil(remote.auth.currentServer) && !isNil(remote.auth.currentUser) && !isNil(remote.auth.currentUserToken) && routes.has(to.path)) {
     destinationRoute = { path: '/', replace: true };
+  } else if (to.path === serverAddUrl && remote.auth.servers.length > 0 || to.path === serverSelectUrl) {
+    if (!jsonConfig.allowServerSelection) {
+      destinationRoute = { path: serverLoginUrl, replace: true };
+    }
   }
 
   if (remote.auth.servers.length <= 0 && jsonConfig.defaultServerURLs.length <= 0) {

--- a/frontend/src/utils/external-config.ts
+++ b/frontend/src/utils/external-config.ts
@@ -53,7 +53,7 @@ function validateJsonConfig(
 export async function getJSONConfig(): Promise<ExternalJSONConfig> {
   if (isNil(externalConfig)) {
     const loadedConfig: unknown = await (
-      await fetch('config.json', { cache: 'no-store' })
+      await fetch('/config.json', { cache: 'no-store' })
     ).json();
 
     validateJsonConfig(loadedConfig);

--- a/frontend/src/utils/external-config.ts
+++ b/frontend/src/utils/external-config.ts
@@ -47,13 +47,26 @@ function validateJsonConfig(
 }
 
 /**
+ * Get the base path for the application
+ */
+function getBasePath(): string {
+  const base = import.meta.env.BASE_URL;
+  if (base.endsWith('/')) {
+    return base.substring(0, base.length - 1);
+  }
+
+  return base;
+}
+
+/**
  * Fetch configuration at runtime from the config.json file
  * We use destr for serialization as it has better support for JS primitives.
  */
 export async function getJSONConfig(): Promise<ExternalJSONConfig> {
   if (isNil(externalConfig)) {
+    const basePath = getBasePath();
     const loadedConfig: unknown = await (
-      await fetch('/config.json', { cache: 'no-store' })
+      await fetch(basePath + '/config.json', { cache: 'no-store' })
     ).json();
 
     validateJsonConfig(loadedConfig);

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -22,7 +22,7 @@ import virtualModules from './scripts/virtual-modules';
 export default defineConfig(({ mode }): UserConfig => {
   const config: UserConfig = {
     appType: 'spa',
-    base: './',
+    base: '/',
     cacheDir: '../node_modules/.cache/vite',
     plugins: [
       Virtual(virtualModules),


### PR DESCRIPTION
### Fixes

- **serverAdd**: Block server addition and selection when disallowed by config.
- **router**: Correct history routerMode to ensure proper asset pathing.

### Description

1. Updated the server addition and selection logic to respect the `allowServerSelection` configuration setting.
2. Fixed an issue with the history routerMode where the base path was incorrectly set to `./`, causing static assets to be pathed incorrectly (e.g., `/server/assets/example.png` instead of `/assets/example.png` when on `/server/login`).

### Testing

- Verified that server addition and selection are blocked when `allowServerSelection` is false.
- Tested history routerMode functionality to ensure static assets are correctly pathed.
