### PR TITLE
chore: fixed scanningItemInProgress text

### DIFF
--- a/frontend/src/components/Layout/AppBar/Buttons/TaskManagerButton.vue
+++ b/frontend/src/components/Layout/AppBar/Buttons/TaskManagerButton.vue
@@ -76,7 +76,7 @@ const mappedTaskList = computed<TaskInfo[]>(() => {
         return {
           progress: tsk.progress,
           text: t('scanningItemInProgress', {
-            library: tsk.data ?? ''
+            item: tsk.data ?? ''
           }),
           id: tsk.id
         };

--- a/packages/i18n/strings/en.json
+++ b/packages/i18n/strings/en.json
@@ -326,7 +326,7 @@
   "saveAsPlaylist": "Save queue as a playlist",
   "saved": "Saved",
   "scanForNewAndUpdatedFiles": "Scan for new and updated files",
-  "scanningItemInProgress": "Scanning '{{library}}'…",
+  "scanningItemInProgress": "Scanning '{{item}}'…",
   "scheduledTasks": "Scheduled tasks",
   "scheduledTasksSettingsDescription": "Manage scheduled tasks running on this server",
   "screenshot": "Screenshot",

--- a/packages/i18n/strings/en.json
+++ b/packages/i18n/strings/en.json
@@ -326,7 +326,7 @@
   "saveAsPlaylist": "Save queue as a playlist",
   "saved": "Saved",
   "scanForNewAndUpdatedFiles": "Scan for new and updated files",
-  "scanningItemInProgress": "Scanning '{{item}}'…",
+  "scanningItemInProgress": "Scanning '{{library}}'…",
   "scheduledTasks": "Scheduled tasks",
   "scheduledTasksSettingsDescription": "Manage scheduled tasks running on this server",
   "screenshot": "Screenshot",


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/37636602-0e7d-4e6a-9dda-22bac590cc48)


After:
![image](https://github.com/user-attachments/assets/43b5de55-d9e0-44af-9864-6d4322564c03)


Because its called Library here, not Item: https://github.com/jellyfin/jellyfin-vue/blob/master/frontend/src/components/Layout/AppBar/Buttons/TaskManagerButton.vue#L79
