### PR TITLE
Allow dupeplicate imports

### DIFF
--- a/frontend/eslint.config.ts
+++ b/frontend/eslint.config.ts
@@ -14,5 +14,10 @@ export default defineConfig([
       'types/global/routes.d.ts',
       'types/global/components.d.ts'
     ]
+  },
+  {
+    rules: {
+      'import/no-duplicates': 'error'
+    }
   }
 ]);


### PR DESCRIPTION
I encountered an issue during development where the system was treating the 'vue-router/auto-routes' imports as if they were part of the main 'vue-router' library. As a result, every time I saved the file, it would incorrectly try to merge those imports together, which was clearly not the intended behavior.

These changes should prevent the issues.