### PR TITLE
fix: /server/login with disabled server selection

### DIFF
--- a/frontend/src/plugins/router/middlewares/login.ts
+++ b/frontend/src/plugins/router/middlewares/login.ts
@@ -41,7 +41,11 @@ export const loginGuard = async (
 ): Promise<Exclude<NavigationGuardReturn, Error>> => {
   const toServerPages = serverPages.has(to.name);
 
-  if (!jsonConfig.allowServerSelection && toServerPages) {
+  /**
+   * Do not allow the server selection pages if allowServerSelection=false,
+   * but do allow the login page.
+   */
+  if (!jsonConfig.allowServerSelection && toServerPages && to.name != '/server/login') {
     return false;
   }
 

--- a/frontend/src/plugins/router/middlewares/login.ts
+++ b/frontend/src/plugins/router/middlewares/login.ts
@@ -42,10 +42,10 @@ export const loginGuard = async (
   const toServerPages = serverPages.has(to.name);
 
   /**
-   * Do not allow the server selection pages if allowServerSelection=false,
+   * Do not allow the server selection pages if `allowServerSelection` is false in config.json,
    * but do allow the login page.
    */
-  if (!jsonConfig.allowServerSelection && toServerPages && to.name != '/server/login') {
+  if (!jsonConfig.allowServerSelection && (toServerPages && to.name !== serverLoginUrl)) {
     return false;
   }
 


### PR DESCRIPTION
It's been a while since I contributed, so I'm kinda new again here and I don't know exactly what I'm doing.

However as far as my testing goes, this seemed to work. However I didn't verify if subtitles still work. But I imagine it should.

the div class=uno-my-auto div caused the media element to not realize it had more room to fill. Removing it let the parent elements css classes become effective. It still seems to work as expected in the mini version of the player.

This could also cause the stretch option to do something, however I'm not sure why anyone would even want this functionality (non-aspect-preserving stretch to fit - if it works). I would probably recommend removing it for simplicity... That is not part of this PR however :)