### PR TITLE
feat(docker): add v6 listener to nginx config

### DIFF
--- a/packaging/docker/contents/nginx.conf
+++ b/packaging/docker/contents/nginx.conf
@@ -1,5 +1,6 @@
 server {
     listen 80;
+    listen [::]:80;
     root ${ASSETS};
     location / {
         # First attempt to serve request as file, then as directory, then fall back to redirecting to index.html


### PR DESCRIPTION
Hi, this adds an ipv6 listener to the nginx config inside the docker container. 

The usecase for this is binding container ports to the loopback like this: `[::1]:1337:80` (handy to avoid docker bypassing the host firewall)
When the process inside the container doesn't listen on v6, it results in strange errors since the connection does get accepted by the container daemon but doesn't make it to the process inside the container.

I have tested this by building the container and running it locally, seems to work fine