### PR TITLE
fix: failing Docker images from CI

### DIFF
--- a/frontend/src/components/Layout/Navigation/CommitLink.vue
+++ b/frontend/src/components/Layout/Navigation/CommitLink.vue
@@ -7,8 +7,7 @@
     rel="noopener noreferrer">
     <template #prepend>
       <JIcon
-        class="i-mdi:github uno-w-10"
-        " />
+        class="i-mdi:github uno-w-10" />
     </template>
   </VListItem>
 </template>

--- a/frontend/types/global/components.d.ts
+++ b/frontend/types/global/components.d.ts
@@ -127,7 +127,6 @@ declare module 'vue' {
     VExpansionPanelText: typeof import('vuetify/components')['VExpansionPanelText']
     VFooter: typeof import('vuetify/components')['VFooter']
     VForm: typeof import('vuetify/components')['VForm']
-    VIcon: typeof import('vuetify/components')['VIcon']
     VItemGroup: typeof import('vuetify/components')['VItemGroup']
     VList: typeof import('vuetify/components')['VList']
     VListItem: typeof import('vuetify/components')['VListItem']


### PR DESCRIPTION
After the merge of #2539, the Docker builds from CI stopped working properly. However, local and Codespace builds (even locally built Docker images) still are working fine, so no idea what's going on. This PR is a playground to test stuff since it can only be reproduced in CI-produced artifacts. When the fix is found, this same PR is going to contain the fixes.