### PR TITLE
Add support for native PGS subtitle rendering without transcoding

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,6 +36,7 @@
     "fast-equals": "5.0.1",
     "hls.js": "1.5.14",
     "jassub": "1.7.16",
+    "libpgs": "0.4.1",
     "lodash-es": "4.17.21",
     "marked": "14.0.0",
     "sortablejs": "1.15.2",

--- a/frontend/src/store/playback-manager.ts
+++ b/frontend/src/store/playback-manager.ts
@@ -291,7 +291,7 @@ class PlaybackManagerStore extends CommonStore<PlaybackManagerState> {
           srcLang: sub.Language ?? undefined,
           type: sub.DeliveryMethod ?? SubtitleDeliveryMethod.Drop,
           srcIndex: sub.srcIndex,
-          codec: sub.Codec === null ? undefined : sub.Codec
+          codec: sub.Codec === null ? undefined : sub.Codec?.toLowerCase()
         }));
     }
   }
@@ -299,7 +299,7 @@ class PlaybackManagerStore extends CommonStore<PlaybackManagerState> {
   /**
    * Filters the native subtitles
    *
-   * As our profile requires either SSA or VTT, if it's not SSA it'll be VTT.
+   * As our profile requires either SSA, PGS or VTT, if it's not SSA or PGS it'll be VTT.
    * This is done this way as server sends as "Codec" the initial value of the track, so it can be webvtt, subrip, srt...
    * This is easier to filter out the SSA subs
    */
@@ -307,7 +307,7 @@ class PlaybackManagerStore extends CommonStore<PlaybackManagerState> {
     return (
       this.currentItemParsedSubtitleTracks?.filter(
         (sub): sub is PlaybackExternalTrack =>
-          !!sub.codec && sub.codec !== 'ass' && sub.codec !== 'ssa' && !!sub.src
+          !!sub.codec && sub.codec !== 'ass' && sub.codec !== 'ssa' && sub.codec !== 'pgssub' && !!sub.src
       ) ?? []
     );
   }
@@ -318,6 +318,17 @@ class PlaybackManagerStore extends CommonStore<PlaybackManagerState> {
         (sub): sub is PlaybackExternalTrack =>
           !!sub.codec
           && (sub.codec === 'ass' || sub.codec === 'ssa')
+          && !!sub.src
+      ) ?? []
+    );
+  }
+
+  public get currentItemPgsParsedSubtitleTracks(): PlaybackExternalTrack[] {
+    return (
+      this.currentItemParsedSubtitleTracks?.filter(
+        (sub): sub is PlaybackExternalTrack =>
+          !!sub.codec
+          && (sub.codec === 'pgssub')
           && !!sub.src
       ) ?? []
     );

--- a/frontend/src/utils/playback-profiles/subtitle-profile.ts
+++ b/frontend/src/utils/playback-profiles/subtitle-profile.ts
@@ -27,6 +27,10 @@ export function getSubtitleProfiles(): SubtitleProfile[] {
     {
       Format: 'ssa',
       Method: SubtitleDeliveryMethod.External
+    },
+    {
+      Format: 'pgssub',
+      Method: SubtitleDeliveryMethod.External
     }
   );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "fast-equals": "5.0.1",
         "hls.js": "1.5.14",
         "jassub": "1.7.16",
+        "libpgs": "0.4.1",
         "lodash-es": "4.17.21",
         "marked": "14.0.0",
         "sortablejs": "1.15.2",
@@ -7627,6 +7628,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/libpgs": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/libpgs/-/libpgs-0.4.1.tgz",
+      "integrity": "sha512-I4mIGz7Lf23xy/8mwSx0qlStz0oZFCz9dLC1xXNaqv5MbVdFhZWE+OMhVBLGjfVkjugyboM9XJ+4bCSibAIGuA==",
+      "license": "MIT"
     },
     "node_modules/lightningcss": {
       "version": "1.26.0",


### PR DESCRIPTION
**Changes**
This PR allows the client to request and render native PGS subtitle streams without transcoding. PGS is a graphical subtitle format. The subtitles are rendered locally by the client on-top of the video element.

This adds a new dependency [libpgs-js](https://github.com/Arcus92/libpgs-js). I just created this library for the Jellyfin project. If desired, you can fork it into the https://github.com/jellyfin domain.

**Related Pull Request (backend):** https://github.com/jellyfin/jellyfin/pull/12056
**Related Pull Request (web):** https://github.com/jellyfin/jellyfin-web/pull/5688