### PR TITLE
fix(subtitle): fix subtitle position by updating libpgs to v0.8.0

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,7 +36,7 @@
     "fast-equals": "5.0.1",
     "hls.js": "1.5.17",
     "jassub": "1.7.17",
-    "libpgs": "0.6.0",
+    "libpgs": "0.8.0",
     "marked": "14.1.3",
     "sortablejs": "1.15.3",
     "swiper": "11.1.14",

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "fast-equals": "5.0.1",
         "hls.js": "1.5.17",
         "jassub": "1.7.17",
-        "libpgs": "0.6.0",
+        "libpgs": "0.8.0",
         "marked": "14.1.3",
         "sortablejs": "1.15.3",
         "swiper": "11.1.14",
@@ -6398,9 +6398,9 @@
       }
     },
     "node_modules/libpgs": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/libpgs/-/libpgs-0.6.0.tgz",
-      "integrity": "sha512-k8ic6VTJTCun8Ump8iAe+tZi3pa1ZhDlq1v4hmZOmYQzSQ44QpZoClMXuSfJ1B91eRWOO6q50rXhyCPuB9dXbg==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/libpgs/-/libpgs-0.8.0.tgz",
+      "integrity": "sha512-YpmcQYP177j08Vd0zEORgtdHsdPLGF8FCL152DgTQg2txLx1ndjgNOJ1n0217ap5rFV8riTugzjM9sqPrT1e5Q==",
       "license": "MIT"
     },
     "node_modules/lightningcss": {


### PR DESCRIPTION
**Changes**
This PR updates libpgs-js to version v0.8.0:
- Fixed a subtitle position issue. The subtitle position now matches the position in FFmpeg.
- Subtitle cropping is now supported. This is based on the FFmpeg implementation, but I couldn't test it on a real subtitle track yet.

**Issues**
Fixes https://github.com/jellyfin/jellyfin-web/issues/6273

**Related PRs**
- https://github.com/jellyfin/jellyfin-web/pull/6291