### PR TITLE
perf: pause patching while navigating

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -3,30 +3,9 @@
   <VApp>
     <JApp>
       <RouterView v-slot="{ Component, route }">
-        <JTransition
-          :name="route.meta.layout.transition.enter ?? defaultTransition"
-          :mode="defaultTransitionMode ?? route.meta.layout.transition.mode">
-          <Suspense @resolve="apploaded = true">
-            <JView
-              :key="route.meta.layout.name ?? 'default'"
-              :comp="getLayoutComponent(route.meta.layout.name)">
-              <JTransition
-                :name="route.meta.layout.transition.enter ?? defaultTransition"
-                :mode="defaultTransitionMode ?? route.meta.layout.transition.mode">
-                <Suspense suspensible>
-                  <JView
-                    :key="route.name"
-                    :comp="Component" />
-                </Suspense>
-              </JTransition>
-            </JView>
-            <template
-              v-if="!apploaded"
-              #fallback>
-              <JSplashscreen />
-            </template>
-          </Suspense>
-        </JTransition>
+        <JView
+          :comp="Component"
+          :route="route" />
       </RouterView>
     </JApp>
     <Snackbar />
@@ -36,15 +15,7 @@
 </template>
 
 <script setup lang="ts">
-import { shallowRef, type Component as VueComponent, onMounted } from 'vue';
-import type { RouteMeta } from 'vue-router';
-import DefaultLayout from '@/layouts/default.vue';
-import FullPageLayout from '@/layouts/fullpage.vue';
-import ServerLayout from '@/layouts/server.vue';
-
-const apploaded = shallowRef(false);
-const defaultTransition = 'slide-x-reverse';
-const defaultTransitionMode = 'out-in';
+import { onMounted } from 'vue';
 
 /**
  * When app is mounted, the classes and styles we initialized in the pre-Vue splashscreen in body
@@ -56,21 +27,4 @@ onMounted(() => {
   document.body.removeAttribute('class');
   document.body.removeAttribute('style');
 });
-
-/**
- * Return the appropiate layout component according to the route's meta.layout property
- */
-function getLayoutComponent(layout: RouteMeta['layout']['name']): VueComponent {
-  switch (layout) {
-    case 'fullpage': {
-      return FullPageLayout as VueComponent;
-    }
-    case 'server': {
-      return ServerLayout as VueComponent;
-    }
-    default: {
-      return DefaultLayout;
-    }
-  }
-}
 </script>

--- a/frontend/src/components/Item/Card/GenericItemCard.vue
+++ b/frontend/src/components/Item/Card/GenericItemCard.vue
@@ -9,7 +9,7 @@
           :class="shape"
           class="elevation-2">
           <div
-            class="d-flex justify-center align-center absolute-cover card-content">
+            class="d-flex align-center justify-center absolute-cover card-content">
             <JSlot class="card-image">
               <slot
                 name="image" />

--- a/frontend/src/components/Item/ItemGrid.vue
+++ b/frontend/src/components/Item/ItemGrid.vue
@@ -10,10 +10,10 @@
         :class="useResponsiveClasses('card-grid-container')">
         <ItemCard
           :item="item"
-          text
           margin
-          overlay
-          link />
+          link
+          text
+          overlay />
       </JVirtual>
       <div
         v-else

--- a/frontend/src/components/Item/ItemMenu.vue
+++ b/frontend/src/components/Item/ItemMenu.vue
@@ -56,7 +56,6 @@
 <script lang="ts">
 import type { BaseItemDto } from '@jellyfin/sdk/lib/generated-client';
 import { useClipboard, useEventListener } from '@vueuse/core';
-import { v4 } from 'uuid';
 import IMdiArrowExpandDown from 'virtual:icons/mdi/arrow-expand-down';
 import IMdiArrowExpandUp from 'virtual:icons/mdi/arrow-expand-up';
 import IMdiCloudSearch from 'virtual:icons/mdi/cloud-search-outline';
