### PR TITLE
fix(GenericItemCard): overlay background alpha

### DIFF
--- a/frontend/src/components/Item/Card/GenericItemCard.vue
+++ b/frontend/src/components/Item/Card/GenericItemCard.vue
@@ -162,7 +162,7 @@ const hasClick = computed(() => !!attrs.onClick);
 
 @media (hover: hover) and (pointer: fine) {
   .card-box:hover .card-overlay-hover {
-    background: rgba(var(--j-color-background), 0.5);
+    background: rgb(var(--j-color-background), 0.5);
   }
   .card-box:hover .card-overlay-hover .card-overlay-hover-hidden {
     opacity: 1;

--- a/frontend/src/components/lib/JApp.vue
+++ b/frontend/src/components/lib/JApp.vue
@@ -10,7 +10,7 @@
       <template v-if="isLoading">
         cursor: wait;
       </template>
-      --j-color-background: rgb(var(--v-theme-background));
+      --j-color-background: var(--v-theme-background);
       --j-font-family: '{{ typography }}';
       }
     </component>


### PR DESCRIPTION
The `--j-color-background` was converted to rgb directly when being redeclared in JApp. However, it needed to be raw so it could be properly passed for the alpha.

Supersedes #2526 