### PR TITLE
fix: positioning of item progress indicators

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,7 +44,7 @@
     "vue": "3.4.23",
     "vue-i18n": "9.13.0",
     "vue-router": "4.3.1",
-    "vuetify": "3.5.16"
+    "vuetify": "3.5.18"
   },
   "devDependencies": {
     "@eslint/config-inspector": "0.4.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "vue": "3.4.23",
         "vue-i18n": "9.13.0",
         "vue-router": "4.3.1",
-        "vuetify": "3.5.16"
+        "vuetify": "3.5.18"
       },
       "devDependencies": {
         "@eslint/config-inspector": "0.4.6",
@@ -11014,9 +11014,9 @@
       }
     },
     "node_modules/vuetify": {
-      "version": "3.5.16",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.5.16.tgz",
-      "integrity": "sha512-jyApfATreFMkgjvK0bL7ntZnr+p9TU73+4E3kX6fIvUitdAP9fltG7yj+v3k14HLqZRSNhTL1GhQ95DFx631zw==",
+      "version": "3.5.18",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.5.18.tgz",
+      "integrity": "sha512-33eRhaLkKaiyH7PDau1xDvFzAGFKNo/nFvyiKhB+DePDZBkvMEphUul+zCitHgUrQCZo1i7kfY97k6q+7QURuQ==",
       "engines": {
         "node": "^12.20 || >=14.13"
       },


### PR DESCRIPTION
Progress indicators on item cards was being displayed centered vertically instead of anchored to the bottom.
Location styles for VProgressLinear was removed in Vuetify 3.5.16 but was reverted in 3.5.17.