@@ -71,7 +70,7 @@ import IMdiPlaylistPlus from 'virtual:icons/mdi/playlist-plus';
 import IMdiRefresh from 'virtual:icons/mdi/refresh';
 import IMdiReplay from 'virtual:icons/mdi/replay';
 import IMdiShuffle from 'virtual:icons/mdi/shuffle';
-import { computed, getCurrentInstance, onMounted, shallowRef, watch } from 'vue';
+import { computed, getCurrentInstance, onMounted, shallowRef, useId, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRoute, useRouter } from 'vue-router';
 import { isStr } from '@/utils/validation';
@@ -120,7 +119,7 @@ const emit = defineEmits<{
 }>();
 
 const { t } = useI18n();
-const instanceId = v4();
+const instanceId = useId();
 const router = useRouter();
 const route = useRoute();
 

--- a/frontend/src/components/Item/Metadata/ImageEditor.vue
+++ b/frontend/src/components/Item/Metadata/ImageEditor.vue
@@ -22,7 +22,7 @@
         </div>
         <div
           v-if="item.Width && item.Height"
-          class="text-center text--secondary text-body-2">
+          class="text-center text-body-2 text--secondary">
           {{ t('dimensions', { width: item.Width, height: item.Height }) }}
         </div>
         <VCardActions class="justify-center">

--- a/frontend/src/components/Layout/AppBar/AppBar.vue
+++ b/frontend/src/components/Layout/AppBar/AppBar.vue
@@ -60,14 +60,14 @@
 
 <script setup lang="ts">
 import { computed, inject, type Ref } from 'vue';
-import { useRoute } from 'vue-router';
-import { windowScroll, isConnectedToServer, prefersNoTransparency } from '@/store';
+import { windowScroll, isConnectedToServer, transparencyEffects } from '@/store';
 import { clientSettings } from '@/store/client-settings';
 import { remote } from '@/plugins/remote';
+import { JView_isRouting } from '@/store/keys';
 
-const route = useRoute();
 const { y } = windowScroll;
