### PR TITLE
refactor: remove dpdm, npm commands, bundle analysis

### DIFF
--- a/.github/workflows/__quality_checks.yml
+++ b/.github/workflows/__quality_checks.yml
@@ -28,15 +28,15 @@ jobs:
           head-ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
   quality:
-    name: Check ${{ matrix.command }} 🕵️‍♂️
+    name: Run ${{ matrix.command }} 🕵️‍♂️
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         command:
           - lint
-          - typecheck
-          - analyze
+          - check:types
+          - analyze:cycles
     defaults:
       run:
         working-directory: frontend

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,16 +7,17 @@
     "defaults and supports es6-module"
   ],
   "scripts": {
-    "analyze": "dpdm --no-warning --no-tree src/**/*.{ts,vue} && vite build --mode analyze",
+    "analyze:bundle": "vite build --mode analyze:bundle",
+    "analyze:cycles": "vite build --mode analyze:cycles",
+    "lint": "eslint . --max-warnings=0 --cache --cache-location ../node_modules/.cache/eslint",
+    "lint:fix": "eslint . --fix --max-warnings=0 --cache --cache-location ../node_modules/.cache/eslint",
+    "lint:inspect": "eslint-config-inspector",
     "build": "vite build",
-    "check": "npm run lint && npm run typecheck",
+    "check": "npm run lint && npm run check:types",
+    "check:types": "vue-tsc",
     "start": "vite",
     "serve": "vite preview",
-    "lint": "eslint . --max-warnings=0 --cache --cache-location ../node_modules/.cache/eslint",
-    "lint-fix": "eslint . --fix --max-warnings=0 --cache --cache-location ../node_modules/.cache/eslint",
-    "eslint-inspect": "eslint-config-inspector",
     "prod": "npm run build && npm run serve",
-    "typecheck": "vue-tsc",
     "clean": "git clean -fxd"
   },
   "dependencies": {
@@ -62,7 +63,6 @@
     "@unocss/eslint-config": "0.62.3",
     "@vitejs/plugin-vue": "5.1.3",
     "browserslist": "4.23.3",
-    "dpdm": "3.14.0",
     "eslint": "9.9.1",
     "eslint-config-flat-gitignore": "0.3.0",
     "eslint-plugin-css": "0.11.0",

--- a/frontend/scripts/plugins/analysis.ts
+++ b/frontend/scripts/plugins/analysis.ts
@@ -1,0 +1,52 @@
+import { visualizer } from 'rollup-plugin-visualizer';
+import type { RollupLog } from 'rollup';
+import type { Plugin } from 'vite';
+
+/**
+ * This plugin extracts the logic for the analyze commands, so the main Vite config is cleaner.
+ */
+export function JellyfinVueAnalysis(): Plugin {
+  const warnings: RollupLog[] = [];
+
+  return {
+    name: 'Jellyfin_Vue:analysis',
+    enforce: 'post',
+    config: (_, env) => {
+      if (env.mode === 'analyze:bundle') {
+        return {
+          build: {
+            rollupOptions: {
+              plugins: [
+                visualizer({
+                  open: true,
+                  filename: 'dist/stats.html'
+                })
+              ]
+            }
+          }
+        };
+      } else if (env.mode === 'analyze:cycles') {
+        return {
+          build: {
+            rollupOptions: {
+              onwarn: (warning) => {
+                if (warning.code === 'CIRCULAR_DEPENDENCY') {
+                  warnings.push(warning);
+                }
+              }
+            }
+          }
+        };
+      }
+    },
+    closeBundle: () => {
+      if (warnings.length > 0) {
+        for (const warning of warnings) {
+          console.warn(warning);
+        }
+
+        throw new Error('There are circular dependencies');
+      }
+    }
+  };
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,7 +4,6 @@ import VueMacros from 'unplugin-vue-macros/vite';
 import Vue from '@vitejs/plugin-vue';
 import browserslist from 'browserslist';
 import { browserslistToTargets } from 'lightningcss';
-import { visualizer } from 'rollup-plugin-visualizer';
 import IconsResolver from 'unplugin-icons/resolver';
 import Icons from 'unplugin-icons/vite';
 import {
@@ -15,148 +14,133 @@ import {
 import Components from 'unplugin-vue-components/vite';
 import UnoCSS from 'unocss/vite';
 import VueRouter from 'unplugin-vue-router/vite';
-import { defineConfig, type UserConfig } from 'vite';
+import { defineConfig } from 'vite';
 import { entrypoints, localeFilesFolder, srcRoot } from './scripts/paths';
 import virtualModules from './scripts/virtual-modules';
+import { JellyfinVueAnalysis } from './scripts/plugins/analysis';
 
-export default defineConfig(({ mode }): UserConfig => {
-  const config: UserConfig = {
-    appType: 'spa',
-    base: './',
-    cacheDir: '../node_modules/.cache/vite',
-    plugins: [
-      Virtual(virtualModules),
-      VueRouter({
-        dts: './types/global/routes.d.ts',
-        importMode: 'sync',
-        routeBlockLang: 'yaml'
-      }),
-      VueMacros({
-        plugins: {
-          vue: Vue({
-            template: {
-              transformAssetUrls: {
-                img: []
-              }
+export default defineConfig({
+  appType: 'spa',
+  base: './',
+  cacheDir: '../node_modules/.cache/vite',
+  plugins: [
+    JellyfinVueAnalysis(),
+    Virtual(virtualModules),
+    VueRouter({
+      dts: './types/global/routes.d.ts',
+      importMode: 'sync',
+      routeBlockLang: 'yaml'
+    }),
+    VueMacros({
+      plugins: {
+        vue: Vue({
+          template: {
+            transformAssetUrls: {
+              img: []
             }
-          })
-        }
-      }),
-      // This plugin allows to autoimport Vue components
-      Components({
-        dts: './types/global/components.d.ts',
-        /**
-         * The icons resolver finds icons components from 'unplugin-icons' using this convenction:
-         * {prefix}-{collection}-{icon} e.g. <i-mdi-thumb-up />
-         */
-        resolvers: [
-          IconsResolver(),
-          VueUseComponentsResolver(),
-          Vuetify3Resolver(),
-          VueUseDirectiveResolver()
-        ]
-      }),
+          }
+        })
+      }
+    }),
+    // This plugin allows to autoimport Vue components
+    Components({
+      dts: './types/global/components.d.ts',
       /**
-       * This plugin allows to use all icons from Iconify as vue components
-       * See: https://github.com/antfu/unplugin-icons
+       * The icons resolver finds icons components from 'unplugin-icons' using this convenction:
+       * {prefix}-{collection}-{icon} e.g. <i-mdi-thumb-up />
        */
-      Icons({
-        compiler: 'vue3'
-      }),
-      VueI18nPlugin({
-        runtimeOnly: true,
-        compositionOnly: true,
-        fullInstall: false,
-        forceStringify: true,
-        include: localeFilesFolder
-      }),
-      UnoCSS()
-    ],
-    build: {
-      /**
-       * See main.ts for an explanation of this target
-       */
-      target: 'esnext',
-      /**
-       * Disable chunk size warnings
-       */
-      chunkSizeWarningLimit: Number.NaN,
-      cssCodeSplit: true,
-      cssMinify: 'lightningcss',
-      modulePreload: false,
-      reportCompressedSize: false,
-      rollupOptions: {
-        input: {
-          splashscreen: entrypoints.splashscreen,
-          main: entrypoints.main,
-          index: entrypoints.index
-        },
-        ...(mode === 'analyze'
-          ? {
-              onwarn: (warning) => { console.warn(warning); }
-            }
-          : {}),
-        output: {
-          chunkFileNames: (chunkInfo) => {
-            /**
-             * This is the default value: https://rollupjs.org/configuration-options/#output-chunkfilenames
-             */
-            return chunkInfo.name === 'validation' ? 'assets/common-[hash].js' : '[name]-[hash].js';
-          },
-          validate: true,
-          plugins: [
-            mode === 'analyze'
-              ? visualizer({
-                open: true,
-                filename: 'dist/stats.html'
-              })
-              : undefined
-          ],
+      resolvers: [
+        IconsResolver(),
+        VueUseComponentsResolver(),
+        Vuetify3Resolver(),
+        VueUseDirectiveResolver()
+      ]
+    }),
+    /**
+     * This plugin allows to use all icons from Iconify as vue components
+     * See: https://github.com/antfu/unplugin-icons
+     */
+    Icons({
+      compiler: 'vue3'
+    }),
+    VueI18nPlugin({
+      runtimeOnly: true,
+      compositionOnly: true,
+      fullInstall: false,
+      forceStringify: true,
+      include: localeFilesFolder
+    }),
+    UnoCSS()
+  ],
+  build: {
+    /**
+     * See main.ts for an explanation of this target
+     */
+    target: 'esnext',
+    /**
+     * Disable chunk size warnings
+     */
+    chunkSizeWarningLimit: Number.NaN,
+    cssCodeSplit: true,
+    cssMinify: 'lightningcss',
+    modulePreload: false,
+    reportCompressedSize: false,
+    rollupOptions: {
+      input: {
+        splashscreen: entrypoints.splashscreen,
+        main: entrypoints.main,
+        index: entrypoints.index
+      },
+      output: {
+        chunkFileNames: (chunkInfo) => {
           /**
-           * This is the first thing that should be debugged when there are issues
-           * withe the bundle. Check these issues:
-           * - https://github.com/vitejs/vite/issues/5142
-           * - https://github.com/evanw/esbuild/issues/399
-           * - https://github.com/rollup/rollup/issues/3888
+           * This is the default value: https://rollupjs.org/configuration-options/#output-chunkfilenames
            */
-          manualChunks(id) {
-            if (
-              id.includes('virtual:locales')
-              || id.includes('@intlify/unplugin-vue-i18n/messages')
-            ) {
-              return 'assets/locales';
-            }
+          return chunkInfo.name === 'validation' ? 'assets/common-[hash].js' : '[name]-[hash].js';
+        },
+        validate: true,
+        /**
+         * This is the first thing that should be debugged when there are issues
+         * withe the bundle. Check these issues:
+         * - https://github.com/vitejs/vite/issues/5142
+         * - https://github.com/evanw/esbuild/issues/399
+         * - https://github.com/rollup/rollup/issues/3888
+         */
+        manualChunks(id) {
+          if (
+            id.includes('virtual:locales')
+            || id.includes('@intlify/unplugin-vue-i18n/messages')
+          ) {
+            return 'assets/locales';
           }
         }
       }
-    },
-    css: {
-      lightningcss: {
-        nonStandard: {
-          deepSelectorCombinator: true
-        },
-        targets: browserslistToTargets(browserslist())
-      }
-    },
-    preview: {
-      port: 3000,
-      strictPort: true,
-      host: '0.0.0.0',
-      cors: true
-    },
-    server: {
-      host: '0.0.0.0',
-      port: 3000
-    },
-    resolve: {
-      alias: {
-        '@/': srcRoot
-      }
-    },
-    worker: {
-      format: 'es'
     }
-  };
-
-  return config;
+  },
+  css: {
+    lightningcss: {
+      nonStandard: {
+        deepSelectorCombinator: true
+      },
+      targets: browserslistToTargets(browserslist())
+    }
+  },
+  preview: {
+    port: 3000,
+    strictPort: true,
+    host: '0.0.0.0',
+    cors: true
+  },
+  server: {
+    host: '0.0.0.0',
+    port: 3000
+  },
+  resolve: {
+    alias: {
+      '@/': srcRoot
+    }
+  },
+  worker: {
+    format: 'es'
+  }
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,6 @@
         "@unocss/eslint-config": "0.62.3",
         "@vitejs/plugin-vue": "5.1.3",
         "browserslist": "4.23.3",
-        "dpdm": "3.14.0",
         "eslint": "9.9.1",
         "eslint-config-flat-gitignore": "0.3.0",
         "eslint-plugin-css": "0.11.0",
@@ -3890,27 +3889,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -3922,18 +3900,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/blurhash": {
@@ -4003,31 +3969,6 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
       }
     },
     "node_modules/builtin-modules": {
@@ -4197,32 +4138,6 @@
         "node": ">=0.8.0"
       }
     },
-    "node_modules/cli-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "restore-cursor": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cli-spinners": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
-      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -4276,16 +4191,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/clone": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/color-convert": {
@@ -4566,19 +4471,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/defaults": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
-      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "clone": "^1.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/define-lazy-prop": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
@@ -4644,25 +4536,6 @@
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.6.tgz",
       "integrity": "sha512-cTOAhc36AalkjtBpfG6O8JimdTMWNXjiePT2xQH/ppBGi/4uIpmj8eKyIkMJErXWARyINV/sB38yf8JCLF5pbQ==",
       "license": "(MPL-2.0 OR Apache-2.0)"
-    },
-    "node_modules/dpdm": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/dpdm/-/dpdm-3.14.0.tgz",
-      "integrity": "sha512-YJzsFSyEtj88q5eTELg3UWU7TVZkG1dpbF4JDQ3t1b07xuzXmdoGeSz9TKOke1mUuOpWlk4q+pBh+aHzD6GBTg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "fs-extra": "^11.1.1",
-        "glob": "^10.3.4",
-        "ora": "^5.4.1",
-        "tslib": "^2.6.2",
-        "typescript": "^5.2.2",
-        "yargs": "^17.7.2"
-      },
-      "bin": {
-        "dpdm": "lib/bin/dpdm.js"
-      }
     },
     "node_modules/duplexer": {
       "version": "0.1.2",
@@ -5799,21 +5672,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/fs-extra": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -5933,13 +5791,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/graceful-fs": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -6027,27 +5878,6 @@
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.1",
@@ -6265,16 +6095,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-interactive": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
-      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-language-code": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/is-language-code/-/is-language-code-3.1.0.tgz",
@@ -6303,19 +6123,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/is-unicode-supported": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-wsl": {
@@ -6519,19 +6326,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/kebab-case": {
@@ -6895,23 +6689,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/log-symbols": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
-      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "is-unicode-supported": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
@@ -7026,16 +6803,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/mimic-fn": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/min-indent": {
@@ -7242,22 +7009,6 @@
         "wrappy": "1"
       }
     },
-    "node_modules/onetime": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mimic-fn": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/open": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/open/-/open-10.1.0.tgz",
@@ -7293,30 +7044,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/ora": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
-      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^4.1.0",
-        "chalk": "^4.1.0",
-        "cli-cursor": "^3.1.0",
-        "cli-spinners": "^2.5.0",
-        "is-interactive": "^1.0.0",
-        "is-unicode-supported": "^0.1.0",
-        "log-symbols": "^4.1.0",
-        "strip-ansi": "^6.0.0",
-        "wcwidth": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-limit": {
@@ -7827,21 +7554,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -7978,27 +7690,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/restore-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/restore-cursor/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/reusify": {
       "version": "1.0.4",
@@ -8183,27 +7874,6 @@
       "resolved": "https://registry.npmjs.org/rvfc-polyfill/-/rvfc-polyfill-1.0.7.tgz",
       "integrity": "sha512-seBl7J1J3/k0LuzW2T9fG6JIOpni5AbU+/87LA+zTYKgTVhsfShmS8K/yOo1eeEjGJHnAdkVAUUM+PEjN9Mpkw==",
       "license": "GPL-3.0"
-    },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -8402,16 +8072,6 @@
       "integrity": "sha512-LjdcbuBeLcdETCrPn9i8AYAZ1eCtu4ECAWtP7UleOiZ9LzVxRzzUZEoZ8zB24nhkQnDWyET0I+3sWokSDS3E7g==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
     },
     "node_modules/string-width": {
       "version": "5.1.2",
@@ -9358,16 +9018,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/unocss": {
       "version": "0.62.3",
       "resolved": "https://registry.npmjs.org/unocss/-/unocss-0.62.3.tgz",
@@ -10090,16 +9740,6 @@
       "integrity": "sha512-9YlCL/ynK3CTlrSRrDxZvUauLzAswPCrsaCgilqFevUYpeEW0/3ScEjaa3kbW/T0ghhkEr7mv+fpjqn1Y1YuTA==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/wcwidth": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "defaults": "^1.0.3"
-      }
     },
     "node_modules/webpack-sources": {
       "version": "3.2.3",


### PR DESCRIPTION
* The dpdm dependency was used just for checking circular dependencies in the bundle. However, it was not perfect, not analyzing the real bundle, but the source files. We were just leveraging Rollup's (Vite internal bundler) warnings for that already when analyzing the bundle, which always gave us the real information. Now, `analyze` consists in 2 different commands (analyze:bundle for the bundle and analyze:cycles for finding cycles)

* The npm commands have been grouped by scope

* Extracted analyze Vite commands to a plugin, so the main config is cleaner