### PR TITLE
fix(router): circular dependency 

### DIFF
--- a/packages/frontend/src/main.ts
+++ b/packages/frontend/src/main.ts
@@ -22,7 +22,7 @@ import 'uno.css';
 import '#/assets/styles/index.css';
 
 /**
- * - VUE PLUGINS, STORE AND DIRECTIVE -
+ * - Vue.js PLUGINS, STORE AND DIRECTIVE -
  * The order of statements IS IMPORTANT
  */
 const remote = createRemote();
@@ -55,3 +55,15 @@ await document.fonts.ready;
  * MOUNTING POINT
  */
 app.mount(document.body);
+
+/**
+ * DEV-MODE LOGIC
+ */
+if (import.meta.env.DEV) {
+  /* eslint-disable-next-line unicorn/no-lonely-if */
+  if (import.meta.hot) {
+    const { handleHotUpdate } = await import('vue-router/auto-routes');
+
+    handleHotUpdate(router);
+  }
+}

--- a/packages/frontend/src/plugins/router/index.ts
+++ b/packages/frontend/src/plugins/router/index.ts
@@ -4,7 +4,6 @@ import {
   createWebHashHistory,
   createWebHistory
 } from 'vue-router';
-import { handleHotUpdate } from 'vue-router/auto-routes';
 import { isStr } from '@jellyfin-vue/shared/validation';
 import { remote } from '../remote/index.ts';
 import { adminGuard } from './middlewares/admin-pages.ts';
@@ -22,9 +21,7 @@ export const router = createRouter({
   /**
    * TODO: Fix this, so it only scrolls to the top once suspense resolves
    */
-  scrollBehavior(_to, _from, savedPosition) {
-    return savedPosition ?? { top: 0 };
-  }
+  scrollBehavior: (_to, _from, savedPosition) => savedPosition ?? { top: 0 }
 });
 
 /**
@@ -76,7 +73,3 @@ watch([
     force: true
   });
 }, { flush: 'sync' });
-
-if (import.meta.hot) {
-  handleHotUpdate(router);
-}

--- a/packages/vite-plugins/src/bundle.ts
+++ b/packages/vite-plugins/src/bundle.ts
@@ -17,7 +17,7 @@ const defaultConfig = { build: { outDir: 'dist' } };
  */
 export function JBundleAnalysis(): Plugin {
   let mode: LiteralUnion<'analyze:bundle' | 'analyze:cycles', string>;
-  const warnings: Rolldown.RolldownLog = [];
+  const warnings: Rolldown.RolldownLog[] = [];
 
   return {
     name: 'Jellyfin_Vue:bundle_analysis',
@@ -43,10 +43,15 @@ export function JBundleAnalysis(): Plugin {
             }
           }
         };
-      } else if (env.mode === 'analyze:cycles') {
+      }
+
+      if (env.mode === 'analyze:cycles') {
         return {
           build: {
             rolldownOptions: {
+              checks: {
+                circularDependency: true
+              },
               onwarn: (warning) => {
                 if (warning.code === 'CIRCULAR_DEPENDENCY') {
                   warnings.push(warning);
@@ -87,7 +92,7 @@ export function JBundleAnalysis(): Plugin {
 }
 
 /**
- * Creates the Rollup's chunking strategy of the application (for code-splitting)
+ * Creates the Rollup's chunking strategy of the app (for code-splitting)
  */
 export function JBundleChunking(): Plugin {
   return {
@@ -117,7 +122,7 @@ export function JBundleChunking(): Plugin {
                       return;
                     }
 
-                    const packageName = normalizedId.slice(nodeModulesIndex + nodeModulesPrefix.length).split('/')[0];
+                    const packageName = normalizedId.slice(nodeModulesIndex + nodeModulesPrefix.length).split('/', 1)[0];
 
                     if (!packageName) {
                       return;


### PR DESCRIPTION
Vite 8 changed the bundler to rolldown, which didn't emit a CIRCULAR_DEPENDENCY warning by default, so our logic stopped working and this issue passed by completely unnoticed.

Fixes #2822 