### PR TITLE
fix(serverAdd): block server addition and selection when disallowed by config

### DIFF
--- a/frontend/src/plugins/router/middlewares/login.ts
+++ b/frontend/src/plugins/router/middlewares/login.ts
@@ -24,6 +24,10 @@ export async function loginGuard(
 
   if (!isNil(remote.auth.currentServer) && !isNil(remote.auth.currentUser) && !isNil(remote.auth.currentUserToken) && routes.has(to.path)) {
     destinationRoute = { path: '/', replace: true };
+  } else if (to.path === serverAddUrl && remote.auth.servers.length > 0 || to.path === serverSelectUrl) {
+    if (!jsonConfig.allowServerSelection) {
+      destinationRoute = { path: serverLoginUrl, replace: true };
+    }
   }
 
   if (remote.auth.servers.length <= 0 && jsonConfig.defaultServerURLs.length <= 0) {


### PR DESCRIPTION
### Fix

Block server addition and selection when disallowed by config.

### Description

Updated the server addition and selection logic to respect the `allowServerSelection` configuration setting.

### Testing

Verified that server addition and selection are blocked when `allowServerSelection` is false.
