### PR TITLE
feat: merge crew entries for people with multiple roles

### DIFF
--- a/packages/frontend/src/pages/item/[itemId].vue
+++ b/packages/frontend/src/pages/item/[itemId].vue
@@ -306,7 +306,7 @@ import { getLibraryApi } from '@jellyfin/sdk/lib/utils/api/library-api';
 import { getUserLibraryApi } from '@jellyfin/sdk/lib/utils/api/user-library-api';
 import { computed, ref } from 'vue';
 import { useRoute } from 'vue-router';
-import { getItemDetailsLink, getMediaStreams } from '#/utils/items.ts';
+import { getItemDetailsLink, getMediaStreams, getMergedCrew } from '#/utils/items.ts';
 import { getItemizedSelect } from '#/utils/forms.ts';
 import { useBaseItem } from '#/composables/apis.ts';
 import { useItemBackdrop } from '#/composables/backdrop.ts';
@@ -341,9 +341,7 @@ const currentAudioTrack = ref<number>();
 const currentSubtitleTrack = ref<number>();
 
 const crew = computed<BaseItemPerson[]>(() =>
-  (item.value.People ?? []).filter(person =>
-    ['Director', 'Writer'].includes(person.Type ?? '')
-  )
+  getMergedCrew(item.value.People ?? [])
 );
 
 const actors = computed<BaseItemPerson[]>(() =>

--- a/packages/frontend/src/pages/series/[itemId].vue
+++ b/packages/frontend/src/pages/series/[itemId].vue
@@ -192,7 +192,7 @@ import { computed } from 'vue';
 import { useRoute } from 'vue-router';
 import { getTvShowsApi } from '@jellyfin/sdk/lib/utils/api/tv-shows-api';
 import { getItemsApi } from '@jellyfin/sdk/lib/utils/api/items-api';
-import { getItemDetailsLink } from '#/utils/items.ts';
+import { getItemDetailsLink, getMergedCrew } from '#/utils/items.ts';
 import { useBaseItem } from '#/composables/apis.ts';
 import { useItemBackdrop } from '#/composables/backdrop.ts';
 import { useItemPageTitle } from '#/composables/page-title.ts';
@@ -229,9 +229,7 @@ const seasonEpisodes = computed(() => {
 });
 
 const crew = computed<BaseItemPerson[]>(() =>
-  (item.value.People ?? []).filter(person =>
-    ['Director', 'Writer'].includes(person.Type ?? '')
-  )
+  getMergedCrew(item.value.People ?? [])
 );
 
 const actors = computed<BaseItemPerson[]>(() =>

--- a/packages/frontend/src/utils/items.ts
+++ b/packages/frontend/src/utils/items.ts
@@ -57,6 +57,48 @@ export enum CardShapes {
 export const defaultSortOrder = [ItemSortBy.PremiereDate, ItemSortBy.ProductionYear, ItemSortBy.SortName];
 
 /**
+ * The person types the server reports once per job, meaning someone credited for
+ * multiple jobs is sent as multiple people.
+ */
+const mergeableCrewTypes = new Set(['Director', 'Writer', 'Producer']);
+
+/**
+ * Gets the crew of an item, combining the credits of a person holding multiple jobs into
+ * a single entry listing all their roles, like "Director / Producer". Actors are left out,
+ * so a person playing multiple characters keeps one entry per character.
+ *
+ * @param people - The people of the item.
+ * @returns The crew, with one entry per person.
+ */
+export function getMergedCrew(people: BaseItemPerson[]): BaseItemPerson[] {
+  const crew: BaseItemPerson[] = [];
+  const indexes = new Map<string, number>();
+
+  for (const person of people) {
+    if (!mergeableCrewTypes.has(person.Type ?? '')) {
+      continue;
+    }
+
+    const index = isNil(person.Id) ? undefined : indexes.get(person.Id);
+
+    if (isNil(index)) {
+      if (!isNil(person.Id)) {
+        indexes.set(person.Id, crew.length);
+      }
+
+      crew.push(person);
+    } else {
+      const merged = crew[index]!;
+      const roles = [merged.Role, person.Role].filter(role => !isNil(role) && role !== '');
+
+      crew[index] = { ...merged, Role: [...new Set(roles)].join(' / ') };
+    }
+  }
+
+  return crew;
+}
+
+/**
  * Determines if the item is a person
  *
  * @param item - The item to be checked.

--- a/packages/frontend/src/utils/items.ts
+++ b/packages/frontend/src/utils/items.ts
@@ -74,11 +74,9 @@ export function getMergedCrew(people: BaseItemPerson[]): BaseItemPerson[] {
   const crew: BaseItemPerson[] = [];
   const indexes = new Map<string, number>();
 
-  for (const person of people) {
-    if (!mergeableCrewTypes.has(person.Type ?? '')) {
-      continue;
-    }
+  const credits = people.filter(person => mergeableCrewTypes.has(person.Type ?? ''));
 
+  for (const person of credits) {
     const index = isNil(person.Id) ? undefined : indexes.get(person.Id);
 
     if (isNil(index)) {


### PR DESCRIPTION
**Changes**

The server sends one `People` entry per credit, so a person credited for several jobs on the same item is listed once per job — Edgar Wright shows up twice in the crew list of *Scott Pilgrim vs. the World*, same avatar, once as Director and once as Screenplay. This combines the credits belonging to the same person into a single entry listing every role, e.g. "Director / Screenplay / Producer". Actors are untouched, so someone playing multiple characters still gets an entry per character.

It follows what jellyfin-web does since https://github.com/jellyfin/jellyfin-web/pull/8209 (shipped in 12.0), using the same merged types — director, writer, producer, which is also what the server keeps in `TmdbUtils.WantedCrewKinds` — and the same `" / "` separator.

The merging lives in a new `getMergedCrew()` in `utils/items.ts`, used by the `crew` computed on both the item and the series page.

One deliberate extra: the crew filter was `['Director', 'Writer']`, so producers never appeared in the crew list at all, unlike in the web client. They are included now. If that was intentional and you would rather keep producers out, say so and I will drop that part — the merging itself works either way.

**Code assistance**

Written with Claude Code using the Opus 5 model. It audited which clients were missing the behavior, wrote `getMergedCrew()` and the call sites, and verified the result by running the dev server against a Jellyfin 12.0 server and driving it in a headless browser. I reviewed the change myself.

Verified against a real library. Crew list for *Scott Pilgrim vs. the World*, before:

```
Edgar Wright         Director
Michael Bacall       Screenplay
Bryan Lee O'Malley   Graphic Novel
Edgar Wright         Screenplay
```

after:

```
Edgar Wright         Director / Screenplay / Producer
Michael Bacall       Screenplay
Bryan Lee O'Malley   Graphic Novel
J. Miles Dale        Executive Producer
Eric Gitter          Producer
...
```

`vue-tsc` and `eslint` report no new problems on the touched files (the repo has a number of pre-existing type errors in storybook and ui-toolkit; the set is identical with and without this change).

I only reproduced the duplicate entries on Android TV originally, but the same gap exists here, in Swiftfin and in jellyfin-roku, so I am opening the equivalent PR against each of those rather than leaving the fix partial across clients.

**Issues**

N/A — no existing issue. Follows up on https://github.com/jellyfin/jellyfin-web/pull/8209.
