### PR TITLE
Add fix for routers

### DIFF
--- a/frontend/src/components/Layout/MainView.vue
+++ b/frontend/src/components/Layout/MainView.vue
@@ -74,7 +74,8 @@ const { comp, route } = defineProps<{
 }>();
 
 const id = useId();
-const root = isNil(inject(JView_isRouting));
+const injectedRouting = inject(JView_isRouting, null);
+const root = isNil(injectedRouting);
 
 const resolved = computed({
   get() {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -5,7 +5,6 @@
  */
 import '@jellyfin-vue/i18n';
 import { createApp } from 'vue';
-import { routes } from 'vue-router/auto-routes';
 import i18next from 'i18next';
 import I18NextVue from 'i18next-vue';
 import { getFontFaces } from '#/utils/data-manipulation';
@@ -26,14 +25,6 @@ import '#/assets/styles/index.css';
  */
 const remote = createRemote();
 const app = createApp(Root);
-
-/**
- * We add routes at this point instead of in the router plugin to avoid circular references
- * in components. At this stage, we're sure plugins are instantiated.
- */
-for (const route of routes) {
-  router.addRoute(route);
-}
 
 app.use(remote);
 app.use(I18NextVue, { i18next });

--- a/frontend/src/plugins/router/index.ts
+++ b/frontend/src/plugins/router/index.ts
@@ -11,13 +11,14 @@ import { loginGuard } from './middlewares/login';
 import { metaGuard } from './middlewares/meta';
 import { validateGuard } from './middlewares/validate';
 import { jsonConfig } from '#/utils/external-config';
+import { routes } from 'vue-router/auto-routes';
 
 export const router = createRouter({
   history:
     jsonConfig.routerMode === 'history'
       ? createWebHistory()
       : createWebHashHistory(),
-  routes: [],
+  routes: routes,
   /**
    * TODO: Fix this, so it only scrolls to the top once suspense resolves
    */
@@ -69,7 +70,8 @@ router.back = () => {
 watch([
   remote.auth.currentUser,
   remote.auth.currentServer
-], () => {
+], async () => {
+  await router.isReady();
   void router.replace({
     ...router.currentRoute.value,
     force: true


### PR DESCRIPTION
These are general router-related fixes. I was running into a few issues—specifically, when reloading the page while on a nested route, it would always redirect to the root (`/`) route, which isn't correct. I resolved this by adding `await router.isReady();` to ensure the router is fully initialized before proceeding.

Additionally, I can't see why the circular dependency issues were happening in the first place. I believe it would be cleaner and more maintainable to consolidate all router-related logic into the router file itself, as it's a better design practice.

Of course, if you have any concerns or strong reasons against this approach, I'm happy to revisit and revise the PR. Thanks!

This has all been tested and works fine.