### PR TITLE
fix: navigation out of video player - VOverlay was hijacking navigation

### DIFF
--- a/frontend/src/components/Playback/MiniVideoPlayer.vue
+++ b/frontend/src/components/Playback/MiniVideoPlayer.vue
@@ -7,6 +7,7 @@
       :scrim="false"
       scroll-strategy="none"
       content-class="minimized-overlay"
+      :close-on-back="false"
       :width="$vuetify.display.mobile ? '60vw' : '25vw'">
       <div
         ref="videoContainerRef"
@@ -14,6 +15,7 @@
       <VOverlay
         :model-value="isHovering"
         contained
+        :close-on-back="false"
         height="100%"
         width="100%">
         <div class="d-flex flex-column">

--- a/frontend/src/pages/playback/video.vue
+++ b/frontend/src/pages/playback/video.vue
@@ -10,6 +10,7 @@
         v-model="overlay"
         contained
         scrim="transparent"
+        :close-on-back="false"
         width="100%"
         height="100%">
         <div


### PR DESCRIPTION
not too much more to say.

closeOnBack according to vuetify documentation:

> Closes the overlay content when the browser's back button is pressed or `$router.back()` is called, cancelling the original navigation. `persistent` overlays will cancel navigation and animate as if they were clicked outside instead of closing.