### PR TITLE
Update README to reflect actual status

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@
 
 Jellyfin Vue is an experimental, alternative browser-based web client for Jellyfin written using Vue.js.
 
-Note: Jellyfin Vue is not currently planned or targeted to replace [the main Jellyfin Web client](https://github.com/jellyfin/jellyfin-web), and is not feature-complete.
+Note: Jellyfin Vue is not planned or targeted to replace [the main Jellyfin Web client](https://github.com/jellyfin/jellyfin-web), and is not feature-complete.
 
 # Usage instructions for end users 👨‍👩‍👧‍👦
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@
 
 ---
 
-This is an alternative client for Jellyfin based on Vue.js. It might not be feature complete and it's constantly evolving.
+Jellyfin Vue is an experimental, alternative browser-based web client for Jellyfin written using Vue.js.
+
+Note: Jellyfin Vue is not currently planned or targeted to replace [the main Jellyfin Web client](https://github.com/jellyfin/jellyfin-web), and is not feature-complete.
 
 # Usage instructions for end users 👨‍👩‍👧‍👦
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@
 
 Jellyfin Vue is an experimental, alternative browser-based web client for Jellyfin written using Vue.js.
 
-Note: Jellyfin Vue is not planned or targeted to replace [the main Jellyfin Web client](https://github.com/jellyfin/jellyfin-web), and is not feature-complete.
+> [!NOTE]
+> Jellyfin Vue is not planned or targeted to replace [the main Jellyfin Web client](https://github.com/jellyfin/jellyfin-web), and is not feature-complete.
 
 # Usage instructions for end users 👨‍👩‍👧‍👦
 


### PR DESCRIPTION
I want to make it very clear in the README what the Vue client is and what it's goals are vis-a-vis the project as a whole, to avoid any mistaken impression about where it's at.

For technical reasons, mostly Vue.js dropping support for "old" browsers, Jellyfin Vue can never reasonably replace the main web client. So, it will always be at most an alternative client.

This PR ensures that this is now spelled out clearly at the top of the README.