### PR TITLE
fix(router): don't use replace on every route when going back

### DIFF
--- a/frontend/src/plugins/router/index.ts
+++ b/frontend/src/plugins/router/index.ts
@@ -45,11 +45,10 @@ const backTransition = 'slide-x';
 router.back = () => {
   const route = router.currentRoute;
 
-    /**
+  /**
    * Play the default page transition but reversed, to play a different effect when going
    * to the previous page.
    */
-
   route.value.meta.layout.transition = {
     enter: 'slide-x-reverse',
     leave: route.value.meta.layout.transition.leave ?? backTransition

--- a/frontend/src/plugins/router/index.ts
+++ b/frontend/src/plugins/router/index.ts
@@ -50,7 +50,13 @@ router.back = () => {
     leave: route.value.meta.layout.transition.leave ?? backTransition
   };
 
-  window.history.back();
+  const historyState = router.options.history.state;
+
+  if (historyState && isStr(historyState.back)) {
+    router.go(-1);
+  } else {
+    router.replace('/');
+  }
 };
 
 /**

--- a/frontend/src/plugins/router/index.ts
+++ b/frontend/src/plugins/router/index.ts
@@ -45,6 +45,11 @@ const backTransition = 'slide-x';
 router.back = () => {
   const route = router.currentRoute;
 
+    /**
+   * Play the default page transition but reversed, to play a different effect when going
+   * to the previous page.
+   */
+
   route.value.meta.layout.transition = {
     enter: 'slide-x-reverse',
     leave: route.value.meta.layout.transition.leave ?? backTransition

--- a/frontend/src/plugins/router/index.ts
+++ b/frontend/src/plugins/router/index.ts
@@ -42,23 +42,15 @@ router.beforeEach(metaGuard);
  */
 const backTransition = 'slide-x';
 
-router.back = (): ReturnType<typeof router.back> => {
+router.back = () => {
   const route = router.currentRoute;
 
-  /**
-   * Play the default page transition but reversed, to play a different effect when going
-   * to the previous page.
-   */
   route.value.meta.layout.transition = {
     enter: 'slide-x-reverse',
     leave: route.value.meta.layout.transition.leave ?? backTransition
   };
 
-  void router.replace(
-    isStr(router.options.history.state.back)
-      ? router.options.history.state.back
-      : '/'
-  );
+  window.history.back();
 };
 
 /**


### PR DESCRIPTION
Related Issue: [#2403](https://github.com/jellyfin/jellyfin-vue/issues/2403)

**Summary**
This merge request resolves a navigation issue where users were unable to traverse the entire navigation history using the back button in the application's sidebar. The problem stemmed from overriding the router.back method with router.replace, which disrupted the history stack and prevented Vue Router from accurately tracking the history length.