### PR TITLE
feat(playback): add streaming quality selector

### DIFF
--- a/packages/frontend/src/components/Buttons/Playback/PlaybackSettingsButton.vue
+++ b/packages/frontend/src/components/Buttons/Playback/PlaybackSettingsButton.vue
@@ -19,9 +19,11 @@
               </VCol>
               <VCol :cols="8">
                 <VSelect
+                  v-model="maxStreamingBitrate"
                   density="comfortable"
-
-                  disabled
+                  :items="qualityItems"
+                  item-title="title"
+                  item-value="value"
                   hide-details />
               </VCol>
             </VRow>
@@ -100,6 +102,28 @@ import { playerElement } from '#/store/player-element.ts';
 
 const menuModel = defineModel<boolean>();
 const { t } = useTranslation();
+
+/**
+ * Streaming quality presets. `0` means automatic (source quality); any other
+ * value is the maximum streaming bitrate in bps passed to the server.
+ */
+const qualityItems = computed(() => [
+  { title: t('auto'), value: 0 },
+  { title: '1080p - 20 Mbps', value: 20_000_000 },
+  { title: '1080p - 10 Mbps', value: 10_000_000 },
+  { title: '720p - 8 Mbps', value: 8_000_000 },
+  { title: '720p - 4 Mbps', value: 4_000_000 },
+  { title: '480p - 3 Mbps', value: 3_000_000 },
+  { title: '480p - 1.5 Mbps', value: 1_500_000 },
+  { title: '360p - 720 kbps', value: 720_000 }
+]);
+const maxStreamingBitrate = computed({
+  get: () => playbackManager.maxStreamingBitrate.value ?? 0,
+  set: (val: number) => {
+    playbackManager.maxStreamingBitrate.value = val || undefined;
+  }
+});
+
 const defaultPlaybackSpeeds = Object.freeze([0.5, 0.75, 1, 1.25, 1.5, 2]);
 const playbackItems = computed(() => defaultPlaybackSpeeds.map(speed => ({
   title: speed === 1 ? t('normal') : String(speed),

--- a/packages/frontend/src/components/Buttons/Playback/PlaybackSettingsButton.vue
+++ b/packages/frontend/src/components/Buttons/Playback/PlaybackSettingsButton.vue
@@ -104,11 +104,11 @@ const menuModel = defineModel<boolean>();
 const { t } = useTranslation();
 
 /**
- * Streaming quality presets. `0` means automatic (source quality); any other
+ * Streaming quality presets. `0` means source quality; any other
  * value is the maximum streaming bitrate in bps passed to the server.
  */
 const qualityItems = computed(() => [
-  { title: t('auto'), value: 0 },
+  { title: t('original'), value: 0 },
   { title: '1080p - 20 Mbps', value: 20_000_000 },
   { title: '1080p - 10 Mbps', value: 10_000_000 },
   { title: '720p - 8 Mbps', value: 8_000_000 },

--- a/packages/frontend/src/store/playback-manager.ts
+++ b/packages/frontend/src/store/playback-manager.ts
@@ -80,7 +80,7 @@ interface PlaybackManagerState {
   playbackSpeed: number;
   /**
    * Maximum streaming bitrate in bps. When set, the server transcodes the
-   * media source to fit within it. Undefined means automatic (source quality).
+   * media source to fit within it. Undefined means source quality.
    */
   maxStreamingBitrate?: number;
 }
@@ -327,7 +327,7 @@ class PlaybackManagerStore extends CommonStore<PlaybackManagerState> {
   });
 
   /**
-   * Maximum streaming bitrate in bps. Undefined means automatic (source quality).
+   * Maximum streaming bitrate in bps. Undefined means source quality.
    * Changing this re-requests the playback info, transparently reloading the
    * source at the current playback time.
    */

--- a/packages/frontend/src/store/playback-manager.ts
+++ b/packages/frontend/src/store/playback-manager.ts
@@ -78,6 +78,11 @@ interface PlaybackManagerState {
   playbackInitiatorId?: BaseItemDto['Id'];
   playbackInitMode: InitMode;
   playbackSpeed: number;
+  /**
+   * Maximum streaming bitrate in bps. When set, the server transcodes the
+   * media source to fit within it. Undefined means automatic (source quality).
+   */
+  maxStreamingBitrate?: number;
 }
 
 /**
@@ -234,6 +239,7 @@ class PlaybackManagerStore extends CommonStore<PlaybackManagerState> {
           itemId: this.currentItem.value.Id,
           userId: remote.auth.currentUserId.value,
           autoOpenLiveStream: true,
+          maxStreamingBitrate: this._state.value.maxStreamingBitrate,
           playbackInfoDto: { DeviceProfile: playbackProfile },
           mediaSourceId: this.currentMediaSource.value.Id,
           audioStreamIndex: this._state.value.mediaSourceIndexes.audio,
@@ -317,6 +323,18 @@ class PlaybackManagerStore extends CommonStore<PlaybackManagerState> {
     get: () => this._state.value.playbackSpeed,
     set: (newSpeed: number) => {
       this._state.value.playbackSpeed = newSpeed;
+    }
+  });
+
+  /**
+   * Maximum streaming bitrate in bps. Undefined means automatic (source quality).
+   * Changing this re-requests the playback info, transparently reloading the
+   * source at the current playback time.
+   */
+  public readonly maxStreamingBitrate = computed({
+    get: () => this._state.value.maxStreamingBitrate,
+    set: (newBitrate: number | undefined) => {
+      this._state.value.maxStreamingBitrate = newBitrate;
     }
   });
 
@@ -779,7 +797,8 @@ class PlaybackManagerStore extends CommonStore<PlaybackManagerState> {
         playSessionId: undefined,
         playbackInitiatorId: undefined,
         playbackInitMode: InitMode.Unknown,
-        playbackSpeed: 1
+        playbackSpeed: 1,
+        maxStreamingBitrate: undefined
       })
     });
     /**

--- a/packages/i18n/strings/en.json
+++ b/packages/i18n/strings/en.json
@@ -274,6 +274,7 @@
   "numberTracks": "{{number}} tracks",
   "offlineCantDoThisWillRetryWhenOnline": "You can't perform this action because you've lost the connection to the server. It will be retried once it's recovered.",
   "originalTitle": "Original title",
+  "original": "Original",
   "overview": "Overview",
   "parallelImageEncodingLimit": "Parallel Image Encoding Limit",
   "parallelLibraryScanLimit": "Parallel Library Scan limit",


### PR DESCRIPTION
The playback settings menu had a disabled quality dropdown. This wires it up: selecting an option sets a maximum streaming bitrate that's passed to the server's playback info request, so it can transcode to fit. "Automatic" keeps the previous behaviour (source quality). Changing the quality reloads the source at the current playback time.