### PR TITLE
refactor: Update subtitle streams to use TextTrack indexes

### DIFF
--- a/frontend/src/store/playback-manager.ts
+++ b/frontend/src/store/playback-manager.ts
@@ -270,6 +270,8 @@ class PlaybackManagerStore extends CommonStore<PlaybackManagerState> {
 
   public get currentItemParsedSubtitleTracks(): PlaybackTrack[] | undefined {
     if (!isNil(this._state.currentMediaSource)) {
+      // TODO: There is currently a bug in Jellyfin server when adding external subtitles may play the incorrect subtitle
+      // https://github.com/jellyfin/jellyfin/issues/13198
       return this._state.currentMediaSource.MediaStreams?.filter(
           sub =>
             sub.Type === MediaStreamType.Subtitle

--- a/frontend/src/store/playback-manager.ts
+++ b/frontend/src/store/playback-manager.ts
@@ -270,17 +270,17 @@ class PlaybackManagerStore extends CommonStore<PlaybackManagerState> {
 
   public get currentItemParsedSubtitleTracks(): PlaybackTrack[] | undefined {
     if (!isNil(this._state.currentMediaSource)) {
-      return this._state.currentMediaSource.MediaStreams?.map(
-        (stream, index) => ({
-          srcIndex: index,
-          ...stream
-        })
-      )
-        .filter(
+      return this._state.currentMediaSource.MediaStreams?.filter(
           sub =>
             sub.Type === MediaStreamType.Subtitle
             && (sub.DeliveryMethod === SubtitleDeliveryMethod.Encode
               || sub.DeliveryMethod === SubtitleDeliveryMethod.External)
+        )
+        .map(
+          (stream, index) => ({
+            srcIndex: index,
+            ...stream
+          })
         )
         .map(sub => ({
           label: sub.DisplayTitle ?? 'Undefined',

--- a/frontend/src/utils/items.ts
+++ b/frontend/src/utils/items.ts
@@ -450,7 +450,13 @@ export function getMediaStreams(
   mediaStreams: MediaStream[],
   streamType: string
 ): MediaStream[] {
-  return mediaStreams.filter(mediaStream => mediaStream.Type === streamType);
+  return mediaStreams.filter(mediaStream => mediaStream.Type === streamType)
+    .map(
+      (stream, index) => ({
+        ...stream,
+        Index: index
+      })
+    )
 }
 
 /**


### PR DESCRIPTION
Subtitles were using the MediaStream index to select what subtitles to play, rather than the TextTrack index.
This meant that the subtitles were playing incorrectly as it was taking into account the Video/Audio streams when selecting a subtitle.
E.G:
    English 1
    English 2
    English (SDH)
    Bulgarian
    CZE

When selecting English 1, This plays the English (SDH).
When selecting English 2, This plays Bulgarian.
When selecting English (SDH), This plays CZE.

This is because the MediaStreams are:
    Video
    Audio
    English 1
    English 2
    etc...

This PR refactors the subtitle selection code to set the Index and srcIndex to be based on the TextStream, instead of the MediaStream.

resolves #2519