-const transparentAppBar = computed(() => !prefersNoTransparency.value && route.meta.layout.transparent && y.value < 10);
+const isRouting = inject(JView_isRouting);
+const transparentAppBar = computed(previous => isRouting?.value ? previous : transparencyEffects.value && y.value < 10);
 
 /**
  * Cycle between the different color schemas

--- a/frontend/src/components/Layout/Carousel/Item/ItemsCarouselTitle.vue
+++ b/frontend/src/components/Layout/Carousel/Item/ItemsCarouselTitle.vue
@@ -16,7 +16,7 @@
     <RouterLink
       v-else-if="itemLink && titleString"
       data-swiper-parallax="-300"
-      class="link d-block text-h4 text-truncate text-sm-h3 text-sm-h2"
+      class="link d-block text-truncate text-h4 text-sm-h3 text-sm-h2"
       :to="itemLink">
       {{ titleString }}
     </RouterLink>

--- a/frontend/src/components/Layout/Navigation/NavigationDrawer.vue
+++ b/frontend/src/components/Layout/Navigation/NavigationDrawer.vue
@@ -40,10 +40,10 @@
 import IMdiHome from 'virtual:icons/mdi/home';
 import { computed, inject, type Ref } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { useRoute } from 'vue-router';
 import type { RouteNamedMap } from 'vue-router/auto-routes';
 import type { getLibraryIcon } from '@/utils/items';
-import { prefersNoTransparency } from '@/store';
+import { transparencyEffects } from '@/store';
+import { JView_isRouting } from '@/store/keys';
 
 export interface DrawerItem {
   icon: ReturnType<typeof getLibraryIcon>;
@@ -56,11 +56,11 @@ const { order, drawerItems } = defineProps<{
   drawerItems: DrawerItem[];
 }>();
 
-const route = useRoute();
 const { t } = useI18n();
 
 const drawer = inject<Ref<boolean>>('NavigationDrawer');
-const transparentLayout = computed(() => !prefersNoTransparency.value && route.meta.layout.transparent);
+const isRouting = inject(JView_isRouting);
+const transparentLayout = computed(previous => isRouting?.value ? previous : transparencyEffects.value);
 
 const items = [
   {

--- a/frontend/src/components/Layout/SettingsPage.vue
+++ b/frontend/src/components/Layout/SettingsPage.vue
@@ -2,7 +2,7 @@
   <VContainer>
     <VRow v-if="$slots.title">
       <VCol>
-        <VRow class="mt-4 mx-0 mb-2 justify-space-between">
+        <VRow class="mt-4 mb-2 mx-0 justify-space-between">
           <h2 class="text-h4">
             <slot name="title" />
           </h2>

--- a/frontend/src/components/Layout/SwiperSection.vue
+++ b/frontend/src/components/Layout/SwiperSection.vue
@@ -66,8 +66,7 @@ import 'swiper/css/free-mode';
 import 'swiper/css/virtual';
 import { A11y, FreeMode, Navigation, Virtual } from 'swiper/modules';
 import { Swiper, SwiperSlide } from 'swiper/vue';
-import { v4 } from 'uuid';
-import { computed } from 'vue';
+import { computed, useId } from 'vue';
 import { useDisplay, useTheme } from 'vuetify';
 import { CardShapes } from '@/utils/items';
 
@@ -77,7 +76,7 @@ const { title, items, shape } = defineProps<{
   shape?: CardShapes;
 }>();
 
-const uuid = v4();
+const uuid = useId();
 const display = useDisplay();
 const theme = useTheme();
 

--- a/frontend/src/components/lib/JView.vue
+++ b/frontend/src/components/lib/JView.vue
@@ -1,20 +1,103 @@
 <template>
-  <div
-    class="j-transition uno-h-full">
-    <component
-      :is="comp">
-      <slot />
-    </component>
-  </div>
+  <JTransition
+    :name="route.meta.layout.transition.enter ?? defaultTransition"
+    :mode="defaultTransitionMode ?? route.meta.layout.transition.mode"
+    skip-pausing>
+    <Suspense
+      :suspensible="!root"
+      @pending="resolved = false"
+      @resolve=" resolved = true">
+      <div
+        :key="root ? route.meta.layout.name ?? 'default' : route.name"
+        class="j-transition uno-h-full">
+        <Component
+          :is="root ? getLayoutComponent(route.meta.layout.name) : comp">
+          <JView
+            v-if="root"
+            v-bind="$props" />
+          <slot v-else />
+        </Component>
+      </div>
+      <template
+        v-if="!apploaded && root"
+        #fallback>
+        <JSplashscreen />
+      </template>
+    </Suspense>
+  </JTransition>
 </template>
 
-<script setup lang="ts">
-/**
- * TODO: Remove j-transition classes from this file once https://github.com/vuejs/core/issues/5148 is fixed
- */
-import type { Component } from 'vue';
+<!-- TODO: Remove j-transition classes from this file once https://github.com/vuejs/core/issues/5148#issuecomment-2041118368 is fixed -->
 
