### PR TITLE
feat: add box-shadow to GenericItemCard

### DIFF
--- a/frontend/src/components/Item/Card/GenericItemCard.vue
+++ b/frontend/src/components/Item/Card/GenericItemCard.vue
@@ -163,6 +163,7 @@ const hasClick = computed(() => !!attrs.onClick);
 @media (hover: hover) and (pointer: fine) {
   .card-box:hover .card-overlay-hover {
     background: rgba(var(--j-color-background), 0.5);
+    box-shadow: inset 0px -64px 64px -50px #000;
   }
   .card-box:hover .card-overlay-hover .card-overlay-hover-hidden {
     opacity: 1;


### PR DESCRIPTION
adds inner shadow to bottom edge of card, so action icons are more visible

Before: 
![image](https://github.com/user-attachments/assets/6b52592b-4935-42c4-833f-4ea7f2419798)

After: 
![image](https://github.com/user-attachments/assets/4fc3ac4d-a8d3-4b41-9d9e-28cc129b54ae)