-const { comp } = defineProps<{
+<script lang="ts">
+import { onErrorCaptured, shallowRef, type Component, watch, computed, provide, useId, ref, type WatchOptions, inject } from 'vue';
+import type { RouteLocationNormalizedGeneric, RouteMeta } from 'vue-router';
+import DefaultLayout from '@/layouts/default.vue';
+import FullPageLayout from '@/layouts/fullpage.vue';
+import ServerLayout from '@/layouts/server.vue';
+import { usePausableEffect } from '@/composables/use-pausable-effect';
+import { JView_isRouting } from '@/store/keys';
+import { router } from '@/plugins/router';
+import { isNil } from '@/utils/validation';
+
+/**
+ * Return the appropiate layout component according to the route's meta.layout property
+ */
+function getLayoutComponent(layout: RouteMeta['layout']['name']): Component {
+  switch (layout) {
+    case 'fullpage': {
+      return FullPageLayout as Component;
+    }
+    case 'server': {
+      return ServerLayout as Component;
+    }
+    default: {
+      return DefaultLayout;
+    }
+  }
+}
+
+const defaultTransition = 'slide-x-reverse';
+const defaultTransitionMode = 'out-in';
+const watchOps = { flush: 'sync' } satisfies WatchOptions;
+const apploaded = shallowRef(false);
+const isRouting = shallowRef(false);
+const _resolveStatus = ref<Record<string, boolean>>({});
+const allResolved = computed(() => Object.values(_resolveStatus.value).every(Boolean));
+const mustBePaused = computed(() => !allResolved.value || isRouting.value);
+
+watch(() => router.currentRoute.value.name, () => isRouting.value = true, watchOps);
+watch(allResolved, () => isRouting.value = false, watchOps);
+</script>
+
+<script setup lang="ts">
+const { comp, route } = defineProps<{
   comp: Component;
+  route: RouteLocationNormalizedGeneric;
 }>();
+
+const id = useId();
+const root = isNil(inject(JView_isRouting));
+
+const resolved = computed({
+  get() {
+    return _resolveStatus.value[id] ?? false;
+  },
+  set(newVal) {
+    _resolveStatus.value[id] = newVal;
+
+    if (root && newVal) {
+      apploaded.value = true;
+    }
+  }
+});
+
+if (root) {
+  provide(JView_isRouting, mustBePaused);
+  usePausableEffect(mustBePaused);
+  onErrorCaptured(() => {
+    resolved.value = true;
+    isRouting.value = false;
+  });
+}
 </script>

--- a/frontend/src/layouts/server.vue
+++ b/frontend/src/layouts/server.vue
@@ -7,8 +7,8 @@
     app
     color="transparent">
     <LocaleSwitcher
-      top
-      elevated />
+      elevated
+      top />
   </VFooter>
 </template>
 

--- a/frontend/src/pages/server/select.vue
+++ b/frontend/src/pages/server/select.vue
@@ -13,7 +13,7 @@
         <div>
           <ServerCard
             v-for="server in $remote.auth.servers"
-            :key="server.Id || v4()"
+            :key="server.Id || useId()"
             class="mt-2"
             :server-info="server" />
         </div>
@@ -38,7 +38,7 @@ meta:
 </route>
 
 <script setup lang="ts">
-import { v4 } from 'uuid';
+import { useId } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { usePageTitle } from '@/composables/page-title';
 

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -1,8 +1,9 @@
 import { getSystemApi } from '@jellyfin/sdk/lib/utils/api/system-api';
 import { computedAsync, useMediaControls, useMediaQuery, useNetwork, useNow, useScroll } from '@vueuse/core';
-import { shallowRef } from 'vue';
+import { computed, shallowRef } from 'vue';
 import { remote } from '@/plugins/remote';
 import { isNil } from '@/utils/validation';
+import { router } from '@/plugins/router';
 
 /**
  * This file contains global variables (specially VueUse refs) that are used multiple times across the client.
@@ -84,6 +85,11 @@ export const hasHDRDisplay = useMediaQuery('(video-dynamic-range:high)');
  * https://developer.mozilla.org/en-US/docs/Web/CSS/@media/update
  */
 export const isSlow = useMediaQuery('(update:slow)');
+
+/**
+ * Whether the layout must use transparency effects
+ */
+export const transparencyEffects = computed(() => !prefersNoTransparency.value && router.currentRoute.value.meta.layout.transparent);
 
 /**
  * Reactively tracks if the user is connected to the server

--- a/frontend/src/store/keys.ts
+++ b/frontend/src/store/keys.ts
@@ -1,0 +1,7 @@
+/**
+ * This file contains all the symbols used with provide/inject API:
+ * https://vuejs.org/guide/components/provide-inject.html#working-with-symbol-keys
+ */
+import type { ComputedRef, InjectionKey } from 'vue';
+
+export const JView_isRouting = Symbol('JView:isRouting') as InjectionKey<ComputedRef<boolean>>;


### PR DESCRIPTION
This also fixes some data changes that happened hile navigating like:

* When using search and clicking on an item, the "No results available" message would appear
* When navigating to a liibrary, the transparency effects of the navdrawer or appbar would match those of the entering route.